### PR TITLE
fix(baselines): map-aware goal validation + eval-harness tweaks

### DIFF
--- a/adsm/launch/adsm_launch.py
+++ b/adsm/launch/adsm_launch.py
@@ -1,5 +1,6 @@
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 
@@ -52,7 +53,7 @@ def generate_launch_description():
                 'source_y': LaunchConfiguration('source_y'),
                 'source_th': LaunchConfiguration('source_th'),
                 'iter_rate': LaunchConfiguration('iter_rate'),
-                'max_iter': 200,
+                'max_iter': ParameterValue(LaunchConfiguration('max_iter'), value_type=int),
                 'stuck_duration_th': 60.0,
                 'visual': True,
                 'data_path': LaunchConfiguration('data_path'),

--- a/adsm/src/adsm.cpp
+++ b/adsm/src/adsm.cpp
@@ -388,10 +388,31 @@ bool Adsm::reached_point(double x, double y) {
 }
 
 void Adsm::create_random_gaol(double start_x, double start_y, double r, double& goal_x, double& goal_y) {
-    double rand_theta = static_cast<double>(rand()) / RAND_MAX * 2 * M_PI;
-    double rand_r = static_cast<double>(rand()) / RAND_MAX * r;
-    goal_x = start_x + rand_r * cos(rand_theta);
-    goal_y = start_y + rand_r * sin(rand_theta);
+    // Sample a random goal within radius r that is inside the map and on a known,
+    // non-lethal cell. Without this guard a sample can land outside the arena or
+    // in a wall; Nav2 then rejects it ("off the global costmap"), the robot never
+    // moves, and the stuck watchdog fires. Fall back to the seed position so the
+    // goal stays in-bounds instead of drifting off the map.
+    const int max_tries = 50;
+    for (int i = 0; i < max_tries; ++i) {
+        double rand_theta = static_cast<double>(rand()) / RAND_MAX * 2 * M_PI;
+        double rand_r = static_cast<double>(rand()) / RAND_MAX * r;
+        double cx = start_x + rand_r * cos(rand_theta);
+        double cy = start_y + rand_r * sin(rand_theta);
+        int mx, my;
+        if (!map_.worldToMap(cx, cy, mx, my)) {
+            continue;  // outside the map bounds
+        }
+        int cost = map_.getCost(mx, my);
+        if (cost == Gridmap::LETHAL_OBSTACLE || cost == Gridmap::NO_INFORMATION) {
+            continue;  // wall or unexplored -> Nav2 can't plan there
+        }
+        goal_x = cx;
+        goal_y = cy;
+        return;
+    }
+    goal_x = start_x;
+    goal_y = start_y;
 }
 
 void Adsm::observe() {
@@ -605,7 +626,9 @@ void Adsm::evaluate() {
         goals_.clear();
         RCLCPP_INFO(this->get_logger(), "Generate a random goal. r: %.2f", random_sample_r_);
         double new_x, new_y;
-        create_random_gaol(goal_.x, goal_.y, random_sample_r_, new_x, new_y);
+        // Seed from the robot's current position, not the previous goal: seeding
+        // from goal_ let an out-of-bounds goal compound into a runaway drift.
+        create_random_gaol(real_x_, real_y_, random_sample_r_, new_x, new_y);
         goals_.push_back(GoalNode(iter_, new_x, new_y, GOAL_RANDOM_TYPE));
     }
 

--- a/ali_igdm/ali_igdm/utils/experiment_logger.py
+++ b/ali_igdm/ali_igdm/utils/experiment_logger.py
@@ -61,18 +61,20 @@ class ExperimentLogger:
         self.csv_writer.writerow(row)
         self.log_file.flush()
 
-    def save_summary(self, step_count, total_dist, elapsed_time, avg_comp_time, 
-                     est_x, est_y, est_error):
+    def save_summary(self, step_count, total_dist, elapsed_time, avg_comp_time,
+                     est_x, est_y, est_error, first_close_time=None):
         """
         Saves the final summary text file.
         """
+        first_close_str = f"{first_close_time:.2f} s" if first_close_time is not None else "never"
         summary = (
             f"ST: {step_count} steps\n"
             f"TD: {total_dist:.2f} m\n"
             f"Time: {elapsed_time:.2f} s\n"
             f"Avg Comp: {avg_comp_time:.4f} s\n"
             f"Error: {est_error:.3f} m\n"
-            f"Est Source: ({est_x:.3f}, {est_y:.3f})"
+            f"Est Source: ({est_x:.3f}, {est_y:.3f})\n"
+            f"First within 0.5m: {first_close_str}"
         )
         
         summary_filename = self.log_filename.replace('.csv', '_summary.txt')

--- a/ali_igdm/setup.py
+++ b/ali_igdm/setup.py
@@ -25,6 +25,7 @@ setup(
     entry_points={
         'console_scripts': [
             "start = ali_igdm.igdm:main",
+            "start_basic = ali_igdm.igdm:main",
         ],
     },
 )

--- a/eesa/eesa/banana.py
+++ b/eesa/eesa/banana.py
@@ -497,7 +497,18 @@ class Banana:
 
     # ------------------------------------------------------------------
     def navigate(self):
-        self.rc.send_goal(self.goal.x, self.goal.y, self.goal.yaw)
+        # Validate the goal against the map: snap it to the nearest known-free
+        # cell with clearance, so we never hand Nav2 a goal inside / against a
+        # wall (which makes the planner fail and the robot wedge -> ROBOT_STUCK).
+        gx, gy = self.goal.x, self.goal.y
+        snapped = self.mc.nearest_free_world(gx, gy)
+        if snapped is None:
+            snapped = (gx, gy)
+        elif abs(snapped[0] - gx) > 1e-3 or abs(snapped[1] - gy) > 1e-3:
+            self.node.get_logger().info(
+                f'Goal clamped to free cell: ({gx:.2f},{gy:.2f}) -> '
+                f'({snapped[0]:.2f},{snapped[1]:.2f})')
+        self.rc.send_goal(snapped[0], snapped[1], self.goal.yaw)
         self.cal_end_time = timer()
 
     def in_motion(self):

--- a/eesa/eesa/map_client.py
+++ b/eesa/eesa/map_client.py
@@ -92,3 +92,38 @@ class MapClient:
 
     def is_in_gridmap(self, x, y):
         return 0 <= x < self.width and 0 <= y < self.height
+
+    def nearest_free_world(self, wx, wy, clearance_m=0.25, max_radius_cells=40):
+        """Snap a world goal to the nearest known-free cell that has
+        ``clearance_m`` of free space around it (no occupied cell within).
+        Prevents handing Nav2 a goal inside / right against a wall, which
+        makes the planner fail and the robot wedge. Returns (wx, wy)
+        unchanged if no map yet, or None if nothing navigable was found."""
+        if self.grid_data is None:
+            return wx, wy
+        cr = max(1, int(round(clearance_m / self.resolution)))
+        cx, cy = self.get_costmap_x_y(wx, wy)
+
+        def navigable(x, y):
+            if not self.is_in_gridmap(x, y):
+                return False
+            v = self.grid_data[y][x]
+            if not (0 <= v < 50):          # exclude unknown (-1) and occupied (>=50)
+                return False
+            for dx in range(-cr, cr + 1):  # clearance: no occupied cell nearby
+                for dy in range(-cr, cr + 1):
+                    xx, yy = x + dx, y + dy
+                    if self.is_in_gridmap(xx, yy) and self.grid_data[yy][xx] >= 50:
+                        return False
+            return True
+
+        if navigable(cx, cy):
+            return wx, wy
+        for r in range(1, max_radius_cells + 1):
+            for dx in range(-r, r + 1):
+                for dy in range(-r, r + 1):
+                    if max(abs(dx), abs(dy)) != r:   # only the ring at radius r
+                        continue
+                    if navigable(cx + dx, cy + dy):
+                        return self.get_world_x_y(cx + dx, cy + dy)
+        return None

--- a/eesa/launch/eesa_launch.py
+++ b/eesa/launch/eesa_launch.py
@@ -5,6 +5,7 @@ and then the EESA search agent.
 """
 from launch import LaunchDescription
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 from launch.actions import DeclareLaunchArgument
 from launch.substitutions import LaunchConfiguration
 
@@ -68,7 +69,7 @@ def generate_launch_description():
                 'source_y': LaunchConfiguration('source_y'),
                 'find_source_th': LaunchConfiguration('find_source_th'),
                 'iter_rate': LaunchConfiguration('iter_rate'),
-                'max_iter': 200,
+                'max_iter': ParameterValue(LaunchConfiguration('max_iter'), value_type=int),
                 'max_stuck_time': LaunchConfiguration('max_stuck_time'),
                 'data_path': LaunchConfiguration('data_path'),
                 'visual': True,

--- a/gaden_maps/recommended_configs.yaml
+++ b/gaden_maps/recommended_configs.yaml
@@ -108,22 +108,22 @@ env_b:
   sim1:
     source: [22.5, 10.5]
     robot_start: [2.5, 14.75]
-    start_time: 200
+    start_time: 800
     notes: ""
   sim2:
     source: [18.0, 10.5]
     robot_start: [2.5, 14.75]
-    start_time: 200
+    start_time: 800
     notes: ""
   sim3:
     source: [14.0, 12.0]
     robot_start: [2.5, 14.75]
-    start_time: 200
+    start_time: 1200
     notes: ""
   sim4:
     source: [6.5, 5.5]
     robot_start: [2.5, 14.75]
-    start_time: 200
+    start_time: 800
     notes: ""
 
 env_c:
@@ -137,7 +137,7 @@ env_c_nowind:
   sim1:
     source: [18.0, 7.5]
     robot_start: [2.5, 4.5]
-    start_time: 200
+    start_time: 800
     notes: "No wind variant — slower gas dispersal, longer warmup."
 
 env_c_slow:

--- a/rrt_infotaxis/rrt_infotaxis/rrt_infotaxis.py
+++ b/rrt_infotaxis/rrt_infotaxis/rrt_infotaxis.py
@@ -39,6 +39,7 @@ class RRTInfotaxisNode(Node):
         self.declare_parameter('zeta_1', 0.1)  # Gaussian dispersion parameter
         self.declare_parameter('zeta_2', 0.1)  # Gaussian dispersion parameter
         self.declare_parameter('positive_weight', 0.5)  # Weight of information gain compared to travel cost
+        self.declare_parameter('max_steps', 0)  # 0 = unlimited
 
         # Sensor readings
         self.sensor_raw_value = None
@@ -451,6 +452,13 @@ class RRTInfotaxisNode(Node):
         if self.sensor_raw_value is None or self.current_position is None:
             self.get_logger().debug('Waiting for sensor and position data...')
             return
+
+        max_steps = self.get_parameter('max_steps').value
+        if max_steps > 0 and self.step_count >= max_steps:
+            self.get_logger().info(f'[MAX STEPS] Reached step limit ({max_steps}). Finishing.')
+            self.search_complete = True
+            import os
+            os._exit(0)
 
         # Initialize sensor threshold with first measurement
         if not self.sensor_initialized:

--- a/scripts/presim.sh
+++ b/scripts/presim.sh
@@ -214,7 +214,7 @@ for sim in "${sim_list[@]}"; do
 
     # Step 2: Simulation
     echo -e "\n  ${YELLOW}[2/2]${RESET} Simulating..."
-    ros2 launch test_env gaden_sim_launch.py scenario:="$scenario" configuration:="$config" simulation:="$sim"
+    ros2 launch test_env gaden_sim_launch.py scenario:="$scenario" configuration:="$config" simulation:="$sim" sim_time:=1500
     sim_status=$?
 
     if [ $sim_status -ne 0 ]; then


### PR DESCRIPTION
## What

Small, independent robustness fixes across the classical GSL baselines, plus eval/logging conveniences. No shared-module or RL coupling — each change is local to its package. Branches off `main` (current `origin/main`).

## Changes

**Goal validation (stop robots wedging on invalid Nav2 goals)**
- `adsm`: sample random goals inside the map on a known, non-lethal cell — retry up to 50×, fall back to the seed pose; seed from the robot's *current* position instead of the previous goal, so an out-of-bounds goal can't compound into runaway drift
- `eesa`: `MapClient.nearest_free_world()` snaps goals to the nearest known-free cell with clearance before `send_goal`

**Eval-harness / config**
- `adsm` + `eesa` launch: `max_iter` is now a configurable `int` param (was hardcoded 200)
- `rrt_infotaxis`: new `max_steps` param (`0` = unlimited) with clean termination
- `recommended_configs.yaml`: longer gas warmup for `env_b` / `env_c_nowind` (`start_time` 200 → 800/1200) — **`start_time` only; mainline `robot_start` values left untouched**
- `presim.sh`: pass `sim_time:=1500` to the GADEN sim launch

**Logging**
- `ali_igdm`: log "first within 0.5m" time in the run summary; add `start_basic` console entry point

## Notes
- 10 files, +99/−17. Independent of PR #32 (rl-deploy) and PR #31 (many_rooms).