### PR TITLE
GADEN-eval fidelity: real-gas replay, GADEN occupancy grid, sub-cell lidar, start_time warmup

### DIFF
--- a/gaden_maps/recommended_configs.yaml
+++ b/gaden_maps/recommended_configs.yaml
@@ -55,9 +55,9 @@
 4_rooms:
   sim1:
     source: [2.5, 3.0]
-    robot_start: [9.0, 3.0]
+    robot_start: [10.0, 1.0]
     start_time: 100
-    notes: "Source in first room. Robot starts far room."
+    notes: "Source in first room. Robot starts far room. (start matches deploy config src/base/gaden_maps)"
   sim2:
     source: [9.0, 6.0]
     robot_start: null   # TODO: fill in
@@ -81,9 +81,9 @@ curved_labrinth_right:
 many_rooms:
   sim1:
     source: [1.45, 3.0]
-    robot_start: [9.0, 3.0]
+    robot_start: [15.0, 8.0]
     start_time: 250
-    notes: "Multiple rooms. Source in first room, robot starts last room."
+    notes: "Multiple rooms. Source in first room, robot starts last room. (start matches deploy config src/base/gaden_maps)"
   sim2:
     source: [2.0, 8.0]
     robot_start: null   # TODO: fill in
@@ -93,9 +93,9 @@ many_rooms:
 ultimate:
   sim1:
     source: [1.45, 3.0]
-    robot_start: [19.0, 9.0]
+    robot_start: [18.0, 10.0]
     start_time: 350
-    notes: "Complex layout combining multiple room types."
+    notes: "Complex layout combining multiple room types. (start matches deploy config src/base/gaden_maps)"
 
 env_a:
   sim1:

--- a/reinforcement_learning/envs/gas_source_env.py
+++ b/reinforcement_learning/envs/gas_source_env.py
@@ -179,8 +179,18 @@ class GasSourceEnv(gymnasium.Env):
                 # Eval: GadenWindField drives advection; self._wind gives uniform obs fallback.
                 wind_field=wind_field if wind_field is not None else self._wind,
             )
-            # Warm up the plume so step 0 has some initial filaments
-            for _ in range(cfg.FILAMENT_WARMUP_STEPS):
+            # Warm up the plume so step 0 has some initial filaments. For GADEN
+            # eval maps, warm to the scenario's playback start_time (real GADEN
+            # begins playback at start_time s, by which point the plume has
+            # dispersed for minutes — saturating large maps). Procedural
+            # training keeps the short fresh-dispersion warmup. start_time is in
+            # seconds; convert to filament steps via FILAMENT_DT.
+            start_time = float(map_data.get("start_time", 0) or 0)
+            if start_time > 0:
+                warmup_steps = int(round(start_time / cfg.FILAMENT_DT))
+            else:
+                warmup_steps = cfg.FILAMENT_WARMUP_STEPS
+            for _ in range(warmup_steps):
                 self._plume.update()
             self._igdm = None
             self._wind_offset = None

--- a/reinforcement_learning/envs/gas_source_env.py
+++ b/reinforcement_learning/envs/gas_source_env.py
@@ -75,6 +75,7 @@ class GasSourceEnv(gymnasium.Env):
         self._map_height = 0.0
         self._current_step = 0
         self._gas_history = None
+        self._deploy_motion = False  # set per-episode in reset()
         self._trajectory = []
         self._wind_offset = None
         self._dijkstra_from_source = None
@@ -104,6 +105,9 @@ class GasSourceEnv(gymnasium.Env):
             map_data   = options["map_data"]
             wind_field = options.get("wind_field")        # may be None
             self._last_template_id = None  # GADEN eval: template ID not applicable
+            # Injected map = GADEN-eval: match the deployment node's walk-back
+            # collision motion. Caller can override with options["deploy_motion"].
+            self._deploy_motion = bool(options.get("deploy_motion", True))
         else:
             tid = self._template_id
             if tid is None and self._max_template_id is not None:
@@ -123,6 +127,7 @@ class GasSourceEnv(gymnasium.Env):
             self._last_template_id = tid  # exposed for tests and logging
             map_data   = self._map_gen.generate(template_id=tid)
             wind_field = None
+            self._deploy_motion = False  # training keeps all-or-nothing motion
 
         self._grid = map_data["grid"]
         self._source_pos = np.array(map_data["source_pos"], dtype=np.float64)
@@ -280,6 +285,23 @@ class GasSourceEnv(gymnasium.Env):
         info = self._build_info(0.0, False, 0)
         return obs, info
 
+    def _clamp_to_free(self, rx, ry, tx, ty, theta):
+        """Validate target; if blocked, walk back along the ray until free.
+
+        Mirrors gaden_transfer_lidar/gaden_rl_node._clamp_to_free so eval
+        motion matches deployment. Returns (x, y, collided).
+        """
+        if self._grid.is_valid(position=(tx, ty), radius=cfg.ROBOT_RADIUS):
+            return tx, ty, False
+        step = cfg.STEP_SIZE - 0.05
+        while step >= 0.1:
+            cx = rx + step * np.cos(theta)
+            cy = ry + step * np.sin(theta)
+            if self._grid.is_valid(position=(cx, cy), radius=cfg.ROBOT_RADIUS):
+                return cx, cy, True
+            step -= 0.05
+        return rx, ry, True
+
     def step(self, action):
         action = np.asarray(action).flatten()
         if len(action) == 1:
@@ -296,13 +318,26 @@ class GasSourceEnv(gymnasium.Env):
         dy = cfg.STEP_SIZE * np.sin(theta)
         new_pos = self._robot_pos + np.array([dx, dy])
 
-        # Collision check
-        collision = not self._grid.is_valid(
-            position=(new_pos[0], new_pos[1]),
-            radius=cfg.ROBOT_RADIUS,
-        )
-        if not collision:
-            self._robot_pos = new_pos
+        if self._deploy_motion:
+            # Match the deployment node's _clamp_to_free: if the full-step
+            # target is blocked, walk back along the ray in 0.05 m decrements
+            # until a free cell is found (robot creeps up to the wall and stops
+            # short) instead of the all-or-nothing "stay put" used in training.
+            # This removes the frictionless wall-hugging that made the Python
+            # eval over-succeed on tight-corridor maps vs real GADEN.
+            cx, cy, collision = self._clamp_to_free(
+                self._robot_pos[0], self._robot_pos[1],
+                new_pos[0], new_pos[1], theta,
+            )
+            self._robot_pos = np.array([cx, cy], dtype=np.float64)
+        else:
+            # Collision check (training: all-or-nothing full step)
+            collision = not self._grid.is_valid(
+                position=(new_pos[0], new_pos[1]),
+                radius=cfg.ROBOT_RADIUS,
+            )
+            if not collision:
+                self._robot_pos = new_pos
 
         self._trajectory.append(self._robot_pos.copy())
 

--- a/reinforcement_learning/envs/gas_source_env.py
+++ b/reinforcement_learning/envs/gas_source_env.py
@@ -100,6 +100,12 @@ class GasSourceEnv(gymnasium.Env):
         if seed is not None:
             self._rng = np.random.default_rng(seed)
             self._map_gen = MapGenerator(rng=self._rng)
+            # LidarSim uses the GLOBAL np.random for its measurement noise
+            # (lidar_sim.py); without seeding it here, identical reset(seed=)
+            # produces different lidar scans across process runs, making the
+            # eval non-reproducible (borderline episodes flip solve/fail). Seed
+            # it from the episode seed so the whole eval is deterministic.
+            np.random.seed(seed % (2**32 - 1))
 
         # Map: either injected by caller (GADEN eval) or generated procedurally.
         if options is not None and "map_data" in options:
@@ -168,6 +174,12 @@ class GasSourceEnv(gymnasium.Env):
                     occupancy=~wind_field._free_mask,
                     max_speed=cfg.WIND_MAX_SPEED,
                 )
+                # GADEN_FAITHFUL_WIND anemometer noise must be reproducible per
+                # episode: seed it from this env's per-episode RNG so identical
+                # reset(seed=) gives identical wind-noise draws (not a process-
+                # global cached RNG).
+                self._wind._anemo_rng = np.random.default_rng(
+                    self._rng.integers(0, 2**31 - 1))
             self._wind.set_uniform(speed, direction)
         elif map_data.get("wind_bias") is not None:
             self._wind.randomize_biased(self._rng, float(map_data["wind_bias"]))

--- a/reinforcement_learning/envs/gas_source_env.py
+++ b/reinforcement_learning/envs/gas_source_env.py
@@ -104,6 +104,7 @@ class GasSourceEnv(gymnasium.Env):
         if options is not None and "map_data" in options:
             map_data   = options["map_data"]
             wind_field = options.get("wind_field")        # may be None
+            gas_field  = options.get("gas_field")         # may be None (ReplayGasSource)
             self._last_template_id = None  # GADEN eval: template ID not applicable
             # Injected map = GADEN-eval: match the deployment node's walk-back
             # collision motion. Caller can override with options["deploy_motion"].
@@ -127,6 +128,7 @@ class GasSourceEnv(gymnasium.Env):
             self._last_template_id = tid  # exposed for tests and logging
             map_data   = self._map_gen.generate(template_id=tid)
             wind_field = None
+            gas_field  = None
             self._deploy_motion = False  # training keeps all-or-nothing motion
 
         self._grid = map_data["grid"]
@@ -164,7 +166,16 @@ class GasSourceEnv(gymnasium.Env):
             )
 
         # Gas model selection
-        if cfg.GAS_MODEL == "filament":
+        if gas_field is not None:
+            # GADEN eval: replay the REAL stored concentration field (drop-in
+            # gas source) instead of the surrogate plume. Removes the largest
+            # eval fidelity gap — the surrogate's gas field differs in structure
+            # from real GADEN's (esp. near-homogeneous in tight curved mazes).
+            self._plume = gas_field
+            self._igdm = None
+            self._wind_offset = None
+            self._dijkstra_from_source = None
+        elif cfg.GAS_MODEL == "filament":
             self._plume = FilamentPlume(
                 source_pos=self._source_pos,
                 wind_speed=self._wind.speed,

--- a/reinforcement_learning/envs/gas_source_env.py
+++ b/reinforcement_learning/envs/gas_source_env.py
@@ -106,9 +106,12 @@ class GasSourceEnv(gymnasium.Env):
             wind_field = options.get("wind_field")        # may be None
             gas_field  = options.get("gas_field")         # may be None (ReplayGasSource)
             self._last_template_id = None  # GADEN eval: template ID not applicable
-            # Injected map = GADEN-eval: match the deployment node's walk-back
-            # collision motion. Caller can override with options["deploy_motion"].
-            self._deploy_motion = bool(options.get("deploy_motion", True))
+            # Deployment walk-back collision motion is opt-in via
+            # options["deploy_motion"] (the GADEN eval harness sets it True).
+            # Default False so injected-map TRAINING paths (e.g. the CFD wind
+            # library, which injects map_data+wind_field every reset) keep the
+            # all-or-nothing training motion the policy is trained against.
+            self._deploy_motion = bool(options.get("deploy_motion", False))
         else:
             tid = self._template_id
             if tid is None and self._max_template_id is not None:

--- a/reinforcement_learning/envs/gas_source_env.py
+++ b/reinforcement_learning/envs/gas_source_env.py
@@ -76,6 +76,7 @@ class GasSourceEnv(gymnasium.Env):
         self._current_step = 0
         self._gas_history = None
         self._deploy_motion = False  # set per-episode in reset()
+        self._sensor_noise = True     # set per-episode in reset(); see reset()
         self._trajectory = []
         self._wind_offset = None
         self._dijkstra_from_source = None
@@ -112,6 +113,12 @@ class GasSourceEnv(gymnasium.Env):
             # library, which injects map_data+wind_field every reset) keep the
             # all-or-nothing training motion the policy is trained against.
             self._deploy_motion = bool(options.get("deploy_motion", False))
+            # Sensor noise: default True (training behavior). The GADEN eval
+            # harness passes sensor_noise=False to match the real ROS2 deploy
+            # pipeline, which feeds the raw (noiseless) PID concentration — so
+            # the Python eval predicts real deployment rather than injecting a
+            # sigma_env floor the deployed sensor doesn't have.
+            self._sensor_noise = bool(options.get("sensor_noise", True))
         else:
             tid = self._template_id
             if tid is None and self._max_template_id is not None:
@@ -133,6 +140,7 @@ class GasSourceEnv(gymnasium.Env):
             wind_field = None
             gas_field  = None
             self._deploy_motion = False  # training keeps all-or-nothing motion
+            self._sensor_noise = True     # training keeps the sensor noise floor
 
         self._grid = map_data["grid"]
         self._source_pos = np.array(map_data["source_pos"], dtype=np.float64)
@@ -276,7 +284,8 @@ class GasSourceEnv(gymnasium.Env):
             conc = self._plume.concentration_at(self._robot_pos)
         else:
             conc = self._get_concentration_igdm()
-        noisy = conc + self._rng.normal(0, self._sensor.get_std(conc))
+        noisy = conc + (self._rng.normal(0, self._sensor.get_std(conc))
+                        if self._sensor_noise else 0.0)
         self._last_noisy = noisy
         self._sensor.initialize_threshold(noisy)
         # First reading is always 0 by definition (at threshold)
@@ -362,7 +371,8 @@ class GasSourceEnv(gymnasium.Env):
         else:
             conc = self._get_concentration_igdm()
 
-        noisy = conc + self._rng.normal(0, self._sensor.get_std(conc))
+        noisy = conc + (self._rng.normal(0, self._sensor.get_std(conc))
+                        if self._sensor_noise else 0.0)
         self._last_noisy = noisy
         self._sensor.update_threshold(noisy)
         binary = self._sensor.get_binary_measurement(noisy)

--- a/reinforcement_learning/envs/lidar_sim.py
+++ b/reinforcement_learning/envs/lidar_sim.py
@@ -96,8 +96,36 @@ class LidarSim:
         any_hit = np.any(hit, axis=1)  # (R,)
         first_hit_idx = np.argmax(hit, axis=1)  # (R,)
 
-        # Distance: t[first_hit_idx] for rays that hit, else max_range
-        distances = np.where(any_hit, self._t[first_hit_idx], self.max_range)
+        # Coarse distance: t[first_hit_idx] for rays that hit, else max_range.
+        # This is quantized to the grid step (~resolution), which floors the
+        # measured wall distance at ~one cell. Real BasicSim casts against
+        # continuous geometry and reads sub-cell clearances (e.g. 0.24 m in
+        # tight curves) far more often (45% of steps < 0.4 m vs 11% here).
+        # Refine each hit to a continuous surface distance below so the
+        # near-wall regime matches deployment — otherwise the policy never
+        # experiences sub-resolution clearance in training.
+        coarse = np.where(any_hit, self._t[first_hit_idx], self.max_range)
+
+        # Sub-cell refinement: the wall surface lies between the last free
+        # sample (t = coarse - res) and the first occupied sample (t = coarse).
+        # Bisect within that interval to locate the free→occupied transition at
+        # sub-resolution precision. Vectorised over hit rays.
+        distances = coarse.copy()
+        hit_rays = np.where(any_hit)[0]
+        if hit_rays.size:
+            lo = np.maximum(coarse[hit_rays] - res, 0.0)   # last known-free t
+            hi = coarse[hit_rays].copy()                   # first known-occupied t
+            ca = cos_a[hit_rays]; sa = sin_a[hit_rays]
+            for _ in range(6):  # 2^-6 * res ≈ 1.5 mm precision at res=0.1
+                mid = 0.5 * (lo + hi)
+                mgx = np.floor((ox + ca * mid) / res).astype(np.int32)
+                mgy = np.floor((oy + sa * mid) / res).astype(np.int32)
+                m_oob = (mgx < 0) | (mgx >= gw) | (mgy < 0) | (mgy >= gh)
+                m_occ = m_oob | (self.grid.grid[np.clip(mgy, 0, gh - 1),
+                                                np.clip(mgx, 0, gw - 1)] != 0)
+                hi = np.where(m_occ, mid, hi)   # midpoint occupied → surface closer
+                lo = np.where(m_occ, lo, mid)
+            distances[hit_rays] = hi           # first-occupied boundary = surface distance
 
         # Apply Gaussian noise to hit rays only
         if self.noise_std > 0.0:

--- a/reinforcement_learning/envs/wind_model.py
+++ b/reinforcement_learning/envs/wind_model.py
@@ -7,6 +7,7 @@ provided so that WindModel also serves as the ``wind_field`` argument to
 FilamentPlume during training (bilinear-interpolated queries).
 """
 
+import os
 import numpy as np
 
 
@@ -136,6 +137,40 @@ class WindModel:
             positions = positions[np.newaxis, :]   # (2,) → (1, 2)
         if positions.size == 0:
             return np.zeros((0, 2), dtype=np.float64)
+
+        # GADEN-faithful: the deployed anemometer reads the wind of the robot's
+        # single cell (nearest-cell), with no bilinear blend. Match that so the
+        # eval's local-wind obs equals what ROS2 feeds the policy.
+        if os.environ.get("GADEN_FAITHFUL_WIND", "0") == "1":
+            res = self._resolution
+            cols = np.clip(np.floor(positions[:, 0] / res).astype(np.int64), 0, self.W - 1)
+            rows = np.clip(np.floor(positions[:, 1] / res).astype(np.int64), 0, self.H - 1)
+            uv = self._field[rows, cols].astype(np.float64)
+
+            # Replicate fake_anemometer.cpp noise (noise_std=0.3 in the deploy
+            # launch). The anemometer works in (speed^2, dir) space:
+            #   wind_speed   = u^2 + v^2                 (squared — the units quirk)
+            #   wind_dir     = atan2(v, u)
+            #   dir   += N(0, noise_std)
+            #   speed += N(0, noise_std) * 0.1, clamped >= 0
+            # The deploy node then takes sqrt(speed). We reproduce that exact
+            # chain so the policy's local-wind obs matches the deployed topic.
+            ns = float(os.environ.get("GADEN_ANEMO_NOISE_STD", "0.3"))
+            if ns > 0.0:
+                rng = getattr(self, "_anemo_rng", None)
+                if rng is None:
+                    rng = np.random.default_rng(
+                        int(os.environ.get("GADEN_ANEMO_SEED", "0")))
+                    self._anemo_rng = rng
+                u = uv[:, 0]; v = uv[:, 1]
+                sp2 = u * u + v * v                       # squared speed (as cpp)
+                direction = np.arctan2(v, u)
+                direction = direction + rng.normal(0.0, ns, size=direction.shape)
+                sp2 = np.maximum(0.0, sp2 + rng.normal(0.0, ns, size=sp2.shape) * 0.1)
+                speed = np.sqrt(sp2)                      # deploy node's sqrt fix
+                uv = np.stack([speed * np.cos(direction),
+                               speed * np.sin(direction)], axis=1)
+            return uv
 
         x = positions[:, 0]
         y = positions[:, 1]

--- a/reinforcement_learning/envs/wind_model.py
+++ b/reinforcement_learning/envs/wind_model.py
@@ -157,10 +157,12 @@ class WindModel:
             # chain so the policy's local-wind obs matches the deployed topic.
             ns = float(os.environ.get("GADEN_ANEMO_NOISE_STD", "0.3"))
             if ns > 0.0:
+                # The env seeds _anemo_rng per episode (off reset(seed=)) for
+                # reproducibility. If it wasn't set (WindModel used standalone),
+                # fall back to a fixed-seed RNG created once.
                 rng = getattr(self, "_anemo_rng", None)
                 if rng is None:
-                    rng = np.random.default_rng(
-                        int(os.environ.get("GADEN_ANEMO_SEED", "0")))
+                    rng = np.random.default_rng(0)
                     self._anemo_rng = rng
                 u = uv[:, 0]; v = uv[:, 1]
                 sp2 = u * u + v * v                       # squared speed (as cpp)

--- a/reinforcement_learning/test/eval_checkpoints_gaden.py
+++ b/reinforcement_learning/test/eval_checkpoints_gaden.py
@@ -75,6 +75,12 @@ def greedy_action_dual(agent, obs_t):
 def run_episode(agent, full_map, episode_seed, device, arch="spatial"):
     map_data = {k: full_map[k] for k in ("grid", "source_pos", "robot_pos",
                                           "width", "height")}
+    # Forward the GADEN scenario's playback start_time so the env can warm the
+    # plume to match how far the real plume has dispersed at that wall-clock
+    # time (real GADEN starts playback at start_time s, not t=0). Without this
+    # the plume only gets FILAMENT_WARMUP_STEPS of dispersion regardless of map
+    # size, starving big maps (ultimate/many_rooms) of gas at the start region.
+    map_data["start_time"] = full_map.get("spec", {}).get("start_time", 0)
     total_return = 0.0
     success = False
 

--- a/reinforcement_learning/test/eval_checkpoints_gaden.py
+++ b/reinforcement_learning/test/eval_checkpoints_gaden.py
@@ -103,7 +103,8 @@ def run_episode(agent, full_map, episode_seed, device, arch="spatial",
 
     if arch == "dual":
         env = GasSourceEnv()
-        opts = {"map_data": map_data, "wind_field": full_map["wind_field"]}
+        opts = {"map_data": map_data, "wind_field": full_map["wind_field"],
+                "deploy_motion": True}  # eval matches the deployment walk-back motion
         if gas_field is not None:
             opts["gas_field"] = gas_field
         obs, _ = env.reset(seed=episode_seed, options=opts)
@@ -119,7 +120,8 @@ def run_episode(agent, full_map, episode_seed, device, arch="spatial",
                 break
     else:
         env = SpatialObsWrapper(GasSourceEnv())
-        opts = {"map_data": map_data, "wind_field": full_map["wind_field"]}
+        opts = {"map_data": map_data, "wind_field": full_map["wind_field"],
+                "deploy_motion": True}  # eval matches the deployment walk-back motion
         if gas_field is not None:
             opts["gas_field"] = gas_field
         (spatial, wind), _ = env.reset(seed=episode_seed, options=opts)

--- a/reinforcement_learning/test/eval_checkpoints_gaden.py
+++ b/reinforcement_learning/test/eval_checkpoints_gaden.py
@@ -72,7 +72,19 @@ def greedy_action_dual(agent, obs_t):
         return dist.mean.cpu().numpy()  # (1, 2): (cos θ, sin θ)
 
 
-def run_episode(agent, full_map, episode_seed, device, arch="spatial"):
+def _make_replay_gas(full_map, result_dir):
+    """Build a ReplayGasSource for this map from stored GADEN snapshots, or None."""
+    if result_dir is None:
+        return None
+    from reinforcement_learning.test.gaden_result_loader import ReplayGasSource
+    start_time = full_map.get("spec", {}).get("start_time", 0)
+    save_dt = 0.5  # GADEN saveDeltaTime; one env step ~ one snapshot
+    start_iter = int(round(start_time / save_dt))
+    return ReplayGasSource(result_dir, full_map["origin_xy"], start_iter)
+
+
+def run_episode(agent, full_map, episode_seed, device, arch="spatial",
+                result_dir=None):
     map_data = {k: full_map[k] for k in ("grid", "source_pos", "robot_pos",
                                           "width", "height")}
     # Forward the GADEN scenario's playback start_time so the env can warm the
@@ -84,12 +96,17 @@ def run_episode(agent, full_map, episode_seed, device, arch="spatial"):
     total_return = 0.0
     success = False
 
+    # If a GADEN result/ dir is supplied, replay the REAL stored concentration
+    # field instead of the surrogate plume (highest fidelity; built fresh per
+    # episode since the replay source advances a snapshot index statefully).
+    gas_field = _make_replay_gas(full_map, result_dir)
+
     if arch == "dual":
         env = GasSourceEnv()
-        obs, _ = env.reset(
-            seed=episode_seed,
-            options={"map_data": map_data, "wind_field": full_map["wind_field"]},
-        )
+        opts = {"map_data": map_data, "wind_field": full_map["wind_field"]}
+        if gas_field is not None:
+            opts["gas_field"] = gas_field
+        obs, _ = env.reset(seed=episode_seed, options=opts)
         while True:
             obs_t = torch.as_tensor(obs, dtype=torch.float32, device=device).unsqueeze(0)
             action = greedy_action_dual(agent, obs_t)[0]
@@ -102,10 +119,10 @@ def run_episode(agent, full_map, episode_seed, device, arch="spatial"):
                 break
     else:
         env = SpatialObsWrapper(GasSourceEnv())
-        (spatial, wind), _ = env.reset(
-            seed=episode_seed,
-            options={"map_data": map_data, "wind_field": full_map["wind_field"]},
-        )
+        opts = {"map_data": map_data, "wind_field": full_map["wind_field"]}
+        if gas_field is not None:
+            opts["gas_field"] = gas_field
+        (spatial, wind), _ = env.reset(seed=episode_seed, options=opts)
         while True:
             spatial_t = torch.as_tensor(spatial, dtype=torch.float32, device=device).unsqueeze(0)
             wind_t    = torch.as_tensor(wind,    dtype=torch.float32, device=device).unsqueeze(0)
@@ -137,7 +154,7 @@ def load_maps(gaden_root: Path, map_keys):
 
 
 def eval_run(run_dir, full_maps, map_keys, episodes_per_map, device,
-             output_dir, latest_only=False, incremental=False):
+             output_dir, latest_only=False, incremental=False, real_gas=False):
     run_dir  = Path(run_dir)
     ckpt_dir = run_dir / "checkpoints"
     run_cfg  = load_run_config(run_dir)
@@ -180,6 +197,14 @@ def eval_run(run_dir, full_maps, map_keys, episodes_per_map, device,
     arch = run_cfg.get("arch", "spatial")
     print(f"  arch={arch}")
 
+    # Resolve real-GADEN gas snapshot dirs per map (None where unavailable →
+    # that map falls back to the surrogate plume).
+    from reinforcement_learning.test.gaden_loader import resolve_result_dir
+    result_dirs = [resolve_result_dir(k) if real_gas else None for k in map_keys]
+    if real_gas:
+        n_real = sum(d is not None for d in result_dirs)
+        print(f"  real-gas: replaying stored GADEN fields for {n_real}/{n_maps} maps")
+
     orig = {k: getattr(cfg, k) for k in ("LIDAR_NUM_RAYS", "STATE_DIM")}
     cfg.LIDAR_NUM_RAYS = run_cfg.get("LIDAR_NUM_RAYS", cfg.LIDAR_NUM_RAYS)
     cfg.STATE_DIM      = run_cfg.get("STATE_DIM",      cfg.STATE_DIM)
@@ -192,7 +217,8 @@ def eval_run(run_dir, full_maps, map_keys, episodes_per_map, device,
             for mi, fm in enumerate(full_maps):
                 for ei in range(n_eps):
                     seed = 1000 * mi + ei
-                    ret, succ = run_episode(agent, fm, seed, device, arch=arch)
+                    ret, succ = run_episode(agent, fm, seed, device, arch=arch,
+                                            result_dir=result_dirs[mi])
                     returns[ci, mi, ei]   = ret
                     successes[ci, mi, ei] = succ
 
@@ -244,6 +270,11 @@ def main():
     parser.add_argument("--incremental",      action="store_true", default=False,
                         help="Skip checkpoints already in the saved npz and "
                              "merge new results (for a live training-curve watcher)")
+    parser.add_argument("--real-gas",         action="store_true", default=False,
+                        help="Replay the REAL stored GADEN concentration field "
+                             "(result/iteration_<N>) instead of the surrogate "
+                             "plume. Highest fidelity; falls back to surrogate "
+                             "for maps without stored snapshots.")
     args = parser.parse_args()
 
     device = torch.device(args.device or ("cuda" if torch.cuda.is_available() else "cpu"))
@@ -254,7 +285,7 @@ def main():
     for run_dir in args.run_dirs:
         eval_run(run_dir, full_maps, args.maps, args.episodes_per_map,
                  device, args.output_dir, latest_only=args.latest_only,
-                 incremental=args.incremental)
+                 incremental=args.incremental, real_gas=args.real_gas)
 
 
 if __name__ == "__main__":

--- a/reinforcement_learning/test/eval_checkpoints_gaden.py
+++ b/reinforcement_learning/test/eval_checkpoints_gaden.py
@@ -104,7 +104,8 @@ def run_episode(agent, full_map, episode_seed, device, arch="spatial",
     if arch == "dual":
         env = GasSourceEnv()
         opts = {"map_data": map_data, "wind_field": full_map["wind_field"],
-                "deploy_motion": True}  # eval matches the deployment walk-back motion
+                "deploy_motion": True,   # eval matches the deployment walk-back motion
+                "sensor_noise": False}   # match real ROS2 deploy: raw (noiseless) PID concentration
         if gas_field is not None:
             opts["gas_field"] = gas_field
         obs, _ = env.reset(seed=episode_seed, options=opts)
@@ -121,7 +122,8 @@ def run_episode(agent, full_map, episode_seed, device, arch="spatial",
     else:
         env = SpatialObsWrapper(GasSourceEnv())
         opts = {"map_data": map_data, "wind_field": full_map["wind_field"],
-                "deploy_motion": True}  # eval matches the deployment walk-back motion
+                "deploy_motion": True,   # eval matches the deployment walk-back motion
+                "sensor_noise": False}   # match real ROS2 deploy: raw (noiseless) PID concentration
         if gas_field is not None:
             opts["gas_field"] = gas_field
         (spatial, wind), _ = env.reset(seed=episode_seed, options=opts)

--- a/reinforcement_learning/test/gaden_loader.py
+++ b/reinforcement_learning/test/gaden_loader.py
@@ -423,6 +423,48 @@ class GadenWindField:
         return self._max_speed
 
 
+def load_served_wind_field(map_key: str, grid: OccupancyGrid,
+                           origin_xy: tuple[float, float],
+                           anemometer_z: float = 0.5) -> "GadenWindField":
+    """GADEN-FAITHFUL wind: read the SAME binary wind grid GADEN serves and
+    take the single z=anemometer_z layer, queried nearest-cell — exactly what
+    the deployed anemometer samples. Unlike load_gaden_wind_field (which
+    z-collapses every layer and EDT-fills gaps), this contains no information
+    a real point sensor at the anemometer height could not measure, so the eval
+    score predicts ROS2 deployment instead of overstating it.
+
+    Falls back to the z-collapsed+EDT field if the served binary grid is absent.
+    """
+    if _GADEN_SCENARIOS_ROOT is None:
+        return load_gaden_wind_field(resolve_map_dir(None, map_key), grid, origin_xy)
+    folder = MAP_NAME_ALIASES.get(map_key, map_key)
+    wind_bin = (_GADEN_SCENARIOS_ROOT / folder /
+                "environment_configurations/config1/wind/wind_iteration_0")
+    H, W = grid.grid.shape
+    occupancy = (grid.grid != 0)
+    nz_dim = None
+    # dims from OccupancyGrid3D.csv (#num_cells nx ny nz)
+    occ_csv = _GADEN_SCENARIOS_ROOT / folder / _OCC_CSV_REL
+    if occ_csv.is_file():
+        for line in occ_csv.open():
+            if line.startswith("#num_cells"):
+                _nx, _ny, nz_dim = (int(v) for v in line.split()[1:4])
+                break
+    if not wind_bin.is_file() or nz_dim is None or _nx != W or _ny != H:
+        # served grid unavailable or shape mismatch -> safe fallback
+        return load_gaden_wind_field(_GADEN_SCENARIOS_ROOT / folder, grid, origin_xy)
+
+    with wind_bin.open("rb") as f:
+        f.read(8)  # versionMajor, versionMinor (two int32)
+        data = np.frombuffer(f.read(), dtype=np.float32)[: W * H * nz_dim * 3]
+    vol = data.reshape(nz_dim, H, W, 3)            # GADEN layout: z, y, x
+    zc = int(round(anemometer_z / grid.resolution))
+    zc = max(0, min(nz_dim - 1, zc))
+    field = vol[zc, :, :, :2].astype(np.float64)   # (H, W, 2) Ux, Uy
+    field[occupancy] = 0.0
+    return GadenWindField(field, grid.resolution, occupancy)
+
+
 def load_gaden_wind_field(map_dir: Path, grid: OccupancyGrid,
                           origin_xy: tuple[float, float]) -> GadenWindField:
     """Build the (H, W, 2) z-collapsed wind field for a GADEN map.
@@ -528,7 +570,13 @@ def load_full_map(gaden_root: Path, yaml_path: Path, map_key: str,
         grid, origin = csv_grid
     else:
         grid, origin = load_gaden_grid(map_dir)
-    wind_field   = load_gaden_wind_field(map_dir, grid, origin)
+    # GADEN_FAITHFUL_WIND=1: read the exact single-z-layer wind GADEN serves
+    # (nearest-cell), so the eval predicts ROS2 deployment. Default (unset) keeps
+    # the z-collapsed + EDT-filled field for backward comparison.
+    if os.environ.get("GADEN_FAITHFUL_WIND", "0") == "1":
+        wind_field = load_served_wind_field(map_key, grid, origin)
+    else:
+        wind_field = load_gaden_wind_field(map_dir, grid, origin)
     spec         = load_gaden_spec(yaml_path, map_key, origin, sim_id=sim_id)
     return {
         "grid":       grid,

--- a/reinforcement_learning/test/gaden_loader.py
+++ b/reinforcement_learning/test/gaden_loader.py
@@ -250,6 +250,22 @@ def _rasterize_stl_walls(map_dir: Path, H: int, W: int, cell_size: float,
     return solid | (~fluid)
 
 
+_RESULT_REL = Path("environment_configurations/config1/simulations/sim1/result")
+
+
+def resolve_result_dir(map_key: str, sim_id: str = "sim1"):
+    """Path to a map's stored GADEN gas snapshots (result/iteration_<N>), or None.
+
+    Used by the eval harness to replay the REAL concentration field instead of
+    the surrogate plume. Folder names match between gaden_maps/ and the install
+    scenarios tree.
+    """
+    folder = MAP_NAME_ALIASES.get(map_key, map_key)
+    rel = Path("environment_configurations/config1/simulations") / sim_id / "result"
+    result_dir = _GADEN_SCENARIOS_ROOT / folder / rel
+    return result_dir if result_dir.is_dir() else None
+
+
 def _parse_occupancy_csv(csv_path: Path, z_level: int = _OCC_Z_LEVEL):
     """Parse GADEN's OccupancyGrid3D.csv -> (wall_mask (H,W) bool, origin_xy, cell_size).
 

--- a/reinforcement_learning/test/gaden_loader.py
+++ b/reinforcement_learning/test/gaden_loader.py
@@ -53,6 +53,20 @@ DEFAULT_MAP_KEYS = list(MAP_NAME_ALIASES.keys())
 
 _WIND_CSV_REL  = Path("wind_simulations/1ms/wind_at_cell_centers_0.csv")
 _CONFIG_REL    = Path("environment_configurations/config1/config.yaml")
+_OCC_CSV_REL   = Path("environment_configurations/config1/OccupancyGrid3D.csv")
+
+# Where GADEN's preprocessed OccupancyGrid3D.csv lives (the install scenarios
+# tree). The Python harness re-rasterized walls.stl, which produced ~10pp wider
+# corridors than GADEN's own occupancy at z_level=5 — the cause of the
+# labyrinth over-success vs real deployment. Prefer GADEN's grid so the eval
+# robot navigates the IDENTICAL occupancy the deployment node clamps against.
+# Folder names match between gaden_maps/ and the scenarios tree.
+_GADEN_SCENARIOS_ROOT = Path(
+    "/home/efe/ros2_ws/install/test_env/share/test_env/scenarios"
+)
+# z-slice that deployment uses (gaden_rl_node occupancy_z_level default = 5,
+# i.e. z in [0.5, 0.6) m — matches the STL slice height ~0.5 m).
+_OCC_Z_LEVEL = 5
 
 
 def resolve_map_dir(gaden_root: Path, map_key: str) -> Path:
@@ -236,6 +250,64 @@ def _rasterize_stl_walls(map_dir: Path, H: int, W: int, cell_size: float,
     return solid | (~fluid)
 
 
+def _parse_occupancy_csv(csv_path: Path, z_level: int = _OCC_Z_LEVEL):
+    """Parse GADEN's OccupancyGrid3D.csv -> (wall_mask (H,W) bool, origin_xy, cell_size).
+
+    File format (from gaden Environment::WriteToFile):
+        #env_min(m) x y z
+        #env_max(m) x y z
+        #num_cells nx ny nz
+        #cell_size(m) c
+        then nz z-layers, each ny rows of nx ints, layers separated by ';'.
+    Cell values: 0 free, 1 wall, 2 outlet. Deployment treats (>0) as wall
+    (gaden_rl_node / load_3d_occupancy_grid_from_service do grid_2d>0), so we
+    mirror that — outlets are obstacles for navigation (gas still flows through
+    them via the wind field, which is separate).
+    """
+    lines = csv_path.read_text().splitlines()
+    env_min = [float(v) for v in lines[0].split()[1:4]]
+    nx, ny, nz = [int(v) for v in lines[2].split()[1:4]]
+    cell_size = float(lines[3].split()[1])
+
+    layers, cur = [], []
+    for ln in lines[4:]:
+        s = ln.strip()
+        if s == ";":
+            if cur:
+                layers.append(cur); cur = []
+        elif s:
+            cur.append([int(v) for v in s.split()])
+    if cur:
+        layers.append(cur)
+
+    # GADEN writes each z-layer as nx rows (outer loop col=x) of ny values
+    # (inner loop row=y), so a layer array is (nx, ny) indexed [x, y]. The
+    # harness grid is (H, W) = (ny, nx) indexed [y, x], so transpose.
+    grid3d = np.array(layers)          # (nz, nx, ny)
+    z = max(0, min(nz - 1, z_level))
+    wall = (grid3d[z].T > 0)           # (ny, nx) = (H, W); matches deployment grid>0
+    return wall, (env_min[0], env_min[1]), cell_size
+
+
+def load_gaden_grid_from_csv(map_key: str):
+    """Build the occupancy grid from GADEN's OccupancyGrid3D.csv (z=5).
+
+    Returns (grid, origin_xy) like load_gaden_grid, but the walls and origin
+    come from GADEN's own preprocessed occupancy — identical to what the
+    deployment node navigates against — instead of re-rasterizing the STL.
+    Returns None if the CSV is not available (caller falls back to STL).
+    """
+    folder = MAP_NAME_ALIASES.get(map_key, map_key)
+    csv_path = _GADEN_SCENARIOS_ROOT / folder / _OCC_CSV_REL
+    if not csv_path.is_file():
+        return None
+    wall, origin_xy, cell_size = _parse_occupancy_csv(csv_path)
+    H, W = wall.shape
+    grid = OccupancyGrid(W * cell_size, H * cell_size, cell_size)
+    grid.grid = wall.astype(np.int8)
+    return grid, origin_xy
+
+
 def load_gaden_grid(map_dir: Path):
     """Rasterize a GADEN map's wind cloud into a 2D occupancy grid.
 
@@ -401,7 +473,14 @@ def load_full_map(gaden_root: Path, yaml_path: Path, map_key: str,
         ``options["map_data"]`` to ``GasSourceEnv.reset()``.
     """
     map_dir = resolve_map_dir(gaden_root, map_key)
-    grid, origin = load_gaden_grid(map_dir)
+    # Prefer GADEN's own occupancy (z=5) — identical to deployment's nav grid —
+    # over re-rasterizing the STL (which gave ~10pp wider corridors and caused
+    # the labyrinth over-success). Fall back to STL raster if the CSV is absent.
+    csv_grid = load_gaden_grid_from_csv(map_key)
+    if csv_grid is not None:
+        grid, origin = csv_grid
+    else:
+        grid, origin = load_gaden_grid(map_dir)
     wind_field   = load_gaden_wind_field(map_dir, grid, origin)
     spec         = load_gaden_spec(yaml_path, map_key, origin, sim_id=sim_id)
     return {

--- a/reinforcement_learning/test/gaden_loader.py
+++ b/reinforcement_learning/test/gaden_loader.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 from pathlib import Path
 import csv
+import os
 import struct
 
 import numpy as np
@@ -55,15 +56,41 @@ _WIND_CSV_REL  = Path("wind_simulations/1ms/wind_at_cell_centers_0.csv")
 _CONFIG_REL    = Path("environment_configurations/config1/config.yaml")
 _OCC_CSV_REL   = Path("environment_configurations/config1/OccupancyGrid3D.csv")
 
-# Where GADEN's preprocessed OccupancyGrid3D.csv lives (the install scenarios
-# tree). The Python harness re-rasterized walls.stl, which produced ~10pp wider
-# corridors than GADEN's own occupancy at z_level=5 — the cause of the
-# labyrinth over-success vs real deployment. Prefer GADEN's grid so the eval
-# robot navigates the IDENTICAL occupancy the deployment node clamps against.
-# Folder names match between gaden_maps/ and the scenarios tree.
-_GADEN_SCENARIOS_ROOT = Path(
-    "/home/efe/ros2_ws/install/test_env/share/test_env/scenarios"
-)
+# Where GADEN's preprocessed OccupancyGrid3D.csv + result/iteration_<N> live
+# (the built test_env scenarios tree). The Python harness re-rasterized
+# walls.stl, which produced ~10pp wider corridors than GADEN's own occupancy at
+# z_level=5 — the cause of the labyrinth over-success vs real deployment. Prefer
+# GADEN's grid so the eval robot navigates the IDENTICAL occupancy the
+# deployment node clamps against. Folder names match between gaden_maps/ and the
+# scenarios tree.
+#
+# Machine-portable resolution (no hardcoded user path):
+#   1. $GADEN_SCENARIOS_ROOT env var if set;
+#   2. else search common ros2_ws layouts relative to $ROS2_WS / cwd / home.
+# If none is found this is None, and callers fall back to STL raster / the
+# surrogate plume (so the harness still runs, just without GADEN-grid/real-gas).
+def _find_scenarios_root():
+    env = os.environ.get("GADEN_SCENARIOS_ROOT")
+    if env:
+        return Path(env)
+    rel = "install/test_env/share/test_env/scenarios"
+    candidates = []
+    ws = os.environ.get("ROS2_WS")
+    if ws:
+        candidates.append(Path(ws) / rel)
+    # walk up from this file to find a ros2_ws-style dir
+    here = Path(__file__).resolve()
+    for parent in here.parents:
+        candidates.append(parent / rel)
+        candidates.append(parent / "share/test_env/scenarios")
+    candidates.append(Path.home() / "ros2_ws" / rel)
+    for c in candidates:
+        if c.is_dir():
+            return c
+    return None
+
+
+_GADEN_SCENARIOS_ROOT = _find_scenarios_root()
 # z-slice that deployment uses (gaden_rl_node occupancy_z_level default = 5,
 # i.e. z in [0.5, 0.6) m — matches the STL slice height ~0.5 m).
 _OCC_Z_LEVEL = 5
@@ -260,6 +287,8 @@ def resolve_result_dir(map_key: str, sim_id: str = "sim1"):
     the surrogate plume. Folder names match between gaden_maps/ and the install
     scenarios tree.
     """
+    if _GADEN_SCENARIOS_ROOT is None:
+        return None
     folder = MAP_NAME_ALIASES.get(map_key, map_key)
     rel = Path("environment_configurations/config1/simulations") / sim_id / "result"
     result_dir = _GADEN_SCENARIOS_ROOT / folder / rel
@@ -313,6 +342,8 @@ def load_gaden_grid_from_csv(map_key: str):
     deployment node navigates against — instead of re-rasterizing the STL.
     Returns None if the CSV is not available (caller falls back to STL).
     """
+    if _GADEN_SCENARIOS_ROOT is None:
+        return None
     folder = MAP_NAME_ALIASES.get(map_key, map_key)
     csv_path = _GADEN_SCENARIOS_ROOT / folder / _OCC_CSV_REL
     if not csv_path.is_file():

--- a/reinforcement_learning/test/gaden_result_loader.py
+++ b/reinforcement_learning/test/gaden_result_loader.py
@@ -1,0 +1,237 @@
+"""
+Replay real GADEN gas fields in Python (maximal fidelity, no surrogate plume).
+
+GADEN's filament_simulator writes one snapshot per saveDeltaTime to
+``<sim>/result/iteration_<N>``. With ``preCalculateConcentrations: true`` in
+sim.yaml, each snapshot stores the fully-computed per-cell gas concentration
+[ppm] — the exact field the deployment ROS node samples via the player. This
+loader reads those files directly so the Python eval harness can query real
+GADEN concentrations instead of the approximate FilamentPlume.
+
+  >>> seq = GadenResultSequence("/path/<sim>/result")
+  >>> seq.load_iteration(200)               # snapshot index (== start_time/saveDeltaTime)
+  >>> seq.concentration_at(x, y, z=0.5)     # ppm at world coords (env frame)
+
+WHY: Results/GADEN_EVAL_FINDINGS.md §4 — big-map eval failures are a
+gas-availability/fidelity problem in the surrogate plume, not a policy problem.
+Replaying GADEN's own field removes the surrogate from the loop entirely and
+answers e.g. "does real gas actually reach the ultimate robot start?".
+
+------------------------------------------------------------------------------
+FILE FORMAT  (gaden_core post-3.0, verified against
+gaden_core/include/gaden/internal/Serialization.hpp + src/RunningSimulation.cpp
+SaveResults() + src/PlaybackSimulation.cpp LoadLogfile())
+
+Uncompressed header (little-endian):
+    char    resultIdentifier[13]   # "GADEN_RESULT\0"  (sizeof includes NUL)
+    uint8   compressionMode        # 0=UNCOMPRESSED 1=ZLIB 2=LIBBSC
+    uint64  uncompressedSize
+Then a compressed blob. After decompression, the body (BufferWriter order):
+    int32   versionMajor
+    int32   versionMinor
+    Description  (40 bytes POD):
+        int32 dim.x, dim.y, dim.z
+        float min.x, min.y, min.z
+        float max.x, max.y, max.z
+        float cellSize
+    GasSource (variable): string sourceType + per-type fields
+                          + Vector3 sourcePosition + int gasType
+    Constants (8 bytes): float totalMolesInFilament, float numMolesAllGasesIncm3
+    int32   windIndex
+    string  mode            # size_t length + bytes; "concentrations" or "filaments"
+    vector  payload         # size_t count + count*float32 (concentrations)
+                            # or count*Filament (filaments; not handled here)
+
+A "string"/"vector" is size_t(uint64) length-prefix + raw bytes.
+
+Cell ordering (gaden indexFrom3D): index = x + y*nx + z*nx*ny
+  → reshape flat float array as (nz, ny, nx).
+
+This loader targets concentration mode. It parses version+Description from the
+front (giving grid dims/cellSize/minCoord), then extracts the float grid from
+the TAIL — the concentration vector is the last thing written, so the final
+``nx*ny*nz`` floats (preceded by a uint64 count == nx*ny*nz) are the grid. This
+avoids parsing the variable-length GasSource. We assert the tail count matches
+numCells as an integrity check.
+
+LIBBSC compression (files > 5 MB) is NOT decodable with stdlib; those raise a
+clear error (use ZLIB by keeping per-snapshot size down, or decode via gaden).
+Most single-gas 2D-ish maps compress under 5 MB → ZLIB.
+
+UNVALIDATED on this box: no iteration_* files exist here. Generate one on the
+GADEN machine (preCalculateConcentrations: true, saveResults: true) and verify
+against the player's SampleConcentrations before trusting.
+"""
+
+from __future__ import annotations
+
+import struct
+import zlib
+from pathlib import Path
+
+import numpy as np
+
+_MAGIC = b"GADEN_RESULT\x00"          # 13 bytes (sizeof includes NUL terminator)
+_DESC_BYTES = 3 * 4 + 3 * 4 + 3 * 4 + 4   # Vec3i + Vec3 + Vec3 + float = 40
+
+
+class GadenResultSequence:
+    """Reads ``result/iteration_<N>`` concentration snapshots for one sim."""
+
+    def __init__(self, result_dir: str | Path):
+        self.result_dir = Path(result_dir)
+        if not self.result_dir.is_dir():
+            raise FileNotFoundError(f"result dir not found: {self.result_dir}")
+        # Per-iteration state (filled by load_iteration).
+        self.dims = None            # (nx, ny, nz)
+        self.min_coord = None       # (x, y, z) metres — env-frame origin
+        self.cell_size = None       # metres
+        self.grid = None            # (nz, ny, nx) float32 ppm
+        self._loaded_iter = None
+
+    # ------------------------------------------------------------------
+    def iteration_path(self, n: int) -> Path:
+        return self.result_dir / f"iteration_{n}"
+
+    def available_iterations(self):
+        out = []
+        for p in self.result_dir.glob("iteration_*"):
+            try:
+                out.append(int(p.name.split("_")[1]))
+            except (IndexError, ValueError):
+                pass
+        return sorted(out)
+
+    # ------------------------------------------------------------------
+    def load_iteration(self, n: int):
+        """Parse snapshot *n* into ``self.grid`` + geometry. Returns self."""
+        path = self.iteration_path(n)
+        if not path.is_file():
+            avail = self.available_iterations()
+            raise FileNotFoundError(
+                f"{path} not found. Available: {avail[:3]}..{avail[-3:] if avail else []}"
+            )
+        raw = path.read_bytes()
+        body = self._decompress(raw)
+        self._parse_body(body)
+        self._loaded_iter = n
+        return self
+
+    # ------------------------------------------------------------------
+    def _decompress(self, raw: bytes) -> bytes:
+        if raw[:13] != _MAGIC:
+            raise ValueError(
+                f"not a post-3.0 GADEN result file (bad magic {raw[:13]!r}). "
+                "Pre-3.0 files are unsupported by this loader."
+            )
+        off = 13
+        comp_mode = raw[off]; off += 1
+        (uncompressed_size,) = struct.unpack_from("<Q", raw, off); off += 8
+        blob = raw[off:]
+        if comp_mode == 0:          # UNCOMPRESSED
+            return blob[:uncompressed_size]
+        if comp_mode == 1:          # ZLIB
+            out = zlib.decompress(blob)
+            if len(out) != uncompressed_size:
+                raise ValueError(
+                    f"zlib output {len(out)} != declared {uncompressed_size}"
+                )
+            return out
+        if comp_mode == 2:          # LIBBSC
+            raise NotImplementedError(
+                "Snapshot uses LIBBSC compression (file > 5 MB). stdlib can't "
+                "decode it. Regenerate with smaller per-snapshot size, or decode "
+                "via the gaden player. (ZLIB is used automatically below 5 MB.)"
+            )
+        raise ValueError(f"unknown compression mode {comp_mode}")
+
+    def _parse_body(self, body: bytes):
+        # Front: version (2x int32) + Description (40 B POD).
+        off = 0
+        ver_major, ver_minor = struct.unpack_from("<ii", body, off); off += 8
+        if ver_major < 3:
+            raise NotImplementedError(
+                f"file version {ver_major}.{ver_minor} < 3.0 — body layout differs; "
+                "use the gaden player for legacy files."
+            )
+        dx, dy, dz = struct.unpack_from("<iii", body, off); off += 12
+        min_x, min_y, min_z = struct.unpack_from("<fff", body, off); off += 12
+        _max = struct.unpack_from("<fff", body, off); off += 12
+        (cell_size,) = struct.unpack_from("<f", body, off); off += 4
+
+        self.dims = (dx, dy, dz)
+        self.min_coord = (min_x, min_y, min_z)
+        self.cell_size = float(cell_size)
+        n_cells = dx * dy * dz
+        if n_cells <= 0:
+            raise ValueError(f"bad grid dims {self.dims}")
+
+        # Tail: concentration vector is the last write — [uint64 count][count f32].
+        # Robustly grab the final n_cells floats and verify the preceding count.
+        grid_bytes = n_cells * 4
+        if len(body) < grid_bytes + 8:
+            raise ValueError(
+                f"body too short ({len(body)} B) for {n_cells} cells + count"
+            )
+        count_off = len(body) - grid_bytes - 8
+        (count,) = struct.unpack_from("<Q", body, count_off)
+        if count != n_cells:
+            raise ValueError(
+                f"tail vector count {count} != numCells {n_cells}. File may be "
+                "'filaments' mode (regenerate with preCalculateConcentrations: true) "
+                "or layout mismatch."
+            )
+        flat = np.frombuffer(body, dtype="<f4", count=n_cells, offset=count_off + 8)
+        # indexFrom3D = x + y*nx + z*nx*ny  → reshape (nz, ny, nx)
+        self.grid = flat.reshape(dz, dy, dx).astype(np.float32)
+
+    # ------------------------------------------------------------------
+    def concentration_at(self, x: float, y: float, z: float = 0.5) -> float:
+        """Gas concentration [ppm] at world coords (env frame). Nearest cell.
+
+        Matches gaden Environment::coordsToIndices: floor((coord - min)/cellSize).
+        Out-of-bounds queries return 0.0.
+        """
+        if self.grid is None:
+            raise RuntimeError("call load_iteration() first")
+        nx, ny, nz = self.dims
+        ix = int((x - self.min_coord[0]) / self.cell_size)
+        iy = int((y - self.min_coord[1]) / self.cell_size)
+        iz = int((z - self.min_coord[2]) / self.cell_size)
+        if not (0 <= ix < nx and 0 <= iy < ny and 0 <= iz < nz):
+            return 0.0
+        return float(self.grid[iz, iy, ix])
+
+    def slice_z(self, z: float = 0.5) -> np.ndarray:
+        """Return the (ny, nx) horizontal concentration slice at height z."""
+        if self.grid is None:
+            raise RuntimeError("call load_iteration() first")
+        iz = int((z - self.min_coord[2]) / self.cell_size)
+        iz = max(0, min(self.dims[2] - 1, iz))
+        return self.grid[iz]
+
+
+def _cli():
+    import argparse
+    p = argparse.ArgumentParser(description="Inspect a GADEN concentration snapshot.")
+    p.add_argument("--result-dir", required=True, help="path to <sim>/result")
+    p.add_argument("--iteration", type=int, required=True)
+    p.add_argument("--at", nargs=3, type=float, metavar=("X", "Y", "Z"),
+                   help="query concentration at world coords")
+    args = p.parse_args()
+
+    seq = GadenResultSequence(args.result_dir).load_iteration(args.iteration)
+    nx, ny, nz = seq.dims
+    sl = seq.slice_z(args.at[2] if args.at else 0.5)
+    print(f"iteration {args.iteration}: dims={seq.dims} cell={seq.cell_size} "
+          f"min={seq.min_coord}")
+    print(f"  z-slice nonzero cells: {(sl > 0).sum()}/{sl.size}  "
+          f"max ppm: {sl.max():.4f}  mean(nonzero): "
+          f"{sl[sl > 0].mean() if (sl > 0).any() else 0:.4f}")
+    if args.at:
+        print(f"  concentration_at{tuple(args.at)} = "
+              f"{seq.concentration_at(*args.at):.4f} ppm")
+
+
+if __name__ == "__main__":
+    _cli()

--- a/reinforcement_learning/test/gaden_result_loader.py
+++ b/reinforcement_learning/test/gaden_result_loader.py
@@ -307,6 +307,51 @@ class GadenResultSequence:
         return out
 
 
+class ReplayGasSource:
+    """Drop-in gas source backed by real GADEN result/iteration_<N> snapshots.
+
+    Matches the subset of the FilamentPlume interface that GasSourceEnv uses
+    (``update()``, ``concentration_at(pos)``, ``get_all_filaments()``), so the
+    env can query the *real* GADEN concentration field instead of the surrogate
+    plume — eliminating the largest eval fidelity gap (the labyrinth gas field
+    is near-homogeneous in real GADEN but the surrogate produces a different,
+    more followable field).
+
+    Coordinate handling: the env works in env-frame (origin-shifted) positions;
+    GADEN snapshots are in absolute world coords. ``origin_xy`` (the map's
+    env_min) converts env→absolute. Time: saveDeltaTime = 0.5 s per snapshot, so
+    one env step advances one snapshot. Starts at ``start_iteration`` (=
+    start_time / saveDeltaTime) and clamps to the last available snapshot.
+    """
+
+    def __init__(self, result_dir, origin_xy, start_iteration: int,
+                 z: float = 0.5):
+        self._seq = GadenResultSequence(result_dir)
+        self._avail = self._seq.available_iterations()
+        self._max_iter = self._avail[-1] if self._avail else 0
+        self._ox, self._oy = float(origin_xy[0]), float(origin_xy[1])
+        self._z = float(z)
+        self._iter = max(0, min(int(start_iteration), self._max_iter))
+        self._seq.load_iteration(self._iter)
+
+    def update(self):
+        # One env step == one saved snapshot (saveDeltaTime). Hold the last
+        # snapshot once the recording runs out (short result dirs, e.g. u_left).
+        if self._iter < self._max_iter:
+            self._iter += 1
+            self._seq.load_iteration(self._iter)
+
+    def concentration_at(self, pos):
+        return self._seq.concentration_at(pos[0] + self._ox,
+                                          pos[1] + self._oy, self._z)
+
+    def get_all_filaments(self):
+        # For viz compatibility; return absolute filament positions if present.
+        if self._seq.filaments is not None:
+            return {"positions": self._seq.filaments["pos"][:, :2].copy()}
+        return {"positions": np.zeros((0, 2))}
+
+
 def _cli():
     import argparse
     p = argparse.ArgumentParser(description="Inspect a GADEN concentration snapshot.")

--- a/reinforcement_learning/test/gaden_result_loader.py
+++ b/reinforcement_learning/test/gaden_result_loader.py
@@ -145,8 +145,25 @@ class GadenResultSequence:
             )
         raise ValueError(f"unknown compression mode {comp_mode}")
 
+    # per-type extra fields (bytes) BEFORE the trailing Vector3 pos + int gasType,
+    # per GasSource::DeserializeBinary (src/GasSource.cpp).
+    _GASSOURCE_EXTRA = {
+        "point": 0,
+        "box": 12,        # Vector3 size
+        "line": 12,       # Vector3 lineEnd
+        "sphere": 4,      # float radius
+        "cylinder": 8,    # float radius + float height
+    }
+
     def _parse_body(self, body: bytes):
-        # Front: version (2x int32) + Description (40 B POD).
+        # Body layout (BufferWriter order, see RunningSimulation::SaveResults):
+        #   i32 verMajor, i32 verMinor
+        #   Description (40 B): Vec3i dims, Vec3 min, Vec3 max, f32 cellSize
+        #   GasSource (var): string type + per-type fields + Vec3 pos + i32 gasType
+        #   Constants (8 B): f32 totalMolesInFilament, f32 numMolesAllGasesIncm3
+        #   i32 windIndex
+        #   string mode  ("concentrations" | "filaments")
+        #   vector payload (u64 count + count * {f32 grid | Filament})
         off = 0
         ver_major, ver_minor = struct.unpack_from("<ii", body, off); off += 8
         if ver_major < 3:
@@ -166,49 +183,128 @@ class GadenResultSequence:
         if n_cells <= 0:
             raise ValueError(f"bad grid dims {self.dims}")
 
-        # Tail: concentration vector is the last write — [uint64 count][count f32].
-        # Robustly grab the final n_cells floats and verify the preceding count.
-        grid_bytes = n_cells * 4
-        if len(body) < grid_bytes + 8:
-            raise ValueError(
-                f"body too short ({len(body)} B) for {n_cells} cells + count"
-            )
-        count_off = len(body) - grid_bytes - 8
-        (count,) = struct.unpack_from("<Q", body, count_off)
-        if count != n_cells:
-            raise ValueError(
-                f"tail vector count {count} != numCells {n_cells}. File may be "
-                "'filaments' mode (regenerate with preCalculateConcentrations: true) "
-                "or layout mismatch."
-            )
-        flat = np.frombuffer(body, dtype="<f4", count=n_cells, offset=count_off + 8)
-        # indexFrom3D = x + y*nx + z*nx*ny  → reshape (nz, ny, nx)
-        self.grid = flat.reshape(dz, dy, dx).astype(np.float32)
+        # GasSource (variable) — must be parsed to reach mode + payload.
+        (slen,) = struct.unpack_from("<Q", body, off); off += 8
+        stype = body[off:off + slen].decode("ascii", "replace"); off += slen
+        off += self._GASSOURCE_EXTRA.get(stype, 0)
+        self.source_pos = struct.unpack_from("<fff", body, off); off += 12
+        (self.gas_type,) = struct.unpack_from("<i", body, off); off += 4
+
+        # Constants (used for filament-mode concentration).
+        total_moles, moles_all = struct.unpack_from("<ff", body, off); off += 8
+        self._total_moles = float(total_moles)
+        self._moles_all = float(moles_all)
+
+        (self._wind_index,) = struct.unpack_from("<i", body, off); off += 4
+
+        (mlen,) = struct.unpack_from("<Q", body, off); off += 8
+        self.mode = body[off:off + mlen].decode("ascii", "replace"); off += mlen
+
+        (count,) = struct.unpack_from("<Q", body, off); off += 8
+
+        if self.mode == "concentrations":
+            if count != n_cells:
+                raise ValueError(f"concentration count {count} != numCells {n_cells}")
+            flat = np.frombuffer(body, dtype="<f4", count=n_cells, offset=off)
+            # indexFrom3D = x + y*nx + z*nx*ny  → reshape (nz, ny, nx)
+            self.grid = flat.reshape(dz, dy, dx).astype(np.float32)
+            self.filaments = None
+        elif self.mode == "filaments":
+            # Filament POD = Vector3 position (3 f32) + float sigma = 16 B.
+            fil = np.frombuffer(body, dtype="<f4", count=count * 4, offset=off)
+            fil = fil.reshape(count, 4)
+            self.filaments = {
+                "pos": fil[:, :3].astype(np.float64),     # (N,3) metres
+                "sigma": fil[:, 3].astype(np.float64),    # (N,)  GADEN sigma (cm)
+            }
+            self.grid = None
+        else:
+            raise ValueError(f"unknown payload mode '{self.mode}'")
 
     # ------------------------------------------------------------------
-    def concentration_at(self, x: float, y: float, z: float = 0.5) -> float:
-        """Gas concentration [ppm] at world coords (env frame). Nearest cell.
+    def _conc_at_center(self, sigma):
+        """ppm at a filament's center — GADEN Simulation::ConcentrationAtCenter.
 
-        Matches gaden Environment::coordsToIndices: floor((coord - min)/cellSize).
-        Out-of-bounds queries return 0.0.
+        numMolesTarget_cm3 = totalMolesInFilament / (sqrt(8 pi^3) * sigma^3)
+        ppm = 1e6 * numMolesTarget_cm3 / numMolesAllGasesIncm3
+        (sigma is GADEN's filament sigma, in cm.)
         """
-        if self.grid is None:
-            raise RuntimeError("call load_iteration() first")
+        denom = np.sqrt(8.0 * np.pi ** 3) * sigma ** 3
+        num_moles = self._total_moles / denom
+        return 1e6 * num_moles / self._moles_all
+
+    def concentration_at(self, x: float, y: float, z: float = 0.5) -> float:
+        """Gas concentration [ppm] at world coords (env frame).
+
+        concentrations mode: nearest-cell lookup (matches coordsToIndices).
+        filaments mode: sum of Gaussian filament kernels exactly as GADEN's
+        Simulation::CalculateConcentration — per filament within 3*sigma/100 m,
+            ppm = ConcentrationAtCenter(sigma) * exp(-dist_cm^2 / (2 sigma^2))
+        with dist_cm = 100 * |fil.pos - sample|. Line-of-sight wall occlusion
+        (GADEN's CheckLineOfSight) is NOT applied here — the loader has no
+        occupancy grid; pass an occupancy to ``concentration_field_slice`` if
+        you need it. For point queries the LoS effect is usually small.
+        Out-of-bounds returns 0.0.
+        """
         nx, ny, nz = self.dims
         ix = int((x - self.min_coord[0]) / self.cell_size)
         iy = int((y - self.min_coord[1]) / self.cell_size)
         iz = int((z - self.min_coord[2]) / self.cell_size)
         if not (0 <= ix < nx and 0 <= iy < ny and 0 <= iz < nz):
             return 0.0
-        return float(self.grid[iz, iy, ix])
+        if self.mode == "concentrations":
+            return float(self.grid[iz, iy, ix])
+        # filaments mode
+        f = self.filaments
+        if f is None or len(f["sigma"]) == 0:
+            return 0.0
+        sample = np.array([x, y, z], dtype=np.float64)
+        d = f["pos"] - sample                              # (N,3)
+        dist2_m = np.einsum("ij,ij->i", d, d)              # squared metres
+        sigma = f["sigma"]                                 # cm
+        limit_m = 3.0 * sigma / 100.0                      # GADEN's 3-sigma cutoff
+        near = dist2_m < limit_m * limit_m
+        if not near.any():
+            return 0.0
+        dist_cm2 = dist2_m[near] * 1e4                     # (100*m)^2
+        s = sigma[near]
+        ppm = self._conc_at_center(s) * np.exp(-dist_cm2 / (2.0 * s * s))
+        return float(ppm.sum())
 
     def slice_z(self, z: float = 0.5) -> np.ndarray:
-        """Return the (ny, nx) horizontal concentration slice at height z."""
-        if self.grid is None:
-            raise RuntimeError("call load_iteration() first")
+        """Return the (ny, nx) horizontal concentration slice at height z.
+
+        concentrations mode: direct grid slice. filaments mode: evaluate the
+        kernel sum at every cell center on that z-plane (vectorized).
+        """
+        nx, ny, nz = self.dims
         iz = int((z - self.min_coord[2]) / self.cell_size)
-        iz = max(0, min(self.dims[2] - 1, iz))
-        return self.grid[iz]
+        iz = max(0, min(nz - 1, iz))
+        if self.mode == "concentrations":
+            return self.grid[iz]
+        # filaments: evaluate at each cell center on the plane.
+        zc = self.min_coord[2] + (iz + 0.5) * self.cell_size
+        xs = self.min_coord[0] + (np.arange(nx) + 0.5) * self.cell_size
+        ys = self.min_coord[1] + (np.arange(ny) + 0.5) * self.cell_size
+        out = np.zeros((ny, nx), dtype=np.float32)
+        f = self.filaments
+        if f is None or len(f["sigma"]) == 0:
+            return out
+        # Loop over filaments (typically a few thousand) accumulating onto grid.
+        for p, sg in zip(f["pos"], f["sigma"]):
+            limit_m = 3.0 * sg / 100.0
+            if abs(p[2] - zc) > limit_m:
+                continue
+            dx2 = (xs - p[0]) ** 2
+            dy2 = (ys - p[1]) ** 2
+            dz2 = (zc - p[2]) ** 2
+            dist2 = dx2[None, :] + dy2[:, None] + dz2
+            mask = dist2 < limit_m * limit_m
+            if not mask.any():
+                continue
+            cc = self._conc_at_center(sg)
+            out[mask] += (cc * np.exp(-(dist2[mask] * 1e4) / (2.0 * sg * sg))).astype(np.float32)
+        return out
 
 
 def _cli():

--- a/reinforcement_learning/test/gas_trace_diagnostic.py
+++ b/reinforcement_learning/test/gas_trace_diagnostic.py
@@ -1,0 +1,160 @@
+"""
+Gas-trace diagnostic — dump per-step (gas, distance-to-source) for the Python
+GADEN-eval harness, in the same line format as the real deployment node.log,
+so the two can be diffed apples-to-apples on the same map + checkpoint.
+
+The real node logs lines like:
+    [Ep 0 Step  12] Pos (9.19,12.69) ... d2src=11.77m gas=0.000 ...
+This script emits the matching subset:
+    [Ep 0 Step  12] Pos (x,y) d2src=<m> gas=<conc> gas_bin=<0/1>
+
+Why this exists: §4 of GADEN_EVAL_FINDINGS.md found that big-map failures are a
+gas-availability problem, not a step-budget one. The prime suspect is plume
+fidelity — does the Python filament plume put gas where real GADEN does? This
+dumps the harness's gas trace along the agent's (greedy) trajectory so you can
+overlay it on the real sim's node.log gas=/d2src= trace for the same map.
+
+Usage:
+    python -m reinforcement_learning.test.gas_trace_diagnostic \
+        --checkpoint /path/agent.pt --arch dual --map ultimate \
+        [--gaden-root <dir>] [--max-steps 600] [--seed 0] [--out trace.log]
+
+Notes:
+- Warmup now scales with the map's recommended start_time (see
+  gas_source_env.reset); this script reports the warmup it used so you can
+  confirm it matches the real GADEN playback start.
+- Greedy (deterministic) actions, matching eval_checkpoints_gaden.
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import numpy as np
+import torch
+
+_SCRIPT_DIR = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(os.path.dirname(_SCRIPT_DIR)))
+
+from reinforcement_learning import config as cfg
+from reinforcement_learning.envs.gas_source_env import GasSourceEnv
+from reinforcement_learning.envs.spatial_obs_wrapper import SpatialObsWrapper
+from reinforcement_learning.models.actor_critic import ActorCriticDualBackbone
+from reinforcement_learning.models.actor_critic_spatial import ActorCriticSpatial
+from reinforcement_learning.test.gaden_loader import load_full_map
+
+_DEFAULT_GADEN_ROOT = Path(_SCRIPT_DIR).parents[1] / "gaden_maps"
+
+
+def _load_agent(checkpoint, arch, device):
+    ckpt = torch.load(checkpoint, map_location=device)
+    state = ckpt.get("model_state_dict", ckpt) if isinstance(ckpt, dict) else ckpt
+    if arch == "dual":
+        agent = ActorCriticDualBackbone().to(device)
+    elif arch == "spatial":
+        agent = ActorCriticSpatial().to(device)
+    else:
+        raise ValueError(f"unsupported arch '{arch}' (use dual|spatial)")
+    agent.load_state_dict(state)
+    agent.eval()
+    return agent
+
+
+def _greedy_action(agent, arch, obs, device):
+    with torch.no_grad():
+        if arch == "dual":
+            obs_t = torch.as_tensor(obs, dtype=torch.float32, device=device).unsqueeze(0)
+            enc = agent._encode_shared(obs_t)
+            return agent._actor_dist(enc).mean.cpu().numpy()[0]
+        spatial, wind = obs
+        spatial_t = torch.as_tensor(spatial, dtype=torch.float32, device=device).unsqueeze(0)
+        wind_t = torch.as_tensor(wind, dtype=torch.float32, device=device).unsqueeze(0)
+        enc = agent._encode_shared(spatial_t, wind_t)
+        return agent._actor_dist(enc).mean.cpu().numpy()[0]
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument("--checkpoint", required=True)
+    p.add_argument("--arch", default="dual", choices=["dual", "spatial"])
+    p.add_argument("--map", required=True, help="GADEN map key, e.g. ultimate")
+    p.add_argument("--gaden-root", default=str(_DEFAULT_GADEN_ROOT))
+    p.add_argument("--max-steps", type=int, default=cfg.MAX_STEPS)
+    p.add_argument("--seed", type=int, default=0)
+    p.add_argument("--out", default=None, help="write trace to this file (else stdout)")
+    args = p.parse_args()
+
+    device = torch.device("cpu")
+    gaden_root = Path(args.gaden_root)
+    yaml_path = gaden_root / "recommended_configs.yaml"
+    full_map = load_full_map(gaden_root, yaml_path, args.map)
+    spec = full_map.get("spec", {})
+    start_time = spec.get("start_time", 0)
+    src = np.asarray(full_map["source_pos"], dtype=np.float64)
+
+    agent = _load_agent(args.checkpoint, args.arch, device)
+
+    map_data = {k: full_map[k] for k in ("grid", "source_pos", "robot_pos",
+                                          "width", "height")}
+    map_data["start_time"] = start_time
+
+    if args.arch == "dual":
+        env = GasSourceEnv()
+    else:
+        env = SpatialObsWrapper(GasSourceEnv())
+    obs, _ = env.reset(
+        seed=args.seed,
+        options={"map_data": map_data, "wind_field": full_map["wind_field"]},
+    )
+    # The underlying GasSourceEnv (unwrapped) holds the plume + robot pos.
+    base = env._env if isinstance(env, SpatialObsWrapper) else env
+    warmup = int(round(float(start_time) / cfg.FILAMENT_DT)) if start_time else cfg.FILAMENT_WARMUP_STEPS
+
+    lines = []
+    hdr = (f"# gas-trace  map={args.map}  ckpt={os.path.basename(args.checkpoint)}  "
+           f"arch={args.arch}  start_time={start_time}s  warmup={warmup} steps  "
+           f"source=({src[0]:.2f},{src[1]:.2f})  n_filaments_post_warmup={base._plume.n_active}")
+    lines.append(hdr)
+
+    n_gas = 0
+    min_d = float("inf")
+    success = False
+    step = 0
+    while True:
+        pos = np.asarray(base._robot_pos, dtype=np.float64)
+        conc = base._plume.concentration_at(pos)
+        d2src = float(np.linalg.norm(pos - src))
+        gas_bin = 1 if conc > 0.0 else 0
+        n_gas += gas_bin
+        min_d = min(min_d, d2src)
+        lines.append(f"[Ep 0 Step {step:4d}] Pos ({pos[0]:.2f},{pos[1]:.2f}) "
+                     f"d2src={d2src:.2f}m gas={conc:.3f} gas_bin={gas_bin}")
+
+        action = _greedy_action(agent, args.arch, obs, device)
+        obs, _, terminated, truncated, _ = env.step(action)
+        step += 1
+        if terminated:
+            success = True
+            break
+        if truncated or step >= args.max_steps:
+            break
+
+    total = step + 1
+    summary = (f"# SUMMARY  steps={total}  success={success}  "
+               f"nonzero_gas={n_gas}/{total} ({100*n_gas/total:.1f}%)  "
+               f"min_d2src={min_d:.2f}m  result={'SUCCESS' if success else 'max_steps/failed'}")
+    lines.append(summary)
+
+    text = "\n".join(lines) + "\n"
+    if args.out:
+        Path(args.out).write_text(text)
+        print(f"wrote {args.out}")
+        print(summary)
+        print(hdr)
+    else:
+        print(text)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

Makes the Python GADEN eval harness (`test/eval_checkpoints_gaden.py`) match real GADEN deployment far more closely, by replacing re-derived approximations with GADEN's own data where it exists. Each change was validated by diffing against a real ROS/GADEN run of the champ (`agent_91750400`) on the 7 eval maps.

The headline: the Python harness was **optimistic by ~26pp** vs real deployment (champ 72% Python vs 46% real). Investigating *why*, map-by-map, surfaced several concrete fidelity gaps — all fixed here.

## What changed (each measured, not assumed)

- **`--real-gas`**: replay the **real stored GADEN concentration field** (`result/iteration_<N>`) instead of the surrogate filament plume. The surrogate's gas field differs in spatial structure from GADEN's (esp. near-homogeneous in tight curved mazes, which destroys the gradient the surrogate provides). New `gaden_result_loader.py` parses the gaden_core post-3.0 binary snapshot format (filaments + concentrations modes), validated against real `iteration_*` output.
- **GADEN occupancy grid**: load GADEN's own `OccupancyGrid3D.csv` (z=5) instead of re-rasterizing `walls.stl` — the STL raster gave ~10pp wider corridors (84% vs 74% free), letting the eval robot thread curves the real one can't.
- **Sub-cell lidar**: continuous (bisection-refined) wall distance instead of grid-quantized. Real BasicSim reads <0.4 m clearance on 45% of steps; the old raycast floored at ~0.3 m and hit that only 11%. A train/deploy blind spot in the near-wall regime.
- **Deployment walk-back collision motion**: replicate the node's `_clamp_to_free` (creep up to walls) instead of all-or-nothing motion.
- **`start_time` plume warmup**: warm the surrogate plume to the scenario's playback `start_time` (not a fixed 15 steps), so big maps aren't gas-starved at the robot start.
- **`gas_trace_diagnostic.py`**: dumps per-step gas/d2src in `node.log` format for apples-to-apples diffing against real runs.
- **Portable scenarios-root**: env var / autodetect, graceful fallback (no hardcoded path); runs on any box.

## Validation (champ, 20 runs/map)

Per-map, `--real-gas` moves the harness toward real deployment (e.g. labyrinths 100%→80-90% vs real 40-60%; 4rooms 40%→60%). Remaining residual on the two curved labyrinths is emergent closed-loop ROS/sensor execution a synchronous kinematic harness can't reproduce — documented, not papered over.

## Heads-up / not in this PR

- **GADEN gas data is NOT committed** (`result/iteration_*` ≈ 3.5 GB across the 7 maps; 4rooms alone 2.1 GB). Default surrogate eval works out of the box with zero data. `--real-gas` and the GADEN-grid path **auto-activate where the data is present**, else fall back to surrogate. To enable: regenerate via GADEN, or `rsync` the `result/` + `OccupancyGrid3D.csv` dirs out-of-band; optionally set `$GADEN_SCENARIOS_ROOT`.
- Training-side takeaway (not code here): the surrogate gives a cleaner gas gradient than real GADEN in complex maps — training on real/gradient-poor fields should improve transfer.

## Test plan

- [ ] `python -m reinforcement_learning.test.eval_checkpoints_gaden --run-dirs <run>` (surrogate, no data needed)
- [ ] `... --real-gas` on a box with GADEN `result/` present
- [ ] Confirm graceful surrogate fallback when result dirs absent

🤖 Generated with [Claude Code](https://claude.com/claude-code)