### PR TITLE
Add OpenFOAM CFD wind-field pipeline for procedural maps

### DIFF
--- a/cfd_wind_pipeline/.gitignore
+++ b/cfd_wind_pipeline/.gitignore
@@ -1,0 +1,16 @@
+# Generated case directories and CFD artifacts
+case_*/
+postProcessing/
+constant/polyMesh/
+*.sqsh
+
+# Outputs / data
+*.npz
+*.png
+*.json
+!example_*.json
+
+# Python
+__pycache__/
+*.pyc
+.ipynb_checkpoints/

--- a/cfd_wind_pipeline/EXPERIMENT_LOG.md
+++ b/cfd_wind_pipeline/EXPERIMENT_LOG.md
@@ -1,0 +1,64 @@
+# Experiment log — CFD-wind transfer campaign
+
+Chronological record of training runs in the CFD-wind / GADEN-transfer
+investigation, and *why* runs were killed. Goal: never re-run a dead end.
+
+## Killed 2026-05-28
+
+### 5193 — `ppo_dual_obs50_noloop` (uniform wind, fresh)
+- **Killed at:** ~132M / 200M steps (66%), after 23.5h.
+- **Why killed:** training success collapsed from 96% → 14% and stayed there;
+  GADEN eval @115M = 0% on all maps. Unrecoverable.
+- **Root cause (not "bad hyperparameters" in general — a bad *combination*):**
+  it inherited the **post-May-25 aggressive curriculum** (feature/rl commit
+  `6205763` added T8 @40% and T9 @60%) AND ran without the champ's
+  stabilizers — `--num-envs 48` (small, noisy gradients) and **no
+  `target_kl`** (destructive updates allowed). Hard templates (T8 dense
+  rooms, T9 hybrid) have sparse reward → mostly destabilizing gradient noise;
+  with a small batch and no KL guard the policy degraded faster than it could
+  learn them, eventually failing even trivial maps.
+- **Contrast — why the champ (76.4%) did NOT collapse with the same arch:**
+  gentle curriculum stopping at T5, `--num-envs 256`, `--target-kl 0.05`,
+  `--clip-epsilon 0.3`. Trained on feature/rl *before* `6205763`.
+- **Keeper:** `agent_49152000.pt` (~49M, pre-collapse) scored **39.3% GADEN,
+  30% many_rooms**. many_rooms-30% is rare (most runs are 0% there) — a lead
+  worth its own follow-up. Preserved before killing.
+
+### 5667 — `ppo_cfd_lib_v3` (CFD library, MEAN wind, fresh)
+- **Killed at:** ~early (≈42M), GADEN @42M = 0%.
+- **Why killed:** confounded — same risky knobs as 5193 (48 envs, no
+  `target_kl`) and trains on hard CFD maps (T4-9) from step 0, so it was
+  collapse-prone AND couldn't cleanly test the CFD hypothesis. Also,
+  observationally it's *identical to uniform training*: the env collapses the
+  spatial wind to its mean for the policy obs (`set_uniform(spatial_mean)`),
+  so only the plume shape differs — the wind input is unchanged.
+- **Lesson:** a mean-wind CFD run cannot beat uniform training *through the
+  wind input* by construction. Not a useful experiment.
+
+### 6651 — `ppo_cfd_localwind` (CFD library, LOCAL wind, fresh)
+- **Killed at:** early.
+- **Why killed:** right *idea* (policy observes local point wind via
+  `query(robot_pos)` — the one genuinely novel lever), but wrong *recipe*:
+  fresh-from-scratch, 48 envs, no `target_kl`, hard maps from step 0. Same
+  collapse risk as 5193. The local-wind variable was confounded with the
+  unstable recipe, so its result would be uninterpretable.
+
+## What we concluded
+
+1. The collapses were a **curriculum/stability artifact, not evidence about
+   CFD or spatial wind.** The CFD hypothesis remains *untested*.
+2. Any clean test must hold the recipe at the **champ's stable settings**
+   (≤T5 curriculum, `target_kl 0.05`, `clip 0.3`, large batch) and vary
+   *only* the wind. Full code-verified root cause: the champ came from
+   feature/rl *before* commit `6205763` (2026-05-25), which is what
+   introduced the aggressive T8/T9 curriculum the later runs inherited.
+3. The only genuinely unexplored lever is **local-wind observation**
+   (`OSL_LOCAL_WIND_OBS=1`). Mean-wind CFD is observationally identical to
+   uniform training.
+
+## Replacement plan
+
+Resume from the champ (`ali_champ/agent_91750400.pt`, 76.4%), keep its
+stabilizers, restrict to its known templates (T0-5 via `--template-filter`),
+and A/B *only* the wind observation: mean vs local. This isolates the single
+unexplored variable on a foundation known to be stable.

--- a/cfd_wind_pipeline/README.md
+++ b/cfd_wind_pipeline/README.md
@@ -1,0 +1,128 @@
+# cfd_wind_pipeline
+
+Generate a library of CFD wind fields on procedural maps using OpenFOAM, for
+use as a training distribution that matches GADEN's spatial-wind characteristics.
+
+## Why this exists
+
+GADEN evaluation maps use spatially-varying wind fields computed by OpenFOAM
+(via SimScale CFD). Our procedural training previously used uniform-per-episode
+wind, which is the only metric where *every* GADEN map lies outside the
+training distribution. This pipeline closes that gap by running real CFD on
+procedural maps offline, then sampling `(map, wind_field)` pairs at training
+time.
+
+Reproduces GADEN's wind statistics within ~10% on the same geometry (validated
+on `many_rooms`):
+
+|                  | mean &#124;U&#124; | speed std | direction std |
+|------------------|-------|-----------|---------------|
+| our CFD          | 0.715 | 0.541     | 1.536 rad     |
+| GADEN actual     | 0.733 | 0.583     | 1.805 rad     |
+
+## Requirements
+
+- SLURM cluster with **Pyxis** + **Enroot** (most HPC clusters)
+- OpenFOAM container as a `.sqsh` file. Build with:
+  ```bash
+  enroot import 'docker://opencfd/openfoam-default:latest'
+  ```
+- Python ≥ 3.10 with `numpy`, `scipy`, `matplotlib` (no other deps)
+- A `reinforcement_learning` package providing `envs.map_generator.MapGenerator`
+  and `test.gaden_loader` (for procedural maps + GADEN refs)
+
+Edit `config.py` (or set env vars `CFD_OPENFOAM_SQSH`, `CFD_RL_PACKAGE_PATH`,
+`CFD_GADEN_MAPS_ROOT`, `CFD_DATA_ROOT`) to match your environment.
+
+## Quickstart
+
+```bash
+cd cfd_wind_pipeline
+DATA=${CFD_DATA_ROOT:-/tmp/cfd_data}; mkdir -p $DATA
+
+# 0. Smoke test (verify OpenFOAM + Pyxis + cluster work end-to-end)
+#    Requires a copy of the windAroundBuildings tutorial at $DATA/test_unmodified
+sbatch sbatch/run_smoke.sh $DATA/test_unmodified
+
+# 1. Generate one case (procedural T5 multi_room)
+python gen_case.py --out-dir $DATA/case_t5_demo \
+    --template-id 5 --seed 7 --inlet-speed 0.5 \
+    --openings-west "1.4-2.9,6.1-7.6" --openings-east "1.4-2.9,6.1-7.6"
+
+# 2. Run CFD (~1-5 min once it starts)
+sbatch sbatch/run_case.sh $DATA/case_t5_demo
+
+# 3. Extract wind field as numpy
+python extract_wind.py --case-dir $DATA/case_t5_demo --write-dict-only
+sbatch sbatch/run_case.sh $DATA/case_t5_demo  # if you also need postProcess re-run
+python extract_wind.py --case-dir $DATA/case_t5_demo --parse-only
+
+# 4. Visualize
+python viz/viz_wind.py --case-dir $DATA/case_t5_demo
+```
+
+## File map
+
+| File | Purpose |
+|---|---|
+| `config.py` | Centralized paths + defaults (env-var overridable) |
+| `gen_case.py` | Generate OpenFOAM case from a procedural map |
+| `gen_case_from_gaden.py` | Same but for a GADEN map (validation only) |
+| `placement.py` | Sample inlet/outlet placements with constraints |
+| `extract_wind.py` | Postprocess OpenFOAM output → (H,W,2) numpy |
+| `parse_doors.py` | Utility to read GADEN's `doors.stl` and find inlet/outlet positions |
+| `viz/viz_wind.py` | Quiver plot of one case's wind field |
+| `viz/viz_placements.py` | Contact-sheet of map + opening placements (pre-CFD review) |
+| `viz/viz_gaden_wind.py` | Visualize a GADEN reference wind field (for comparison) |
+| `sbatch/run_case.sh` | SLURM wrapper: blockMesh + snappyHexMesh + simpleFoam |
+| `sbatch/run_smoke.sh` | Smoke test using OpenFOAM's stock tutorial |
+
+## Pipeline
+
+```
+MapGenerator → 2D grid → STL (extruded walls, with openings + boundary
+                              blockers) →
+  blockMeshDict + snappyHexMeshDict + k-epsilon BCs →
+  blockMesh → snappyHexMesh → simpleFoam (steady, k-epsilon) →
+  postProcess (cutting-plane sample at z=H/2) →
+  Python: interpolate to (H,W,2) → wind_field.npz
+```
+
+## Notes on the opening placement strategy
+
+GADEN scenarios have **4 doors** total: 2 inlets + 2 outlets, placed at
+specific positions on opposite walls. We mirror this with a heuristic sampler
+(`placement.py`) that:
+
+- Picks 1–3 inlets on one wall (default W or S), 1–3 outlets on opposite wall
+- Requires opening width ∈ [1.0, 2.5] m
+- Requires openings ≥ 1 m apart on the same wall
+- Requires each opening's clearance zone (immediate cells inside) to be 100%
+  free (no interior walls right behind the opening) and far zone ≥ 85% free
+- Requires the opening to connect to the map's main interior via flood-fill
+- Requires inlet-to-outlet distance ≥ 0.5 × map diagonal
+
+Use `viz/viz_placements.py` to render a contact sheet of N sampled placements
+for review *before* spending CFD compute.
+
+## What stays outside the repo (in `$CFD_DATA_ROOT`)
+
+- Generated case directories (`case_*/`) — these contain GBs of mesh data
+- `*.sqsh` container files (huge)
+- `wind_field.npz` library outputs
+- `.png` visualizations
+
+The repo only contains source.
+
+## Validation
+
+On GADEN `many_rooms` geometry with the same 4-door layout GADEN uses:
+- See `case_gaden_4doors/` (if you generated one) and compare to
+  `gaden_many_rooms_wind.png`
+- Stats match within 5-15% on mean, speed std, direction std
+
+On procedural T5 multi_room with random 2-inlet/2-outlet placement:
+- Direction circular_std ≈ 1.1–1.5 rad (vs GADEN range 1.02-2.00)
+- Speed std ≈ 0.1–0.6 m/s (vs GADEN range 0.29-0.65)
+- Channels through interior gaps + recirculation zones in side rooms appear
+  naturally (the "trap room" failure-mode geometry)

--- a/cfd_wind_pipeline/build_library.py
+++ b/cfd_wind_pipeline/build_library.py
@@ -1,0 +1,140 @@
+"""Generate a batch of OpenFOAM case directories for the wind library.
+
+For each case:
+1. Sample procedural map (template_id, seed) and valid inlet/outlet openings
+   using placement.sample_map_with_openings.
+2. Shell out to gen_case.py to write the full case dir.
+3. Append to manifest.json.
+
+The cases are written but NOT executed. Run them with:
+    sbatch sbatch/run_array.sh <library-dir>
+which uses SLURM array job indexing into the manifest.
+
+Usage:
+    python build_library.py --library-dir $CFD_DATA_ROOT/library_v1 \\
+        --n-cases 200 --templates 5,6,7,8,10 \\
+        --inlet-speeds 0.3,0.5,0.7 --start-seed 1000
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from config import PYTHON_BIN
+from placement import sample_map_with_openings
+
+
+def opening_str(specs, side):
+    """Format openings on a given side as gen_case.py expects: 'lo-hi,lo-hi'."""
+    parts = [f"{o.lo:.3f}-{o.hi:.3f}" for o in specs if o.side == side]
+    return ','.join(parts)
+
+
+def build_one(case_dir: Path, template_id: int, seed: int, inlet_speed: float,
+              gen_case_script: Path, bg_cells_per_meter: float):
+    """Try to generate a single case. Returns dict with params, or None on failure."""
+    # Force inlet_side='west' (W↔E placements only): gen_case uses fixed
+    # inlet/outlet patches on x=0 / x=W bg-mesh faces, so S↔N openings would
+    # leave those patches empty → simpleFoam pRefCell crash.
+    map_data, ops = sample_map_with_openings(template_id, seed, inlet_side='west')
+    if ops is None:
+        return None
+
+    cmd = [
+        PYTHON_BIN, str(gen_case_script),
+        '--out-dir', str(case_dir),
+        '--template-id', str(template_id),
+        '--seed', str(seed),
+        '--inlet-speed', f"{inlet_speed:.3f}",
+        '--bg-cells-per-meter', f"{bg_cells_per_meter:.2f}",
+        '--openings-west', opening_str(ops, 'west'),
+        '--openings-east', opening_str(ops, 'east'),
+        '--openings-south', opening_str(ops, 'south'),
+        '--openings-north', opening_str(ops, 'north'),
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"  gen_case failed for {case_dir.name}: {result.stderr[-500:]}")
+        return None
+
+    return {
+        'case_dir': str(case_dir),
+        'template_id': template_id,
+        'seed': seed,
+        'inlet_speed': inlet_speed,
+        'openings': [
+            {'side': o.side, 'lo': o.lo, 'hi': o.hi, 'role': o.role}
+            for o in ops
+        ],
+    }
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--library-dir', required=True,
+                   help='Output directory; cases written as case_NNNN/')
+    p.add_argument('--n-cases', type=int, default=100)
+    p.add_argument('--templates', type=str, default='5,6,7,8,10',
+                   help='Comma-separated template IDs to sample from')
+    p.add_argument('--inlet-speeds', type=str, default='0.3,0.5,0.7',
+                   help='Comma-separated inlet speed values [m/s]')
+    p.add_argument('--start-seed', type=int, default=1000)
+    p.add_argument('--bg-cells-per-meter', type=float, default=2.0,
+                   help='Background mesh resolution. 2.0 gives ~5cm cells, '
+                        '7x faster than 4.0 with ~3-5%% accuracy delta.')
+    args = p.parse_args()
+
+    templates = [int(x) for x in args.templates.split(',')]
+    speeds = [float(x) for x in args.inlet_speeds.split(',')]
+
+    lib = Path(args.library_dir)
+    lib.mkdir(parents=True, exist_ok=True)
+    gen_case_script = Path(__file__).parent / 'gen_case.py'
+
+    rng = np.random.default_rng(args.start_seed)
+
+    manifest = []
+    attempt = 0
+    case_idx = 0
+    t0 = time.time()
+    while case_idx < args.n_cases:
+        template_id = int(rng.choice(templates))
+        seed = args.start_seed + attempt
+        inlet_speed = float(rng.choice(speeds))
+        attempt += 1
+
+        case_dir = lib / f"case_{case_idx:04d}"
+        if case_dir.exists():
+            case_idx += 1
+            continue
+
+        entry = build_one(case_dir, template_id, seed, inlet_speed, gen_case_script,
+                          args.bg_cells_per_meter)
+        if entry is not None:
+            entry['bg_cells_per_meter'] = args.bg_cells_per_meter
+        if entry is None:
+            print(f"[{case_idx}/{args.n_cases}] skip: T{template_id} seed={seed} (no valid openings)")
+            continue
+        manifest.append(entry)
+        case_idx += 1
+        if case_idx % 10 == 0 or case_idx == args.n_cases:
+            elapsed = time.time() - t0
+            rate = case_idx / max(elapsed, 1e-6)
+            eta = (args.n_cases - case_idx) / max(rate, 1e-6)
+            print(f"[{case_idx}/{args.n_cases}] built (attempts={attempt}, "
+                  f"rate={rate:.2f}/s, eta={eta:.0f}s)")
+
+    (lib / 'manifest.json').write_text(json.dumps(manifest, indent=2))
+    print(f"\nWrote manifest.json with {len(manifest)} entries to {lib}")
+    print(f"Submit with:  sbatch --array=0-{len(manifest)-1}%24 "
+          f"{Path(__file__).parent}/sbatch/run_array.sh {lib}")
+
+
+if __name__ == '__main__':
+    main()

--- a/cfd_wind_pipeline/build_library.py
+++ b/cfd_wind_pipeline/build_library.py
@@ -83,7 +83,12 @@ def main():
     p.add_argument('--templates', type=str, default='5,6,7,8,10',
                    help='Comma-separated template IDs to sample from')
     p.add_argument('--inlet-speeds', type=str, default='0.3,0.5,0.7',
-                   help='Comma-separated inlet speed values [m/s]')
+                   help='Discrete inlet speed values [m/s]. Used only if '
+                        '--inlet-speed-range is not given.')
+    p.add_argument('--inlet-speed-range', type=str, default=None,
+                   help='Continuous inlet-speed range "lo,hi" [m/s]. If given, '
+                        'each case samples uniformly from this range. '
+                        'Overrides --inlet-speeds.')
     p.add_argument('--start-seed', type=int, default=1000)
     p.add_argument('--bg-cells-per-meter', type=float, default=2.0,
                    help='Background mesh resolution. 2.0 gives ~5cm cells, '
@@ -91,7 +96,12 @@ def main():
     args = p.parse_args()
 
     templates = [int(x) for x in args.templates.split(',')]
-    speeds = [float(x) for x in args.inlet_speeds.split(',')]
+    if args.inlet_speed_range:
+        speed_lo, speed_hi = (float(x) for x in args.inlet_speed_range.split(','))
+        speeds = None
+    else:
+        speed_lo = speed_hi = None
+        speeds = [float(x) for x in args.inlet_speeds.split(',')]
 
     lib = Path(args.library_dir)
     lib.mkdir(parents=True, exist_ok=True)
@@ -106,7 +116,10 @@ def main():
     while case_idx < args.n_cases:
         template_id = int(rng.choice(templates))
         seed = args.start_seed + attempt
-        inlet_speed = float(rng.choice(speeds))
+        if speeds is not None:
+            inlet_speed = float(rng.choice(speeds))
+        else:
+            inlet_speed = float(rng.uniform(speed_lo, speed_hi))
         attempt += 1
 
         case_dir = lib / f"case_{case_idx:04d}"

--- a/cfd_wind_pipeline/cfd_library_env.py
+++ b/cfd_wind_pipeline/cfd_library_env.py
@@ -1,0 +1,80 @@
+"""Thin gym.Env wrapper that always resets from a CFD library.
+
+The training VecEnv calls `env.reset()` (no options) on auto-reset, so to
+swap the training distribution we need to intercept reset() and inject
+`options={"map_data": ..., "wind_field": ...}` from the library.
+
+Drop-in replacement: build the wrapper inside the env factory (`make_env`)
+and the rest of the training code is unchanged.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+
+class CFDLibraryEnv:
+    """Wraps a GasSourceEnv and reroutes reset() to a CFD library sample.
+
+    If `mix_synthetic` > 0, that fraction of resets falls back to the env's
+    original procedural-map + synthetic-wind reset (no options). This is a
+    safety valve so the policy still sees the original distribution if the
+    library is small.
+    """
+
+    def __init__(self, env, sampler, mix_synthetic: float = 0.0,
+                 rng: Optional[np.random.Generator] = None):
+        self._env = env
+        self._sampler = sampler
+        self._mix = float(mix_synthetic)
+        self._rng = rng or np.random.default_rng()
+
+    # All non-reset attributes pass through to the wrapped env.
+    def __getattr__(self, name):
+        return getattr(self._env, name)
+
+    def reset(self, *, seed=None, options=None):
+        # Honor explicit options (e.g. eval-time GADEN map_data) — do not override.
+        if options is not None and ("map_data" in options or "wind_field" in options):
+            return self._env.reset(seed=seed, options=options)
+        # Stochastic mix with original distribution.
+        if self._mix > 0.0 and self._rng.random() < self._mix:
+            return self._env.reset(seed=seed)
+        # Default: sample from the library.
+        lib_opts = self._sampler.sample()
+        if options:
+            lib_opts = {**options, **lib_opts}
+        return self._env.reset(seed=seed, options=lib_opts)
+
+    def step(self, action):
+        return self._env.step(action)
+
+
+def make_cfd_env(seed: int, rank: int, library_dir: str,
+                 rl_package_path: str,
+                 mix_synthetic: float = 0.0,
+                 template_id: Optional[int] = None):
+    """Factory replacing train.py's `make_env`. Returns a thunk that
+    constructs a CFDLibraryEnv ready for the VecEnv."""
+    # Lazy imports because this module is also used outside training contexts.
+    if rl_package_path not in sys.path:
+        sys.path.insert(0, rl_package_path)
+    pkg_dir = os.path.dirname(os.path.abspath(__file__))
+    if pkg_dir not in sys.path:
+        sys.path.insert(0, pkg_dir)
+    from reinforcement_learning.envs.gas_source_env import GasSourceEnv
+    from cfd_library_loader import CFDLibrarySampler
+
+    def _init():
+        env = GasSourceEnv(template_id=template_id)
+        rng = np.random.default_rng(seed + rank)
+        sampler = CFDLibrarySampler(library_dir, rng, rl_package_path=rl_package_path)
+        wrapped = CFDLibraryEnv(env, sampler, mix_synthetic=mix_synthetic, rng=rng)
+        wrapped.reset(seed=seed + rank)
+        return wrapped
+
+    return _init

--- a/cfd_wind_pipeline/cfd_library_env.py
+++ b/cfd_wind_pipeline/cfd_library_env.py
@@ -54,12 +54,17 @@ class CFDLibraryEnv:
         return self._env.step(action)
 
 
-def make_cfd_env(seed: int, rank: int, library_dir: str,
+def make_cfd_env(seed: int, rank: int, library_dirs,
                  rl_package_path: str,
                  mix_synthetic: float = 0.0,
-                 template_id: Optional[int] = None):
+                 template_id: Optional[int] = None,
+                 template_filter=None):
     """Factory replacing train.py's `make_env`. Returns a thunk that
-    constructs a CFDLibraryEnv ready for the VecEnv."""
+    constructs a CFDLibraryEnv ready for the VecEnv.
+
+    library_dirs : str | list of str — one or more CFD libraries to pool.
+    template_filter : iterable of int — restrict to these template_ids.
+    """
     # Lazy imports because this module is also used outside training contexts.
     if rl_package_path not in sys.path:
         sys.path.insert(0, rl_package_path)
@@ -72,7 +77,9 @@ def make_cfd_env(seed: int, rank: int, library_dir: str,
     def _init():
         env = GasSourceEnv(template_id=template_id)
         rng = np.random.default_rng(seed + rank)
-        sampler = CFDLibrarySampler(library_dir, rng, rl_package_path=rl_package_path)
+        sampler = CFDLibrarySampler(library_dirs, rng,
+                                    rl_package_path=rl_package_path,
+                                    template_filter=template_filter)
         wrapped = CFDLibraryEnv(env, sampler, mix_synthetic=mix_synthetic, rng=rng)
         wrapped.reset(seed=seed + rank)
         return wrapped

--- a/cfd_wind_pipeline/cfd_library_loader.py
+++ b/cfd_wind_pipeline/cfd_library_loader.py
@@ -1,0 +1,157 @@
+"""Load CFD library cases as (map_data, wind_field) ready to pass into
+GasSourceEnv.reset(options=...).
+
+The training-side wrapper (CFDLibrarySampler) samples a random valid case
+at every env reset, so the policy sees a different (geometry, wind) pair
+each episode instead of MapGenerator+synthetic-wind.
+
+Interface mirrors reinforcement_learning.test.gaden_loader so the env code
+needs no changes — just pass `options={"map_data": ..., "wind_field": ...}`
+to reset().
+
+Usage (training-side):
+    from cfd_wind_pipeline.cfd_library_loader import CFDLibrarySampler
+    sampler = CFDLibrarySampler(library_dir, rng, rl_package_path=...)
+    obs, _ = env.reset(options=sampler.sample())
+
+Usage (one-shot inspection):
+    case = load_cfd_case(case_dir, rl_package_path=...)
+    print(case['map_data']['source_pos'], case['wind_field'].max_speed())
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Optional
+
+import numpy as np
+
+
+def _import_rl_modules(rl_package_path: str):
+    """Lazy import the env modules we need; lets this file be used without
+    the RL package on PYTHONPATH (e.g. by callers in other modules)."""
+    if rl_package_path not in sys.path:
+        sys.path.insert(0, rl_package_path)
+    from reinforcement_learning.envs.occupancy_grid import OccupancyGrid
+    from reinforcement_learning.test.gaden_loader import GadenWindField
+    return OccupancyGrid, GadenWindField
+
+
+def load_cfd_case(case_dir: str | Path, rl_package_path: str) -> dict:
+    """Load a single CFD library case as map_data + wind_field.
+
+    Returns
+    -------
+    dict with keys::
+
+        map_data:    {grid, source_pos, robot_pos, width, height}
+                     The format GasSourceEnv.reset(options["map_data"]) expects.
+        wind_field:  GadenWindField (interface-compatible; spatially-varying CFD wind)
+        case_dir:    Path
+        meta:        full meta.json contents (template_id, seed, openings, ...)
+    """
+    OccupancyGrid, GadenWindField = _import_rl_modules(rl_package_path)
+
+    case = Path(case_dir)
+    if not (case / 'wind_field.npz').exists():
+        raise FileNotFoundError(f"{case}/wind_field.npz not found (case not complete)")
+
+    meta = json.loads((case / 'meta.json').read_text())
+    g = np.load(case / 'grid.npz')
+    grid_arr = g['grid']
+    cell_size = float(g['cell_size'])
+    map_w = float(g['map_width'])
+    map_h = float(g['map_height'])
+
+    # Reconstruct an OccupancyGrid object with the loaded grid array.
+    occ = OccupancyGrid(map_w, map_h, cell_size)
+    occ.grid = grid_arr.astype(np.int8)
+    occ.grid_height, occ.grid_width = grid_arr.shape
+
+    # Wind field — same shape and interface as GADEN.
+    w = np.load(case / 'wind_field.npz')
+    field = w['field'].astype(np.float64)
+    wind = GadenWindField(field=field, resolution=cell_size,
+                          occupancy=(grid_arr != 0))
+
+    map_data = {
+        'grid': occ,
+        'source_pos': tuple(meta['source_pos']),
+        'robot_pos': tuple(meta['robot_pos']),
+        'width': map_w,
+        'height': map_h,
+    }
+    return {'map_data': map_data, 'wind_field': wind, 'case_dir': case, 'meta': meta}
+
+
+class CFDLibrarySampler:
+    """Yield a random complete case at each call to sample().
+
+    Filters out cases that are missing wind_field.npz or are flagged
+    degenerate at construction time so training never sees junk wind.
+    """
+
+    def __init__(self, library_dir: str | Path, rng: np.random.Generator,
+                 rl_package_path: str,
+                 reject_degenerate: bool = True,
+                 min_speed: float = 0.05,
+                 min_speed_std: float = 0.02,
+                 min_circ_std: float = 0.3):
+        """Scan the library and cache the valid case dirs.
+
+        Filters mirror cfd_wind_pipeline.library_stats.is_degenerate:
+        - mean |U| >= min_speed
+        - std |U| >= min_speed_std
+        - circular std >= min_circ_std (rules out single-direction stagnation)
+        """
+        self._rng = rng
+        self._rl_pkg = rl_package_path
+        lib = Path(library_dir)
+        manifest_path = lib / 'manifest.json'
+        if not manifest_path.exists():
+            raise FileNotFoundError(f"No manifest.json at {lib}")
+        manifest = json.loads(manifest_path.read_text())
+
+        self._cases = []
+        n_skipped = 0
+        for entry in manifest:
+            # Manifests store absolute paths (legacy) — but a library can be
+            # moved/renamed. Always resolve relative to manifest location.
+            cd = lib / Path(entry['case_dir']).name
+            wf_path = cd / 'wind_field.npz'
+            if not wf_path.exists():
+                n_skipped += 1
+                continue
+            if reject_degenerate:
+                d = np.load(wf_path)
+                g = np.load(cd / 'grid.npz')['grid']
+                field = d['field']
+                speeds = np.linalg.norm(field, axis=-1)
+                free = (g == 0)
+                s = speeds[free]
+                if s.size == 0 or s.mean() < min_speed or s.std() < min_speed_std:
+                    n_skipped += 1
+                    continue
+                dirs = np.arctan2(field[..., 1], field[..., 0])[free]
+                R = np.sqrt(np.mean(np.sin(dirs))**2 + np.mean(np.cos(dirs))**2)
+                circ = np.sqrt(-2*np.log(R)) if R > 1e-8 else float('inf')
+                if circ < min_circ_std:
+                    n_skipped += 1
+                    continue
+            self._cases.append(cd)
+        print(f"[CFDLibrarySampler] {library_dir}: kept {len(self._cases)} cases "
+              f"({n_skipped} skipped — incomplete or degenerate)")
+        if not self._cases:
+            raise RuntimeError(f"No valid cases in {library_dir}")
+
+    def __len__(self) -> int:
+        return len(self._cases)
+
+    def sample(self) -> dict:
+        """Return {map_data, wind_field} suitable for env.reset(options=...)."""
+        cd = self._cases[self._rng.integers(0, len(self._cases))]
+        case = load_cfd_case(cd, self._rl_pkg)
+        # Drop helper fields so it's pure reset-options
+        return {'map_data': case['map_data'], 'wind_field': case['wind_field']}

--- a/cfd_wind_pipeline/cfd_library_loader.py
+++ b/cfd_wind_pipeline/cfd_library_loader.py
@@ -93,58 +93,79 @@ class CFDLibrarySampler:
     degenerate at construction time so training never sees junk wind.
     """
 
-    def __init__(self, library_dir: str | Path, rng: np.random.Generator,
+    def __init__(self, library_dirs, rng: np.random.Generator,
                  rl_package_path: str,
                  reject_degenerate: bool = True,
                  min_speed: float = 0.05,
                  min_speed_std: float = 0.02,
-                 min_circ_std: float = 0.3):
-        """Scan the library and cache the valid case dirs.
+                 min_circ_std: float = 0.3,
+                 template_filter=None):
+        """Scan one or more libraries and cache the valid case dirs.
 
-        Filters mirror cfd_wind_pipeline.library_stats.is_degenerate:
-        - mean |U| >= min_speed
-        - std |U| >= min_speed_std
-        - circular std >= min_circ_std (rules out single-direction stagnation)
+        library_dirs : str | Path | list
+            A single library dir, or a list to pool multiple libraries
+            (e.g. easy T0-3 + hard T4-9) into one sampling distribution.
+        template_filter : iterable of int, optional
+            If given, keep only cases whose template_id is in this set.
+            Use to restrict to the champ's known templates (0-5) and avoid
+            OOD template shock during finetuning.
+
+        Degenerate filters mirror library_stats.is_degenerate:
+        mean |U| >= min_speed, std |U| >= min_speed_std,
+        circular std >= min_circ_std (rules out single-direction stagnation).
         """
         self._rng = rng
         self._rl_pkg = rl_package_path
-        lib = Path(library_dir)
-        manifest_path = lib / 'manifest.json'
-        if not manifest_path.exists():
-            raise FileNotFoundError(f"No manifest.json at {lib}")
-        manifest = json.loads(manifest_path.read_text())
+        if isinstance(library_dirs, (str, Path)):
+            library_dirs = [library_dirs]
+        tmpl_set = set(template_filter) if template_filter is not None else None
 
         self._cases = []
         n_skipped = 0
-        for entry in manifest:
-            # Manifests store absolute paths (legacy) — but a library can be
-            # moved/renamed. Always resolve relative to manifest location.
-            cd = lib / Path(entry['case_dir']).name
-            wf_path = cd / 'wind_field.npz'
-            if not wf_path.exists():
-                n_skipped += 1
-                continue
-            if reject_degenerate:
-                d = np.load(wf_path)
-                g = np.load(cd / 'grid.npz')['grid']
-                field = d['field']
-                speeds = np.linalg.norm(field, axis=-1)
-                free = (g == 0)
-                s = speeds[free]
-                if s.size == 0 or s.mean() < min_speed or s.std() < min_speed_std:
+        n_tmpl_filtered = 0
+        for library_dir in library_dirs:
+            lib = Path(library_dir)
+            manifest_path = lib / 'manifest.json'
+            if not manifest_path.exists():
+                raise FileNotFoundError(f"No manifest.json at {lib}")
+            manifest = json.loads(manifest_path.read_text())
+            kept_here = 0
+            for entry in manifest:
+                if tmpl_set is not None and entry.get('template_id') not in tmpl_set:
+                    n_tmpl_filtered += 1
+                    continue
+                # Resolve relative to manifest location (libraries may be moved).
+                cd = lib / Path(entry['case_dir']).name
+                wf_path = cd / 'wind_field.npz'
+                if not wf_path.exists():
                     n_skipped += 1
                     continue
-                dirs = np.arctan2(field[..., 1], field[..., 0])[free]
-                R = np.sqrt(np.mean(np.sin(dirs))**2 + np.mean(np.cos(dirs))**2)
-                circ = np.sqrt(-2*np.log(R)) if R > 1e-8 else float('inf')
-                if circ < min_circ_std:
-                    n_skipped += 1
-                    continue
-            self._cases.append(cd)
-        print(f"[CFDLibrarySampler] {library_dir}: kept {len(self._cases)} cases "
-              f"({n_skipped} skipped — incomplete or degenerate)")
+                if reject_degenerate:
+                    d = np.load(wf_path)
+                    g = np.load(cd / 'grid.npz')['grid']
+                    field = d['field']
+                    speeds = np.linalg.norm(field, axis=-1)
+                    free = (g == 0)
+                    s = speeds[free]
+                    if s.size == 0 or s.mean() < min_speed or s.std() < min_speed_std:
+                        n_skipped += 1
+                        continue
+                    dirs = np.arctan2(field[..., 1], field[..., 0])[free]
+                    R = np.sqrt(np.mean(np.sin(dirs))**2 + np.mean(np.cos(dirs))**2)
+                    circ = np.sqrt(-2*np.log(R)) if R > 1e-8 else float('inf')
+                    if circ < min_circ_std:
+                        n_skipped += 1
+                        continue
+                self._cases.append(cd)
+                kept_here += 1
+            print(f"[CFDLibrarySampler] {library_dir}: kept {kept_here} cases")
+        msg = (f"[CFDLibrarySampler] TOTAL kept {len(self._cases)} "
+               f"({n_skipped} incomplete/degenerate")
+        if tmpl_set is not None:
+            msg += f", {n_tmpl_filtered} template-filtered (keep {sorted(tmpl_set)})"
+        print(msg + ")")
         if not self._cases:
-            raise RuntimeError(f"No valid cases in {library_dir}")
+            raise RuntimeError(f"No valid cases in {library_dirs}")
 
     def __len__(self) -> int:
         return len(self._cases)

--- a/cfd_wind_pipeline/config.py
+++ b/cfd_wind_pipeline/config.py
@@ -1,0 +1,65 @@
+"""Centralized configuration for the CFD wind pipeline.
+
+Override any of these via environment variables of the same name.
+"""
+import os
+
+# ---------------------------------------------------------------------------
+# Paths — environment-specific. Override via env var if needed.
+# ---------------------------------------------------------------------------
+
+# Path to a Python package providing `reinforcement_learning.envs.map_generator`
+# (used to generate procedural maps) and `.test.gaden_loader` (used to load
+# GADEN maps + wind fields for reference visualizations and validation).
+RL_PACKAGE_PATH = os.environ.get(
+    'CFD_RL_PACKAGE_PATH',
+    '/comp04-storage/efe-mantaroglu/osl/friend_base_loop_spatial',
+)
+
+# Path to the Pyxis-importable OpenFOAM squashfs container.
+# Build with:  enroot import 'docker://opencfd/openfoam-default:latest'
+OPENFOAM_SQSH = os.environ.get(
+    'CFD_OPENFOAM_SQSH',
+    '/comp04-storage/efe-mantaroglu/osl/opencfd+openfoam-default+latest.sqsh',
+)
+
+# Path to the GADEN maps directory (with recommended_configs.yaml at the root).
+GADEN_MAPS_ROOT = os.environ.get(
+    'CFD_GADEN_MAPS_ROOT',
+    '/comp04-storage/efe-mantaroglu/osl/friend_base_loop_spatial/gaden_maps',
+)
+
+# Working directory for case dirs / wind library / artifacts.
+# This is DATA, not code — should NOT be inside the git repo.
+DATA_ROOT = os.environ.get(
+    'CFD_DATA_ROOT',
+    '/comp04-storage/efe-mantaroglu/osl/cfd_test',
+)
+
+# Python interpreter to use inside sbatch jobs.
+PYTHON_BIN = os.environ.get(
+    'CFD_PYTHON_BIN',
+    '/home/efe-mantaroglu/simenv/bin/python',
+)
+
+# ---------------------------------------------------------------------------
+# Defaults for the pipeline
+# ---------------------------------------------------------------------------
+
+# Wall + bg-mesh defaults
+WALL_HEIGHT_M = 3.0
+WALL_THICK_M = 0.6        # also the wall_thick_cells * cell_size
+BG_PAD_M = 0.5            # padding between map edge and bg-mesh boundary
+BG_CELLS_PER_M = 4.0
+
+# Inlet defaults
+DEFAULT_INLET_SPEED = 0.5   # m/s
+
+# simpleFoam controls
+SIMPLE_END_TIME = 200       # iterations to run (steady-state)
+
+# Placement sampler defaults
+PLACE_N_INLETS_PROBS = {1: 0.2, 2: 0.6, 3: 0.2}
+PLACE_N_OUTLETS_PROBS = {1: 0.2, 2: 0.6, 3: 0.2}
+PLACE_INLET_SIDE_PROBS = {'west': 0.7, 'south': 0.3}
+PLACE_OPENING_WIDTH_RANGE = (1.0, 2.5)   # m

--- a/cfd_wind_pipeline/extract_wind.py
+++ b/cfd_wind_pipeline/extract_wind.py
@@ -1,0 +1,175 @@
+"""Extract wind field from an OpenFOAM case as a (H, W, 2) numpy grid.
+
+Strategy:
+1. Add a `sample` function object to the case that writes a horizontal slice
+   at z=wall_height/2 as a raw (x y z Ux Uy Uz) text file.
+2. Run `postProcess -func sample -latestTime` in the container to produce it.
+3. Read the raw file, interpolate onto our (H, W) grid using nearest-cell or
+   bilinear via scipy.
+4. Save the wind field as wind_field.npz alongside the case.
+
+Run AFTER the case has been solved (simpleFoam done).
+"""
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+from scipy.interpolate import griddata
+
+
+SAMPLE_DICT = """/*--------------------------------*- C++ -*----------------------------------*\\
+| OpenFOAM auto-generated wind-slice sampler                                  |
+\\*---------------------------------------------------------------------------*/
+type            surfaces;
+libs            (sampling);
+writeControl    onEnd;
+surfaceFormat   raw;
+fields          (U);
+interpolationScheme cellPoint;
+
+surfaces
+(
+    midSlice
+    {{
+        type cuttingPlane;
+        planeType pointAndNormal;
+        pointAndNormalDict
+        {{
+            point  (0 0 {z_slice});
+            normal (0 0 1);
+        }}
+        interpolate true;
+    }}
+);
+"""
+
+
+def add_sample_dict(case_dir: Path, z_slice: float):
+    (case_dir / 'system' / 'sample').write_text(
+        SAMPLE_DICT.format(z_slice=z_slice)
+    )
+
+
+def parse_raw_surface_file(path: Path):
+    """Parse OpenFOAM raw surface output.
+    Format: header comment lines + 'x y z Ux Uy Uz' per row.
+    Returns: (xy, uxy) arrays."""
+    data = np.loadtxt(path, comments='#')
+    if data.ndim == 1:
+        data = data.reshape(1, -1)
+    xy = data[:, :2]  # x, y (z is constant on the slice)
+    uxy = data[:, 3:5]  # Ux, Uy (ignore Uz)
+    return xy, uxy
+
+
+def grid_interpolate(xy, uxy, map_width, map_height, cell_size,
+                     occupancy_grid):
+    """Interpolate (x,y)→(Ux,Uy) onto a regular grid matching our cells."""
+    H, W = occupancy_grid.shape
+    # Grid cell centers
+    cx = (np.arange(W) + 0.5) * cell_size  # x coordinates of cell centers
+    cy = (np.arange(H) + 0.5) * cell_size  # y coordinates
+    gx, gy = np.meshgrid(cx, cy, indexing='xy')  # (H, W)
+    pts = np.stack([gx.ravel(), gy.ravel()], axis=1)
+
+    # Use nearest-neighbor for robustness near walls; linear for smooth interior
+    Ux = griddata(xy, uxy[:, 0], pts, method='linear', fill_value=0.0)
+    Uy = griddata(xy, uxy[:, 1], pts, method='linear', fill_value=0.0)
+    # Backfill NaN regions (outside convex hull) with nearest
+    Ux_nn = griddata(xy, uxy[:, 0], pts, method='nearest')
+    Uy_nn = griddata(xy, uxy[:, 1], pts, method='nearest')
+    Ux = np.where(np.isfinite(Ux), Ux, Ux_nn)
+    Uy = np.where(np.isfinite(Uy), Uy, Uy_nn)
+
+    field = np.stack([Ux.reshape(H, W), Uy.reshape(H, W)], axis=-1)
+    # Zero out wind in wall cells
+    field[occupancy_grid != 0] = 0.0
+    return field
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--case-dir', required=True)
+    p.add_argument('--write-dict-only', action='store_true',
+                   help='Just write the sample dict; do not parse')
+    p.add_argument('--parse-only', action='store_true',
+                   help='Skip dict writing; only parse existing sample output')
+    args = p.parse_args()
+
+    case = Path(args.case_dir)
+    meta = json.loads((case / 'meta.json').read_text())
+    z_slice = meta['wall_height_m'] / 2
+
+    if not args.parse_only:
+        add_sample_dict(case, z_slice)
+        print(f"Wrote system/sample with z_slice={z_slice}")
+
+    if args.write_dict_only:
+        return
+
+    # Find the raw surface file
+    pp_dir = case / 'postProcessing' / 'sample'
+    if not pp_dir.exists():
+        raise FileNotFoundError(
+            f"{pp_dir} not found. Run `postProcess -func sample -latestTime` "
+            "in the container first."
+        )
+    # Latest time subdir
+    times = sorted([p for p in pp_dir.iterdir() if p.is_dir()],
+                   key=lambda p: float(p.name))
+    if not times:
+        raise FileNotFoundError(f"No time directories in {pp_dir}")
+    last_time = times[-1]
+    raw_files = list(last_time.glob('U_midSlice.raw')) + \
+                list(last_time.glob('midSlice*.raw')) + \
+                list(last_time.glob('*.raw'))
+    if not raw_files:
+        raise FileNotFoundError(f"No .raw files in {last_time}")
+    raw_path = raw_files[0]
+    print(f"Reading {raw_path}")
+
+    xy, uxy = parse_raw_surface_file(raw_path)
+    print(f"  {len(xy)} sample points, Ux range [{uxy[:,0].min():.3f}, {uxy[:,0].max():.3f}], "
+          f"Uy range [{uxy[:,1].min():.3f}, {uxy[:,1].max():.3f}]")
+
+    # Load original grid for binning + wall masking
+    grid_npz = np.load(case / 'grid.npz')
+    occ_grid = grid_npz['grid']
+    cell_size = float(grid_npz['cell_size'])
+    map_w = float(grid_npz['map_width'])
+    map_h = float(grid_npz['map_height'])
+
+    field = grid_interpolate(xy, uxy, map_w, map_h, cell_size, occ_grid)
+    H, W = field.shape[:2]
+    print(f"Wind field: shape {field.shape}, "
+          f"|U| range [{np.linalg.norm(field, axis=-1).min():.3f}, "
+          f"{np.linalg.norm(field, axis=-1).max():.3f}], "
+          f"mean |U| = {np.linalg.norm(field, axis=-1).mean():.3f}")
+    # Free-cell stats
+    free_mask = (occ_grid == 0)
+    speeds = np.linalg.norm(field, axis=-1)
+    free_speeds = speeds[free_mask]
+    print(f"Free cells: n={free_mask.sum()}, "
+          f"mean |U| = {free_speeds.mean():.3f}, "
+          f"std |U| = {free_speeds.std():.3f} (spatial variance — was 0 in uniform training!)")
+    # Direction stats
+    dirs = np.arctan2(field[..., 1], field[..., 0])
+    free_dirs = dirs[free_mask]
+    # Circular std
+    sin_mean = np.mean(np.sin(free_dirs))
+    cos_mean = np.mean(np.cos(free_dirs))
+    R = np.sqrt(sin_mean**2 + cos_mean**2)
+    circ_std = np.sqrt(-2 * np.log(R)) if R > 0 else float('inf')
+    print(f"Free-cell direction: circular_std = {circ_std:.3f} rad "
+          f"(GADEN range was 1.02-2.00)")
+
+    out_path = case / 'wind_field.npz'
+    np.savez_compressed(out_path, field=field.astype(np.float32),
+                        cell_size=cell_size,
+                        map_width=map_w, map_height=map_h)
+    print(f"Saved {out_path}")
+
+
+if __name__ == '__main__':
+    main()

--- a/cfd_wind_pipeline/gen_case.py
+++ b/cfd_wind_pipeline/gen_case.py
@@ -570,17 +570,20 @@ boundaryField
 
 def find_in_mesh_point(grid_arr, cell_size, z):
     """Find a free-cell location to act as locationInMesh (the seed point
-    snappyHexMesh uses to identify the fluid region)."""
-    H, W = grid_arr.shape
-    # Try center first, then sweep
-    centers = [(H // 2, W // 2)]
-    for r in range(H):
-        for c in range(W):
-            centers.append((r, c))
-    for r, c in centers:
-        if grid_arr[r, c] == 0:
-            return ((c + 0.5) * cell_size, (r + 0.5) * cell_size, z)
-    raise RuntimeError("No free cell found for locationInMesh")
+    snappyHexMesh uses to identify the fluid region).
+
+    Picks the free cell whose Euclidean distance to the nearest wall is
+    maximized — i.e. the deepest interior point in the largest open chamber.
+    This avoids snappyHexMesh failures where a picked cell, after mesh
+    snapping, ends up inside a wall.
+    """
+    from scipy.ndimage import distance_transform_edt
+    free = (grid_arr == 0)
+    if not free.any():
+        raise RuntimeError("No free cell found for locationInMesh")
+    edt = distance_transform_edt(free)
+    r, c = np.unravel_index(np.argmax(edt), edt.shape)
+    return ((c + 0.5) * cell_size, (r + 0.5) * cell_size, z)
 
 
 def main():

--- a/cfd_wind_pipeline/gen_case.py
+++ b/cfd_wind_pipeline/gen_case.py
@@ -568,21 +568,33 @@ boundaryField
 # Main
 # ---------------------------------------------------------------------------
 
-def find_in_mesh_point(grid_arr, cell_size, z):
+def find_in_mesh_point(grid_arr, cell_size, z, bg_cells_per_meter=4.0):
     """Find a free-cell location to act as locationInMesh (the seed point
     snappyHexMesh uses to identify the fluid region).
 
     Picks the free cell whose Euclidean distance to the nearest wall is
     maximized — i.e. the deepest interior point in the largest open chamber.
-    This avoids snappyHexMesh failures where a picked cell, after mesh
-    snapping, ends up inside a wall.
+    Filters to points with enough clearance to survive mesh snapping at the
+    given bg-mesh resolution (snappyHexMesh effectively thickens walls by
+    up to one bg-cell).
     """
     from scipy.ndimage import distance_transform_edt
     free = (grid_arr == 0)
     if not free.any():
         raise RuntimeError("No free cell found for locationInMesh")
-    edt = distance_transform_edt(free)
-    r, c = np.unravel_index(np.argmax(edt), edt.shape)
+    edt = distance_transform_edt(free) * cell_size  # in meters
+    # Require clearance >= bg_cell_size + safety margin. At bg=2 (0.5m cells)
+    # this needs ~0.7m clearance; at bg=4 (0.25m cells) it needs ~0.45m.
+    bg_cell = 1.0 / bg_cells_per_meter
+    min_clearance = bg_cell + 0.2
+    candidates = (edt >= min_clearance)
+    if candidates.any():
+        # Among well-cleared cells, pick the one with maximum EDT
+        masked = np.where(candidates, edt, -1.0)
+        r, c = np.unravel_index(np.argmax(masked), masked.shape)
+    else:
+        # No cell has the desired clearance — fall back to global max
+        r, c = np.unravel_index(np.argmax(edt), edt.shape)
     return ((c + 0.5) * cell_size, (r + 0.5) * cell_size, z)
 
 
@@ -693,7 +705,8 @@ def main():
                           nx, ny, nz)
 
     # 4. snappyHexMeshDict
-    in_mesh_pt = find_in_mesh_point(grid_arr, cell_size, args.height / 2)
+    in_mesh_pt = find_in_mesh_point(grid_arr, cell_size, args.height / 2,
+                                    bg_cells_per_meter=args.bg_cells_per_meter)
     print(f"locationInMesh = {in_mesh_pt}")
     write_snappy_dict(out_dir / 'system' / 'snappyHexMeshDict', in_mesh_pt)
 

--- a/cfd_wind_pipeline/gen_case.py
+++ b/cfd_wind_pipeline/gen_case.py
@@ -1,0 +1,744 @@
+"""Generate OpenFOAM case for a procedural map.
+
+Pipeline:
+1. Generate one procedural map using MapGenerator (or a small hand-crafted one)
+2. Write the walls as STL (cubes for each wall cell) into constant/triSurface/walls.stl
+3. Generate all required OpenFOAM dict files (blockMeshDict, snappyHexMeshDict,
+   controlDict, etc.) into system/
+4. Generate 0.orig/{U,p,k,epsilon,nut} with inlet on x=0 face, outlet on x=W face
+5. Save metadata (grid, dims, inlet/outlet face names) for the extractor later
+
+Output: a complete OpenFOAM case directory at OUT_DIR ready for
+  blockMesh + snappyHexMesh + simpleFoam.
+"""
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import numpy as np
+
+# Local import (this file is meant to be run from the cfd_wind_pipeline/ dir,
+# or with PYTHONPATH including it)
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from config import RL_PACKAGE_PATH
+sys.path.insert(0, RL_PACKAGE_PATH)
+from reinforcement_learning.envs.map_generator import MapGenerator
+
+
+# ---------------------------------------------------------------------------
+# STL writing (ASCII format)
+# ---------------------------------------------------------------------------
+
+def _box_facets(x0, y0, z0, x1, y1, z1):
+    """Return 12 triangle facets (each = (normal, [v1,v2,v3])) for an axis-aligned box."""
+    # vertices
+    v = [
+        (x0, y0, z0), (x1, y0, z0), (x1, y1, z0), (x0, y1, z0),
+        (x0, y0, z1), (x1, y0, z1), (x1, y1, z1), (x0, y1, z1),
+    ]
+    # faces: 6 quads × 2 triangles each, each with outward normal
+    quads = [
+        ((0, 0, -1), [0, 3, 2, 1]),  # -z (bottom)
+        ((0, 0,  1), [4, 5, 6, 7]),  # +z (top)
+        ((-1, 0, 0), [0, 4, 7, 3]),  # -x
+        ((1,  0, 0), [1, 2, 6, 5]),  # +x
+        ((0, -1, 0), [0, 1, 5, 4]),  # -y
+        ((0,  1, 0), [2, 3, 7, 6]),  # +y
+    ]
+    facets = []
+    for normal, q in quads:
+        # split quad into two triangles (q[0], q[1], q[2]) and (q[0], q[2], q[3])
+        facets.append((normal, (v[q[0]], v[q[1]], v[q[2]])))
+        facets.append((normal, (v[q[0]], v[q[2]], v[q[3]])))
+    return facets
+
+
+def write_stl(facets, path, name='walls'):
+    """Write ASCII STL file."""
+    with open(path, 'w') as f:
+        f.write(f"solid {name}\n")
+        for normal, (v1, v2, v3) in facets:
+            f.write(f"  facet normal {normal[0]:.6e} {normal[1]:.6e} {normal[2]:.6e}\n")
+            f.write("    outer loop\n")
+            for v in (v1, v2, v3):
+                f.write(f"      vertex {v[0]:.6e} {v[1]:.6e} {v[2]:.6e}\n")
+            f.write("    endloop\n")
+            f.write("  endfacet\n")
+        f.write(f"endsolid {name}\n")
+
+
+# ---------------------------------------------------------------------------
+# Procedural map → STL conversion
+# ---------------------------------------------------------------------------
+
+def map_to_walls_stl(grid_arr, cell_size, height, out_path,
+                     bg_pad=0.0, openings=None):
+    """For each wall cell in the 2D grid, emit a cube STL.
+
+    grid_arr: (H, W) int, nonzero = wall
+    cell_size: m per cell
+    height: vertical extrusion in m
+    bg_pad: if > 0, also add wall panels that extend outer walls to x=-bg_pad / y=-bg_pad
+            for each side, EXCEPT at y/x positions inside an opening.
+    openings: dict with keys 'west', 'east', 'south', 'north', each a list of
+              (lo, hi) tuples — y-ranges for west/east, x-ranges for south/north.
+              If a y/x falls in any range for that side, no blocking wall is added there.
+
+    Returns the total facet count.
+    """
+    facets = []
+    H, W = grid_arr.shape
+    map_w = W * cell_size
+    map_h = H * cell_size
+
+    # 1. Wall cells from grid
+    for r in range(H):
+        for c in range(W):
+            if grid_arr[r, c] != 0:
+                x0 = c * cell_size
+                y0 = r * cell_size
+                facets.extend(_box_facets(x0, y0, 0.0,
+                                           x0 + cell_size, y0 + cell_size, height))
+
+    # 2. Boundary-blocking wall panels (extend outer walls to bg-mesh boundary)
+    if bg_pad > 0:
+        openings = openings or {}
+        def in_opening(side, coord):
+            return any(lo <= coord <= hi for lo, hi in openings.get(side, []))
+        # West (x=-bg_pad to x=0), iterate over y-cells
+        for r in range(H):
+            y_c = (r + 0.5) * cell_size
+            if not in_opening('west', y_c):
+                facets.extend(_box_facets(-bg_pad, r*cell_size, 0,
+                                           0, (r+1)*cell_size, height))
+        # East
+        for r in range(H):
+            y_c = (r + 0.5) * cell_size
+            if not in_opening('east', y_c):
+                facets.extend(_box_facets(map_w, r*cell_size, 0,
+                                           map_w + bg_pad, (r+1)*cell_size, height))
+        # South (y=-bg_pad to y=0)
+        for c in range(W):
+            x_c = (c + 0.5) * cell_size
+            if not in_opening('south', x_c):
+                facets.extend(_box_facets(c*cell_size, -bg_pad, 0,
+                                           (c+1)*cell_size, 0, height))
+        # North
+        for c in range(W):
+            x_c = (c + 0.5) * cell_size
+            if not in_opening('north', x_c):
+                facets.extend(_box_facets(c*cell_size, map_h, 0,
+                                           (c+1)*cell_size, map_h + bg_pad, height))
+
+    write_stl(facets, out_path, name='walls')
+    return len(facets)
+
+
+def parse_opening_list(s):
+    """Parse '0.5-1.5,3.0-4.0' into [(0.5,1.5), (3.0,4.0)]."""
+    if not s:
+        return []
+    result = []
+    for chunk in s.split(','):
+        lo, hi = chunk.split('-')
+        result.append((float(lo), float(hi)))
+    return result
+
+
+def punch_openings(grid_arr, cell_size, wall_thick_cells, openings):
+    """Clear cells in the outer wall band corresponding to the openings."""
+    H, W = grid_arr.shape
+    for y_lo, y_hi in openings.get('west', []):
+        r_lo, r_hi = int(y_lo / cell_size), int(np.ceil(y_hi / cell_size))
+        grid_arr[r_lo:r_hi, :wall_thick_cells] = 0
+    for y_lo, y_hi in openings.get('east', []):
+        r_lo, r_hi = int(y_lo / cell_size), int(np.ceil(y_hi / cell_size))
+        grid_arr[r_lo:r_hi, -wall_thick_cells:] = 0
+    for x_lo, x_hi in openings.get('south', []):
+        c_lo, c_hi = int(x_lo / cell_size), int(np.ceil(x_hi / cell_size))
+        grid_arr[:wall_thick_cells, c_lo:c_hi] = 0
+    for x_lo, x_hi in openings.get('north', []):
+        c_lo, c_hi = int(x_lo / cell_size), int(np.ceil(x_hi / cell_size))
+        grid_arr[-wall_thick_cells:, c_lo:c_hi] = 0
+
+
+# ---------------------------------------------------------------------------
+# OpenFOAM dict writers — minimal viable for snappyHexMesh + simpleFoam k-epsilon
+# ---------------------------------------------------------------------------
+
+_HEADER = """/*--------------------------------*- C++ -*----------------------------------*\\
+| OpenFOAM auto-generated for procedural-map CFD                              |
+\\*---------------------------------------------------------------------------*/
+FoamFile
+{{
+    version     2.0;
+    format      ascii;
+    class       {cls};
+    object      {obj};
+}}
+// * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * //
+"""
+
+
+def write_block_mesh_dict(path, x_min, x_max, y_min, y_max, z_min, z_max,
+                          nx, ny, nz):
+    """Background mesh as a single hex block with named patches."""
+    txt = _HEADER.format(cls='dictionary', obj='blockMeshDict')
+    txt += f"""
+scale 1;
+
+vertices
+(
+    ({x_min} {y_min} {z_min})
+    ({x_max} {y_min} {z_min})
+    ({x_max} {y_max} {z_min})
+    ({x_min} {y_max} {z_min})
+    ({x_min} {y_min} {z_max})
+    ({x_max} {y_min} {z_max})
+    ({x_max} {y_max} {z_max})
+    ({x_min} {y_max} {z_max})
+);
+
+blocks
+(
+    hex (0 1 2 3 4 5 6 7) ({nx} {ny} {nz}) simpleGrading (1 1 1)
+);
+
+edges
+(
+);
+
+boundary
+(
+    inlet
+    {{
+        type patch;
+        faces ((0 4 7 3));
+    }}
+    outlet
+    {{
+        type patch;
+        faces ((1 2 6 5));
+    }}
+    sides
+    {{
+        type wall;
+        faces ((0 1 5 4) (3 7 6 2));
+    }}
+    floor
+    {{
+        type wall;
+        faces ((0 3 2 1));
+    }}
+    ceiling
+    {{
+        type wall;
+        faces ((4 5 6 7));
+    }}
+);
+
+mergePatchPairs
+(
+);
+"""
+    Path(path).write_text(txt)
+
+
+def write_snappy_dict(path, in_mesh_point, refinement_level=2):
+    txt = _HEADER.format(cls='dictionary', obj='snappyHexMeshDict')
+    px, py, pz = in_mesh_point
+    txt += f"""
+castellatedMesh true;
+snap            true;
+addLayers       false;
+
+geometry
+{{
+    walls
+    {{
+        type triSurfaceMesh;
+        file "walls.stl";
+    }}
+}}
+
+castellatedMeshControls
+{{
+    maxLocalCells     1000000;
+    maxGlobalCells    5000000;
+    minRefinementCells 0;
+    maxLoadUnbalance  0.1;
+    nCellsBetweenLevels 1;
+
+    features
+    (
+    );
+
+    refinementSurfaces
+    {{
+        walls
+        {{
+            level ({refinement_level} {refinement_level});
+            patchInfo {{ type wall; }}
+        }}
+    }}
+
+    resolveFeatureAngle 30;
+
+    refinementRegions
+    {{
+    }}
+
+    locationInMesh ({px} {py} {pz});
+    allowFreeStandingZoneFaces true;
+}}
+
+snapControls
+{{
+    nSmoothPatch 3;
+    tolerance    2.0;
+    nSolveIter   30;
+    nRelaxIter   5;
+}}
+
+addLayersControls
+{{
+    relativeSizes       true;
+    layers              {{}}
+    expansionRatio      1.0;
+    finalLayerThickness 0.3;
+    minThickness        0.1;
+    nGrow               0;
+    featureAngle        60;
+    nRelaxIter          3;
+    nSmoothSurfaceNormals 1;
+    nSmoothNormals      3;
+    nSmoothThickness    10;
+    maxFaceThicknessRatio 0.5;
+    maxThicknessToMedialRatio 0.3;
+    minMedianAxisAngle  90;
+    nBufferCellsNoExtrude 0;
+    nLayerIter          50;
+}}
+
+meshQualityControls
+{{
+    maxNonOrtho         65;
+    maxBoundarySkewness 20;
+    maxInternalSkewness 4;
+    maxConcave          80;
+    minVol              1e-13;
+    minTetQuality       -1e30;
+    minArea             -1;
+    minTwist            0.02;
+    minDeterminant      0.001;
+    minFaceWeight       0.05;
+    minVolRatio         0.01;
+    minTriangleTwist    -1;
+    nSmoothScale        4;
+    errorReduction      0.75;
+}}
+
+mergeTolerance 1e-6;
+"""
+    Path(path).write_text(txt)
+
+
+def write_control_dict(path, end_time=200, write_interval=50, delta_t=1):
+    txt = _HEADER.format(cls='dictionary', obj='controlDict')
+    txt += f"""
+application     simpleFoam;
+startFrom       latestTime;
+startTime       0;
+stopAt          endTime;
+endTime         {end_time};
+deltaT          {delta_t};
+writeControl    timeStep;
+writeInterval   {write_interval};
+purgeWrite      0;
+writeFormat     binary;
+writePrecision  6;
+writeCompression off;
+timeFormat      general;
+timePrecision   6;
+runTimeModifiable true;
+"""
+    Path(path).write_text(txt)
+
+
+def write_fv_schemes(path):
+    txt = _HEADER.format(cls='dictionary', obj='fvSchemes')
+    txt += """
+ddtSchemes      { default steadyState; }
+gradSchemes
+{
+    default        Gauss linear;
+    grad(U)        cellLimited Gauss linear 1;
+}
+divSchemes
+{
+    default                 none;
+    div(phi,U)              bounded Gauss linearUpwind grad(U);
+    div(phi,k)              bounded Gauss upwind;
+    div(phi,epsilon)        bounded Gauss upwind;
+    div(phi,omega)          bounded Gauss upwind;
+    div((nuEff*dev2(T(grad(U))))) Gauss linear;
+}
+laplacianSchemes { default Gauss linear corrected; }
+interpolationSchemes { default linear; }
+snGradSchemes   { default corrected; }
+wallDist        { method meshWave; }
+"""
+    Path(path).write_text(txt)
+
+
+def write_fv_solution(path):
+    txt = _HEADER.format(cls='dictionary', obj='fvSolution')
+    txt += """
+solvers
+{
+    p
+    {
+        solver          GAMG;
+        tolerance       1e-7;
+        relTol          0.01;
+        smoother        GaussSeidel;
+    }
+    "(U|k|epsilon|omega)"
+    {
+        solver          smoothSolver;
+        smoother        symGaussSeidel;
+        tolerance       1e-7;
+        relTol          0.1;
+    }
+}
+SIMPLE
+{
+    nNonOrthogonalCorrectors 0;
+    consistent yes;
+    residualControl
+    {
+        p               1e-3;
+        U               1e-4;
+        "(k|epsilon|omega)" 1e-4;
+    }
+}
+relaxationFactors
+{
+    equations
+    {
+        U               0.9;
+        ".*"            0.7;
+    }
+}
+"""
+    Path(path).write_text(txt)
+
+
+def write_transport_props(path, nu=1.5e-5):
+    txt = _HEADER.format(cls='dictionary', obj='transportProperties')
+    txt += f"""
+transportModel  Newtonian;
+nu              {nu};
+"""
+    Path(path).write_text(txt)
+
+
+def write_turbulence_props(path):
+    txt = _HEADER.format(cls='dictionary', obj='turbulenceProperties')
+    txt += """
+simulationType  RAS;
+RAS
+{
+    RASModel        kEpsilon;
+    turbulence      on;
+    printCoeffs     on;
+}
+"""
+    Path(path).write_text(txt)
+
+
+# ---- 0.orig fields ----
+
+def _field_header(cls, obj):
+    return _HEADER.format(cls=cls, obj=obj)
+
+
+def write_U_field(path, inlet_speed):
+    """U = velocity. Inlet: fixed velocity. Outlet: zeroGradient.
+    Walls (sides, floor, ceiling, walls): no-slip (uniform 0).
+    """
+    txt = _field_header('volVectorField', 'U')
+    txt += f"""
+dimensions      [0 1 -1 0 0 0 0];
+internalField   uniform (0 0 0);
+
+boundaryField
+{{
+    inlet     {{ type fixedValue;  value uniform ({inlet_speed} 0 0); }}
+    outlet    {{ type zeroGradient; }}
+    sides     {{ type noSlip; }}
+    floor     {{ type noSlip; }}
+    ceiling   {{ type noSlip; }}
+    walls     {{ type noSlip; }}
+}}
+"""
+    Path(path).write_text(txt)
+
+
+def write_p_field(path):
+    txt = _field_header('volScalarField', 'p')
+    txt += """
+dimensions      [0 2 -2 0 0 0 0];
+internalField   uniform 0;
+
+boundaryField
+{
+    inlet     { type zeroGradient; }
+    outlet    { type fixedValue; value uniform 0; }
+    sides     { type zeroGradient; }
+    floor     { type zeroGradient; }
+    ceiling   { type zeroGradient; }
+    walls     { type zeroGradient; }
+}
+"""
+    Path(path).write_text(txt)
+
+
+def write_k_field(path, k_init=0.1):
+    txt = _field_header('volScalarField', 'k')
+    txt += f"""
+dimensions      [0 2 -2 0 0 0 0];
+internalField   uniform {k_init};
+
+boundaryField
+{{
+    inlet     {{ type fixedValue; value uniform {k_init}; }}
+    outlet    {{ type zeroGradient; }}
+    sides     {{ type kqRWallFunction; value uniform {k_init}; }}
+    floor     {{ type kqRWallFunction; value uniform {k_init}; }}
+    ceiling   {{ type kqRWallFunction; value uniform {k_init}; }}
+    walls     {{ type kqRWallFunction; value uniform {k_init}; }}
+}}
+"""
+    Path(path).write_text(txt)
+
+
+def write_epsilon_field(path, eps_init=0.01):
+    txt = _field_header('volScalarField', 'epsilon')
+    txt += f"""
+dimensions      [0 2 -3 0 0 0 0];
+internalField   uniform {eps_init};
+
+boundaryField
+{{
+    inlet     {{ type fixedValue; value uniform {eps_init}; }}
+    outlet    {{ type zeroGradient; }}
+    sides     {{ type epsilonWallFunction; value uniform {eps_init}; }}
+    floor     {{ type epsilonWallFunction; value uniform {eps_init}; }}
+    ceiling   {{ type epsilonWallFunction; value uniform {eps_init}; }}
+    walls     {{ type epsilonWallFunction; value uniform {eps_init}; }}
+}}
+"""
+    Path(path).write_text(txt)
+
+
+def write_nut_field(path):
+    txt = _field_header('volScalarField', 'nut')
+    txt += """
+dimensions      [0 2 -1 0 0 0 0];
+internalField   uniform 0;
+
+boundaryField
+{
+    inlet     { type calculated; value uniform 0; }
+    outlet    { type calculated; value uniform 0; }
+    sides     { type nutkWallFunction; value uniform 0; }
+    floor     { type nutkWallFunction; value uniform 0; }
+    ceiling   { type nutkWallFunction; value uniform 0; }
+    walls     { type nutkWallFunction; value uniform 0; }
+}
+"""
+    Path(path).write_text(txt)
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+def find_in_mesh_point(grid_arr, cell_size, z):
+    """Find a free-cell location to act as locationInMesh (the seed point
+    snappyHexMesh uses to identify the fluid region)."""
+    H, W = grid_arr.shape
+    # Try center first, then sweep
+    centers = [(H // 2, W // 2)]
+    for r in range(H):
+        for c in range(W):
+            centers.append((r, c))
+    for r, c in centers:
+        if grid_arr[r, c] == 0:
+            return ((c + 0.5) * cell_size, (r + 0.5) * cell_size, z)
+    raise RuntimeError("No free cell found for locationInMesh")
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--out-dir', required=True)
+    p.add_argument('--template-id', type=int, default=2,
+                   help='Map template ID (0=empty, 1=single_wall, 2=u_shape, '
+                        '3=three_walls, 4=complex_maze, 5=multi_room)')
+    p.add_argument('--seed', type=int, default=42)
+    p.add_argument('--height', type=float, default=3.0, help='wall height [m]')
+    p.add_argument('--inlet-speed', type=float, default=1.0, help='m/s')
+    p.add_argument('--bg-cells-per-meter', type=float, default=4.0,
+                   help='background mesh resolution')
+    p.add_argument('--end-time', type=int, default=200,
+                   help='simpleFoam steady-state iterations to run')
+    p.add_argument('--strip-outer', action='store_true', default=True,
+                   help='Strip outer wall band so inlet/outlet are open')
+    p.add_argument('--no-strip-outer', dest='strip_outer', action='store_false')
+    p.add_argument('--strip-margin', type=float, default=0.6,
+                   help='Margin to strip from outer walls [m]')
+    p.add_argument('--strip-all-sides', action='store_true', default=True,
+                   help='Strip N/S sides too (in addition to inlet/outlet E/W)')
+    p.add_argument('--opening-width', type=float, default=None,
+                   help='GADEN-style single-opening (centered) — punches one opening this wide on E+W')
+    p.add_argument('--openings-west', type=str, default='',
+                   help='Explicit list of y-ranges on west wall, e.g. "1.4-2.9,6.1-7.6"')
+    p.add_argument('--openings-east', type=str, default='')
+    p.add_argument('--openings-south', type=str, default='')
+    p.add_argument('--openings-north', type=str, default='')
+    args = p.parse_args()
+
+    out_dir = Path(args.out_dir)
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    (out_dir / 'system').mkdir(parents=True)
+    (out_dir / 'constant' / 'triSurface').mkdir(parents=True)
+    (out_dir / '0.orig').mkdir()
+
+    # 1. Generate map
+    rng = np.random.default_rng(args.seed)
+    gen = MapGenerator(rng=rng)
+    map_data = gen.generate(template_id=args.template_id)
+    grid_obj = map_data['grid']
+    # Grid resolution per map_generator: cells are 0.1m by default
+    grid_arr = grid_obj.grid                # (H, W) — 0=free, nonzero=wall
+    cell_size = grid_obj.resolution
+    map_width = map_data['width']
+    map_height = map_data['height']
+    print(f"Map: template={args.template_id}, size={map_width:.2f}×{map_height:.2f} m, "
+          f"grid={grid_arr.shape}, cell={cell_size:.3f} m, walls={(grid_arr != 0).sum()}")
+
+    # 2. Boundary opening mode
+    H, W = grid_arr.shape
+    openings = {
+        'west':  parse_opening_list(args.openings_west),
+        'east':  parse_opening_list(args.openings_east),
+        'south': parse_opening_list(args.openings_south),
+        'north': parse_opening_list(args.openings_north),
+    }
+    if any(openings.values()):
+        wall_thick = max(1, int(round(args.strip_margin / cell_size)))
+        punch_openings(grid_arr, cell_size, wall_thick, openings)
+        n_open = sum(len(v) for v in openings.values())
+        print(f"Punched {n_open} explicit openings; walls = {(grid_arr != 0).sum()}")
+    elif args.opening_width is not None:
+        ow_cells = max(1, int(round(args.opening_width / cell_size)))
+        wall_thick = max(1, int(round(args.strip_margin / cell_size)))
+        mid_y = H // 2
+        half = ow_cells // 2
+        grid_arr[max(0, mid_y - half):mid_y + half, :wall_thick] = 0
+        grid_arr[max(0, mid_y - half):mid_y + half, -wall_thick:] = 0
+        y_lo = (mid_y - half) * cell_size; y_hi = (mid_y + half) * cell_size
+        openings['west'] = [(y_lo, y_hi)]
+        openings['east'] = [(y_lo, y_hi)]
+        print(f"Punched centered {ow_cells*cell_size:.2f}m E+W openings; "
+              f"walls = {(grid_arr != 0).sum()}")
+    elif args.strip_outer:
+        margin = max(1, int(round(args.strip_margin / cell_size)))
+        grid_arr[:, :margin] = 0
+        grid_arr[:, -margin:] = 0
+        if args.strip_all_sides:
+            grid_arr[:margin, :] = 0
+            grid_arr[-margin:, :] = 0
+        print(f"Stripped outer walls (margin {margin} cells = {margin*cell_size:.2f}m); "
+              f"new wall count = {(grid_arr != 0).sum()}")
+
+    # 3. Walls → STL (with boundary-blocking panels if explicit openings supplied)
+    pad = 0.5
+    stl_path = out_dir / 'constant' / 'triSurface' / 'walls.stl'
+    if any(openings.values()):
+        n_facets = map_to_walls_stl(grid_arr, cell_size, args.height, str(stl_path),
+                                     bg_pad=pad, openings=openings)
+    else:
+        n_facets = map_to_walls_stl(grid_arr, cell_size, args.height, str(stl_path))
+    print(f"STL: {n_facets} facets → {stl_path}")
+
+    # 3. blockMeshDict (background bounding box, slightly larger than map)
+    x_min, x_max = -pad, map_width + pad
+    y_min, y_max = -pad, map_height + pad
+    z_min, z_max = 0.0, args.height
+    nx = max(8, int((x_max - x_min) * args.bg_cells_per_meter))
+    ny = max(8, int((y_max - y_min) * args.bg_cells_per_meter))
+    nz = max(4, int((z_max - z_min) * args.bg_cells_per_meter))
+    print(f"Background mesh: {nx}×{ny}×{nz} cells over {x_max-x_min:.1f}×{y_max-y_min:.1f}×{z_max-z_min:.1f} m")
+    write_block_mesh_dict(out_dir / 'system' / 'blockMeshDict',
+                          x_min, x_max, y_min, y_max, z_min, z_max,
+                          nx, ny, nz)
+
+    # 4. snappyHexMeshDict
+    in_mesh_pt = find_in_mesh_point(grid_arr, cell_size, args.height / 2)
+    print(f"locationInMesh = {in_mesh_pt}")
+    write_snappy_dict(out_dir / 'system' / 'snappyHexMeshDict', in_mesh_pt)
+
+    # 5. Other system files
+    write_control_dict(out_dir / 'system' / 'controlDict', end_time=args.end_time)
+    write_fv_schemes(out_dir / 'system' / 'fvSchemes')
+    write_fv_solution(out_dir / 'system' / 'fvSolution')
+
+    # 6. constant
+    write_transport_props(out_dir / 'constant' / 'transportProperties')
+    write_turbulence_props(out_dir / 'constant' / 'turbulenceProperties')
+
+    # 7. 0.orig fields
+    write_U_field(out_dir / '0.orig' / 'U', args.inlet_speed)
+    write_p_field(out_dir / '0.orig' / 'p')
+    write_k_field(out_dir / '0.orig' / 'k')
+    write_epsilon_field(out_dir / '0.orig' / 'epsilon')
+    write_nut_field(out_dir / '0.orig' / 'nut')
+
+    # 8. Save map metadata
+    meta = {
+        'template_id': int(args.template_id),
+        'seed': int(args.seed),
+        'map_width_m': float(map_width),
+        'map_height_m': float(map_height),
+        'cell_size_m': float(cell_size),
+        'grid_shape': list(grid_arr.shape),
+        'inlet_speed': float(args.inlet_speed),
+        'inlet_face': 'inlet (x=0 face)',
+        'outlet_face': f'outlet (x={x_max} face)',
+        'wall_height_m': float(args.height),
+        'bg_mesh_nx_ny_nz': [nx, ny, nz],
+        'locationInMesh': list(in_mesh_pt),
+        'source_pos': map_data['source_pos'],
+        'robot_pos': map_data['robot_pos'],
+    }
+    (out_dir / 'meta.json').write_text(json.dumps(meta, indent=2))
+    np.savez_compressed(out_dir / 'grid.npz',
+                        grid=grid_arr.astype(np.uint8),
+                        cell_size=cell_size,
+                        map_width=map_width,
+                        map_height=map_height)
+
+    print(f"\nCase ready at {out_dir}")
+    print("Run with:")
+    print(f"  cd {out_dir}")
+    print("  blockMesh && snappyHexMesh -overwrite && cp -r 0.orig 0 && simpleFoam")
+
+
+if __name__ == '__main__':
+    main()

--- a/cfd_wind_pipeline/gen_case_from_gaden.py
+++ b/cfd_wind_pipeline/gen_case_from_gaden.py
@@ -1,0 +1,158 @@
+"""Load a GADEN map's geometry and run OUR CFD pipeline on it.
+Then compare the resulting wind to GADEN's original wind on the same geometry.
+
+Usage:
+  python gen_case_from_gaden.py --map many_rooms --out-dir case_gaden_many_rooms
+"""
+import argparse
+import json
+import os
+import shutil
+import sys
+from pathlib import Path
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from config import RL_PACKAGE_PATH, GADEN_MAPS_ROOT
+sys.path.insert(0, RL_PACKAGE_PATH)
+from reinforcement_learning.test.gaden_loader import load_full_map
+
+from gen_case import (
+    map_to_walls_stl, parse_opening_list, punch_openings,
+    write_block_mesh_dict, write_snappy_dict, write_control_dict,
+    write_fv_schemes, write_fv_solution, write_transport_props,
+    write_turbulence_props,
+    write_U_field, write_p_field, write_k_field, write_epsilon_field,
+    write_nut_field, find_in_mesh_point,
+)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--out-dir', required=True)
+    p.add_argument('--map', required=True, help='GADEN map key e.g. many_rooms')
+    p.add_argument('--gaden-root', default=GADEN_MAPS_ROOT)
+    p.add_argument('--height', type=float, default=3.0)
+    p.add_argument('--inlet-speed', type=float, default=0.1)
+    p.add_argument('--bg-cells-per-meter', type=float, default=4.0)
+    p.add_argument('--end-time', type=int, default=200)
+    p.add_argument('--strip-margin', type=float, default=0.6,
+                   help='outer margin to clear so bg-mesh inlet/outlet have open faces')
+    p.add_argument('--opening-width', type=float, default=None,
+                   help='GADEN-style: keep outer walls, punch a single opening this wide on E+W (meters)')
+    p.add_argument('--openings-west', type=str, default='',
+                   help='List of y-ranges as "1.4-2.9,6.1-7.6"')
+    p.add_argument('--openings-east', type=str, default='')
+    p.add_argument('--openings-south', type=str, default='')
+    p.add_argument('--openings-north', type=str, default='')
+    args = p.parse_args()
+
+    out_dir = Path(args.out_dir)
+    if out_dir.exists():
+        shutil.rmtree(out_dir)
+    (out_dir / 'system').mkdir(parents=True)
+    (out_dir / 'constant' / 'triSurface').mkdir(parents=True)
+    (out_dir / '0.orig').mkdir()
+
+    # 1. Load GADEN geometry
+    gaden_root = Path(args.gaden_root)
+    yaml_path = gaden_root / 'recommended_configs.yaml'
+    fm = load_full_map(gaden_root, yaml_path, args.map)
+    grid_obj = fm['grid']
+    grid_arr = np.array(grid_obj.grid, dtype=np.int8)  # may be wall=1
+    cell_size = grid_obj.resolution
+    H, W = grid_arr.shape
+    map_w = W * cell_size
+    map_h = H * cell_size
+    print(f"GADEN map: {args.map}, shape={grid_arr.shape}, cell={cell_size}, "
+          f"map={map_w:.2f}x{map_h:.2f} m, walls={(grid_arr != 0).sum()}")
+
+    # 2. Boundary openings
+    openings = {
+        'west':  parse_opening_list(args.openings_west),
+        'east':  parse_opening_list(args.openings_east),
+        'south': parse_opening_list(args.openings_south),
+        'north': parse_opening_list(args.openings_north),
+    }
+    if any(openings.values()):
+        wall_thick = max(1, int(round(args.strip_margin / cell_size)))
+        punch_openings(grid_arr, cell_size, wall_thick, openings)
+        n_open = sum(len(v) for v in openings.values())
+        print(f"Punched {n_open} openings (W={openings['west']}, E={openings['east']}, "
+              f"S={openings['south']}, N={openings['north']}); walls = {(grid_arr != 0).sum()}")
+    elif args.opening_width is not None:
+        ow_cells = max(1, int(round(args.opening_width / cell_size)))
+        wall_thick = max(1, int(round(args.strip_margin / cell_size)))
+        mid_y = H // 2
+        half = ow_cells // 2
+        grid_arr[max(0, mid_y - half):mid_y + half, :wall_thick] = 0
+        grid_arr[max(0, mid_y - half):mid_y + half, -wall_thick:] = 0
+        # Update openings dict for boundary-blocking
+        y_lo = (mid_y - half) * cell_size; y_hi = (mid_y + half) * cell_size
+        openings['west'] = [(y_lo, y_hi)]
+        openings['east'] = [(y_lo, y_hi)]
+        print(f"Punched {ow_cells*cell_size:.2f}m middle E+W openings, walls = {(grid_arr != 0).sum()}")
+    else:
+        margin = max(1, int(round(args.strip_margin / cell_size)))
+        grid_arr[:, :margin] = 0
+        grid_arr[:, -margin:] = 0
+        grid_arr[:margin, :] = 0
+        grid_arr[-margin:, :] = 0
+        print(f"Stripped {margin}-cell outer band, walls now = {(grid_arr != 0).sum()}")
+
+    # 3. Walls → STL (with boundary-blocking panels for true GADEN-style flow)
+    pad = 0.5
+    stl_path = out_dir / 'constant' / 'triSurface' / 'walls.stl'
+    n_facets = map_to_walls_stl(grid_arr, cell_size, args.height, str(stl_path),
+                                bg_pad=pad, openings=openings)
+    print(f"STL: {n_facets} facets → {stl_path}")
+
+    # 4. Background mesh
+    x_min, x_max = -pad, map_w + pad
+    y_min, y_max = -pad, map_h + pad
+    z_min, z_max = 0.0, args.height
+    nx = max(8, int((x_max - x_min) * args.bg_cells_per_meter))
+    ny = max(8, int((y_max - y_min) * args.bg_cells_per_meter))
+    nz = max(4, int((z_max - z_min) * args.bg_cells_per_meter))
+    print(f"Background mesh: {nx}x{ny}x{nz}")
+    write_block_mesh_dict(out_dir / 'system' / 'blockMeshDict',
+                          x_min, x_max, y_min, y_max, z_min, z_max, nx, ny, nz)
+
+    in_mesh_pt = find_in_mesh_point(grid_arr, cell_size, args.height / 2)
+    print(f"locationInMesh = {in_mesh_pt}")
+    write_snappy_dict(out_dir / 'system' / 'snappyHexMeshDict', in_mesh_pt)
+    write_control_dict(out_dir / 'system' / 'controlDict', end_time=args.end_time)
+    write_fv_schemes(out_dir / 'system' / 'fvSchemes')
+    write_fv_solution(out_dir / 'system' / 'fvSolution')
+    write_transport_props(out_dir / 'constant' / 'transportProperties')
+    write_turbulence_props(out_dir / 'constant' / 'turbulenceProperties')
+    write_U_field(out_dir / '0.orig' / 'U', args.inlet_speed)
+    write_p_field(out_dir / '0.orig' / 'p')
+    write_k_field(out_dir / '0.orig' / 'k')
+    write_epsilon_field(out_dir / '0.orig' / 'epsilon')
+    write_nut_field(out_dir / '0.orig' / 'nut')
+
+    meta = {
+        'source': 'gaden',
+        'gaden_map': args.map,
+        'map_width_m': float(map_w),
+        'map_height_m': float(map_h),
+        'cell_size_m': float(cell_size),
+        'grid_shape': list(grid_arr.shape),
+        'inlet_speed': float(args.inlet_speed),
+        'wall_height_m': float(args.height),
+        'bg_mesh_nx_ny_nz': [nx, ny, nz],
+        'locationInMesh': list(in_mesh_pt),
+    }
+    (out_dir / 'meta.json').write_text(json.dumps(meta, indent=2))
+    np.savez_compressed(out_dir / 'grid.npz',
+                        grid=grid_arr.astype(np.uint8),
+                        cell_size=cell_size,
+                        map_width=map_w,
+                        map_height=map_h)
+    print(f"Case ready at {out_dir}")
+
+
+if __name__ == '__main__':
+    main()

--- a/cfd_wind_pipeline/library_stats.py
+++ b/cfd_wind_pipeline/library_stats.py
@@ -1,0 +1,93 @@
+"""Aggregate stats on a wind library: which cases succeeded, summary stats,
+flag degenerate fields (near-zero, single-direction, etc.).
+
+Usage:
+    python library_stats.py --library-dir $CFD_DATA_ROOT/library_v1
+"""
+import argparse
+import json
+from pathlib import Path
+
+import numpy as np
+
+
+def field_stats(field, free_mask):
+    speeds = np.linalg.norm(field, axis=-1)
+    free_speeds = speeds[free_mask]
+    dirs = np.arctan2(field[..., 1], field[..., 0])
+    free_dirs = dirs[free_mask]
+    sin_m = np.mean(np.sin(free_dirs))
+    cos_m = np.mean(np.cos(free_dirs))
+    R = np.sqrt(sin_m**2 + cos_m**2)
+    circ_std = float(np.sqrt(-2 * np.log(R))) if R > 1e-8 else float('inf')
+    return {
+        'mean_speed': float(free_speeds.mean()),
+        'std_speed': float(free_speeds.std()),
+        'max_speed': float(free_speeds.max()),
+        'circ_std': circ_std,
+    }
+
+
+def is_degenerate(s):
+    if s['mean_speed'] < 0.05: return 'near-zero wind'
+    if s['std_speed'] < 0.02: return 'uniform wind (no spatial variance)'
+    if s['circ_std'] < 0.3:   return 'single-direction (no recirculation)'
+    return None
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--library-dir', required=True)
+    p.add_argument('--write-summary', action='store_true',
+                   help='Write summary.json with per-case stats + reject list')
+    args = p.parse_args()
+
+    lib = Path(args.library_dir)
+    manifest = json.loads((lib / 'manifest.json').read_text())
+
+    n_total = len(manifest)
+    n_complete = 0
+    n_degenerate = 0
+    summary = []
+    for entry in manifest:
+        case = Path(entry['case_dir'])
+        wind_path = case / 'wind_field.npz'
+        if not wind_path.exists():
+            summary.append({**entry, 'status': 'incomplete'})
+            continue
+        n_complete += 1
+        d = np.load(wind_path)
+        field = d['field']
+        grid = np.load(case / 'grid.npz')['grid']
+        free = (grid == 0)
+        s = field_stats(field, free)
+        reason = is_degenerate(s)
+        if reason:
+            n_degenerate += 1
+        summary.append({**entry, 'status': 'ok' if reason is None else 'degenerate',
+                        'reject_reason': reason, **s})
+
+    print(f"Library: {lib}")
+    print(f"  total cases:    {n_total}")
+    print(f"  completed:      {n_complete}  ({100*n_complete/n_total:.0f}%)")
+    print(f"  degenerate:     {n_degenerate}  ({100*n_degenerate/max(n_complete,1):.0f}% of complete)")
+    print(f"  usable:         {n_complete - n_degenerate}")
+
+    ok = [s for s in summary if s.get('status') == 'ok']
+    if ok:
+        ms = np.array([s['mean_speed'] for s in ok])
+        ss = np.array([s['std_speed'] for s in ok])
+        cs = np.array([s['circ_std'] for s in ok])
+        print(f"  good-case stats (n={len(ok)}):")
+        print(f"    mean |U|:    {ms.mean():.3f} ± {ms.std():.3f}  [{ms.min():.3f}, {ms.max():.3f}]")
+        print(f"    speed std:   {ss.mean():.3f} ± {ss.std():.3f}  [{ss.min():.3f}, {ss.max():.3f}]")
+        print(f"    circ std:    {cs.mean():.3f} ± {cs.std():.3f}  [{cs.min():.3f}, {cs.max():.3f}]")
+        print(f"    GADEN target: speed std 0.29-0.65, circ std 1.02-2.00")
+
+    if args.write_summary:
+        (lib / 'summary.json').write_text(json.dumps(summary, indent=2))
+        print(f"Wrote {lib / 'summary.json'}")
+
+
+if __name__ == '__main__':
+    main()

--- a/cfd_wind_pipeline/parse_doors.py
+++ b/cfd_wind_pipeline/parse_doors.py
@@ -1,0 +1,98 @@
+"""Parse a binary STL with multiple disjoint surfaces (doors), report each one's
+bounding box so we can identify inlet/outlet positions."""
+import argparse
+import struct
+import sys
+from pathlib import Path
+
+import numpy as np
+
+
+def parse_binary_stl(path):
+    """Return triangles as (N, 3, 3) array of vertices."""
+    with open(path, 'rb') as f:
+        header = f.read(80)
+        n_tri = struct.unpack('<I', f.read(4))[0]
+        tris = np.zeros((n_tri, 3, 3), dtype=np.float32)
+        for i in range(n_tri):
+            f.read(12)  # normal
+            for j in range(3):
+                tris[i, j] = struct.unpack('<fff', f.read(12))
+            f.read(2)  # attribute
+    return tris
+
+
+def cluster_into_components(tris, tol=0.01):
+    """Connected components by shared vertices. Returns list of triangle-index arrays."""
+    # Build vertex → triangle index mapping via voxelized vertex coordinates
+    n = len(tris)
+    # Round each vertex to tol cells for hashing
+    keys = (tris / tol).round().astype(np.int64)
+    vert_to_tri = {}
+    for ti in range(n):
+        for vi in range(3):
+            k = tuple(keys[ti, vi])
+            vert_to_tri.setdefault(k, []).append(ti)
+    # Union-find over triangles sharing any vertex
+    parent = list(range(n))
+    def find(a):
+        while parent[a] != a:
+            parent[a] = parent[parent[a]]
+            a = parent[a]
+        return a
+    def union(a, b):
+        ra, rb = find(a), find(b)
+        if ra != rb:
+            parent[ra] = rb
+    for verts in vert_to_tri.values():
+        for v in verts[1:]:
+            union(verts[0], v)
+    # Group triangles by root
+    groups = {}
+    for ti in range(n):
+        groups.setdefault(find(ti), []).append(ti)
+    return list(groups.values())
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--stl', required=True)
+    args = p.parse_args()
+
+    tris = parse_binary_stl(args.stl)
+    print(f"{len(tris)} triangles total")
+    groups = cluster_into_components(tris)
+    print(f"{len(groups)} connected components (\"doors\")")
+    print()
+    print(f"{'Door':>4s}  {'nTri':>5s}  {'x_min':>7s} {'x_max':>7s}  "
+          f"{'y_min':>7s} {'y_max':>7s}  {'z_min':>7s} {'z_max':>7s}  {'wall_side':>10s}")
+    door_info = []
+    for i, group in enumerate(sorted(groups, key=len, reverse=True)):
+        verts = tris[group].reshape(-1, 3)
+        mn = verts.min(axis=0)
+        mx = verts.max(axis=0)
+        # Which side of the bounding box does it sit on?
+        # We'll learn this after seeing the global bbox
+        door_info.append((i, len(group), mn, mx))
+
+    # Global bbox
+    all_verts = tris.reshape(-1, 3)
+    gmn = all_verts.min(axis=0)
+    gmx = all_verts.max(axis=0)
+    print(f"global bbox: x=[{gmn[0]:.2f},{gmx[0]:.2f}] y=[{gmn[1]:.2f},{gmx[1]:.2f}] z=[{gmn[2]:.2f},{gmx[2]:.2f}]")
+    print()
+    for i, n_t, mn, mx in door_info:
+        # Identify which wall side this door is on (smallest gap to global bbox edge)
+        side = ""
+        if mn[0] - gmn[0] < 0.2: side = "WEST"
+        elif gmx[0] - mx[0] < 0.2: side = "EAST"
+        elif mn[1] - gmn[1] < 0.2: side = "SOUTH"
+        elif gmx[1] - mx[1] < 0.2: side = "NORTH"
+        else: side = "INTERIOR"
+        print(f"{i:>4d}  {n_t:>5d}  {mn[0]:>7.2f} {mx[0]:>7.2f}  "
+              f"{mn[1]:>7.2f} {mx[1]:>7.2f}  {mn[2]:>7.2f} {mx[2]:>7.2f}  {side:>10s}  "
+              f"size {mx[0]-mn[0]:.2f}x{mx[1]-mn[1]:.2f}x{mx[2]-mn[2]:.2f}")
+
+
+if __name__ == '__main__':
+    main()

--- a/cfd_wind_pipeline/placement.py
+++ b/cfd_wind_pipeline/placement.py
@@ -1,0 +1,205 @@
+"""Heuristic inlet/outlet placement on procedural maps.
+
+Constraints:
+- Inlets on one wall, outlets on opposite wall (W↔E or S↔N)
+- Each opening 1.0-2.5 m wide
+- Openings on the same wall ≥ 1 m apart
+- Each opening must connect to the map's main interior via flood-fill
+  (filters out "sealed-off room" cases)
+- Inlet-to-outlet euclidean distance ≥ 0.5 × map diagonal
+"""
+import os
+import sys
+from dataclasses import dataclass
+from typing import Optional
+
+import numpy as np
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from config import RL_PACKAGE_PATH
+sys.path.insert(0, RL_PACKAGE_PATH)
+from reinforcement_learning.envs.map_generator import MapGenerator
+
+
+@dataclass
+class OpeningSpec:
+    side: str            # 'west', 'east', 'south', 'north'
+    lo: float            # m
+    hi: float            # m
+    role: str            # 'inlet' or 'outlet'
+
+    def center(self, map_w, map_h):
+        mid = 0.5 * (self.lo + self.hi)
+        if self.side == 'west':  return (0.0, mid)
+        if self.side == 'east':  return (map_w, mid)
+        if self.side == 'south': return (mid, 0.0)
+        if self.side == 'north': return (mid, map_h)
+
+
+def _clearance_zone_free(grid, side, lo, hi, cell_size, wall_thick_cells,
+                          near_depth_m=0.5, far_depth_m=1.5,
+                          near_min_free=1.0, far_min_free=0.85):
+    """Two-zone check inside the opening:
+    - Near zone (depth 0 to near_depth_m, full opening width): MUST be 100% free.
+      This kills "wall directly behind the opening" cases.
+    - Far zone (near_depth_m to far_depth_m): >= far_min_free free.
+      Allows some interior walls deeper in.
+    """
+    H, W = grid.shape
+    near_d = max(1, int(round(near_depth_m / cell_size)))
+    far_d = max(near_d + 1, int(round(far_depth_m / cell_size)))
+    if side == 'west':
+        r_lo, r_hi = int(lo / cell_size), int(np.ceil(hi / cell_size))
+        c_near = (wall_thick_cells, wall_thick_cells + near_d)
+        c_far = (wall_thick_cells + near_d, wall_thick_cells + far_d)
+    elif side == 'east':
+        r_lo, r_hi = int(lo / cell_size), int(np.ceil(hi / cell_size))
+        c_near = (W - wall_thick_cells - near_d, W - wall_thick_cells)
+        c_far = (W - wall_thick_cells - far_d, W - wall_thick_cells - near_d)
+    elif side == 'south':
+        c_lo, c_hi = int(lo / cell_size), int(np.ceil(hi / cell_size))
+        r_near = (wall_thick_cells, wall_thick_cells + near_d)
+        r_far = (wall_thick_cells + near_d, wall_thick_cells + far_d)
+    else:  # north
+        c_lo, c_hi = int(lo / cell_size), int(np.ceil(hi / cell_size))
+        r_near = (H - wall_thick_cells - near_d, H - wall_thick_cells)
+        r_far = (H - wall_thick_cells - far_d, H - wall_thick_cells - near_d)
+    if side in ('west', 'east'):
+        near = grid[r_lo:r_hi, c_near[0]:c_near[1]]
+        far = grid[r_lo:r_hi, c_far[0]:c_far[1]]
+    else:
+        near = grid[r_near[0]:r_near[1], c_lo:c_hi]
+        far = grid[r_far[0]:r_far[1], c_lo:c_hi]
+    if near.size == 0 or far.size == 0: return False
+    if (near == 0).mean() < near_min_free: return False
+    if (far == 0).mean() < far_min_free: return False
+    return True
+
+
+def _flood_fill_from_edge(grid, side, lo, hi, cell_size, wall_thick_cells):
+    """Try to fill from the opening cells; return # of reached free cells."""
+    H, W = grid.shape
+    work = grid.copy()
+    # Punch the opening
+    if side == 'west':
+        r_lo, r_hi = int(lo / cell_size), int(np.ceil(hi / cell_size))
+        work[r_lo:r_hi, :wall_thick_cells] = 0
+    elif side == 'east':
+        r_lo, r_hi = int(lo / cell_size), int(np.ceil(hi / cell_size))
+        work[r_lo:r_hi, -wall_thick_cells:] = 0
+    elif side == 'south':
+        c_lo, c_hi = int(lo / cell_size), int(np.ceil(hi / cell_size))
+        work[:wall_thick_cells, c_lo:c_hi] = 0
+    elif side == 'north':
+        c_lo, c_hi = int(lo / cell_size), int(np.ceil(hi / cell_size))
+        work[-wall_thick_cells:, c_lo:c_hi] = 0
+    free = (work == 0)
+    # BFS from the opening cells
+    if side == 'west':   seeds = [(r, 0) for r in range(r_lo, r_hi) if free[r, 0]]
+    elif side == 'east': seeds = [(r, W-1) for r in range(r_lo, r_hi) if free[r, W-1]]
+    elif side == 'south':seeds = [(0, c) for c in range(c_lo, c_hi) if free[0, c]]
+    else:                seeds = [(H-1, c) for c in range(c_lo, c_hi) if free[H-1, c]]
+    if not seeds:
+        return 0
+    visited = np.zeros_like(free, dtype=bool)
+    from collections import deque
+    q = deque(seeds)
+    for r, c in seeds: visited[r, c] = True
+    while q:
+        r, c = q.popleft()
+        for dr, dc in [(-1,0),(1,0),(0,-1),(0,1)]:
+            nr, nc = r+dr, c+dc
+            if 0 <= nr < H and 0 <= nc < W and free[nr, nc] and not visited[nr, nc]:
+                visited[nr, nc] = True
+                q.append((nr, nc))
+    return int(visited.sum())
+
+
+def _try_place_opening(grid, side, map_dim, cell_size, wall_thick_cells,
+                       width, existing, rng, min_separation=1.0,
+                       min_reach_cells=200, max_attempts=30):
+    """Try to find one valid opening on a given side. Returns OpeningSpec or None."""
+    edge = map_dim  # length of this wall in meters (W for N/S, H for W/E)
+    for _ in range(max_attempts):
+        lo = float(rng.uniform(0.2, edge - width - 0.2))
+        hi = lo + width
+        # Check spacing from existing openings on same side
+        overlap = False
+        for o in existing:
+            if o.side == side:
+                # gap test
+                if not (hi + min_separation < o.lo or lo > o.hi + min_separation):
+                    overlap = True; break
+        if overlap: continue
+        # Check clearance zone (no walls right behind opening)
+        if not _clearance_zone_free(grid, side, lo, hi, cell_size, wall_thick_cells):
+            continue
+        # Check connectivity
+        reach = _flood_fill_from_edge(grid, side, lo, hi, cell_size, wall_thick_cells)
+        if reach < min_reach_cells: continue
+        return (lo, hi)
+    return None
+
+
+def sample_openings(grid, cell_size, map_w, map_h, rng,
+                    wall_thick_m=0.6,
+                    n_inlets=None, n_outlets=None,
+                    inlet_side=None,
+                    min_width=1.0, max_width=2.5):
+    """Sample inlet/outlet openings for one map. Returns list of OpeningSpec
+    or None if no valid config found."""
+    wall_thick_cells = max(1, int(round(wall_thick_m / cell_size)))
+    if n_inlets is None:
+        n_inlets = int(rng.choice([1, 2, 3], p=[0.2, 0.6, 0.2]))
+    if n_outlets is None:
+        n_outlets = int(rng.choice([1, 2, 3], p=[0.2, 0.6, 0.2]))
+    if inlet_side is None:
+        inlet_side = rng.choice(['west', 'south'], p=[0.7, 0.3])
+    opposites = {'west': 'east', 'south': 'north'}
+    outlet_side = opposites[inlet_side]
+
+    openings = []
+    # Place inlets
+    inlet_wall_dim = map_h if inlet_side in ('west', 'east') else map_w
+    for _ in range(n_inlets):
+        w = float(rng.uniform(min_width, max_width))
+        res = _try_place_opening(grid, inlet_side, inlet_wall_dim, cell_size,
+                                  wall_thick_cells, w, openings, rng)
+        if res is None: continue
+        openings.append(OpeningSpec(inlet_side, res[0], res[1], 'inlet'))
+    if not openings: return None
+    # Place outlets
+    outlet_wall_dim = map_h if outlet_side in ('west', 'east') else map_w
+    for _ in range(n_outlets):
+        w = float(rng.uniform(min_width, max_width))
+        res = _try_place_opening(grid, outlet_side, outlet_wall_dim, cell_size,
+                                  wall_thick_cells, w, openings, rng)
+        if res is None: continue
+        openings.append(OpeningSpec(outlet_side, res[0], res[1], 'outlet'))
+    if not any(o.role == 'outlet' for o in openings): return None
+    # Min separation between any inlet and outlet
+    diag = (map_w**2 + map_h**2) ** 0.5
+    min_sep = 0.5 * diag
+    for i in [o for o in openings if o.role == 'inlet']:
+        for j in [o for o in openings if o.role == 'outlet']:
+            ic = i.center(map_w, map_h); jc = j.center(map_w, map_h)
+            d = ((ic[0]-jc[0])**2 + (ic[1]-jc[1])**2) ** 0.5
+            if d < min_sep:
+                return None
+    return openings
+
+
+def sample_map_with_openings(template_id, seed, max_retries=10):
+    """Generate one map + valid openings. Returns (map_data, openings) or (None, None)."""
+    rng = np.random.default_rng(seed)
+    gen_rng = np.random.default_rng(seed)
+    gen = MapGenerator(rng=gen_rng)
+    map_data = gen.generate(template_id=template_id)
+    grid = np.array(map_data['grid'].grid, dtype=np.int8)
+    cell_size = map_data['grid'].resolution
+    map_w = map_data['width']; map_h = map_data['height']
+    for attempt in range(max_retries):
+        ops = sample_openings(grid, cell_size, map_w, map_h, rng)
+        if ops is not None:
+            return map_data, ops
+    return None, None

--- a/cfd_wind_pipeline/placement.py
+++ b/cfd_wind_pipeline/placement.py
@@ -189,8 +189,12 @@ def sample_openings(grid, cell_size, map_w, map_h, rng,
     return openings
 
 
-def sample_map_with_openings(template_id, seed, max_retries=10):
-    """Generate one map + valid openings. Returns (map_data, openings) or (None, None)."""
+def sample_map_with_openings(template_id, seed, max_retries=10, inlet_side=None):
+    """Generate one map + valid openings. Returns (map_data, openings) or (None, None).
+
+    `inlet_side` is forwarded to sample_openings. Pass 'west' to restrict to
+    W↔E placements (required when gen_case uses fixed inlet/outlet patches on
+    the x=0 / x=W bg-mesh faces)."""
     rng = np.random.default_rng(seed)
     gen_rng = np.random.default_rng(seed)
     gen = MapGenerator(rng=gen_rng)
@@ -199,7 +203,8 @@ def sample_map_with_openings(template_id, seed, max_retries=10):
     cell_size = map_data['grid'].resolution
     map_w = map_data['width']; map_h = map_data['height']
     for attempt in range(max_retries):
-        ops = sample_openings(grid, cell_size, map_w, map_h, rng)
+        ops = sample_openings(grid, cell_size, map_w, map_h, rng,
+                              inlet_side=inlet_side)
         if ops is not None:
             return map_data, ops
     return None, None

--- a/cfd_wind_pipeline/prune_mesh.py
+++ b/cfd_wind_pipeline/prune_mesh.py
@@ -1,0 +1,57 @@
+"""Prune OpenFOAM mesh artifacts from a library, keeping only what training needs.
+
+Drops ~130MB/case → ~400KB/case (the wind_field.npz, grid.npz, meta.json).
+After pruning, the cases can no longer be re-postprocessed — they'd need to
+be regenerated from the manifest entry (~15 min/case).
+
+Usage:
+    python prune_mesh.py --library-dir $CFD_DATA_ROOT/library_v1 [--dry-run]
+"""
+import argparse
+import shutil
+import subprocess
+from pathlib import Path
+
+
+def prune_one(case_dir: Path, dry_run: bool):
+    if not (case_dir / 'wind_field.npz').exists():
+        return 0  # never pruned — case didn't finish
+    bytes_freed = 0
+    targets = ['constant', 'system', '0', '0.orig', 'postProcessing']
+    for t in targets:
+        p = case_dir / t
+        if p.exists():
+            bytes_freed += int(subprocess.check_output(['du', '-sb', str(p)]).split()[0])
+            if not dry_run:
+                shutil.rmtree(p)
+    # Time-step dirs (numeric names): "100", "200", "50.5", etc.
+    for sub in case_dir.iterdir():
+        if sub.is_dir() and sub.name.replace('.', '', 1).isdigit():
+            bytes_freed += int(subprocess.check_output(['du', '-sb', str(sub)]).split()[0])
+            if not dry_run:
+                shutil.rmtree(sub)
+    return bytes_freed
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--library-dir', required=True)
+    p.add_argument('--dry-run', action='store_true',
+                   help='Show what would be freed; do not delete.')
+    args = p.parse_args()
+
+    lib = Path(args.library_dir)
+    cases = sorted(lib.glob('case_*'))
+    total = 0
+    n_pruned = 0
+    for c in cases:
+        freed = prune_one(c, args.dry_run)
+        if freed > 0:
+            n_pruned += 1
+            total += freed
+    print(f"{'[DRY-RUN] would free' if args.dry_run else 'Freed'} "
+          f"{total/1e9:.2f} GB across {n_pruned}/{len(cases)} cases.")
+
+
+if __name__ == '__main__':
+    main()

--- a/cfd_wind_pipeline/sbatch/run_array.sh
+++ b/cfd_wind_pipeline/sbatch/run_array.sh
@@ -26,7 +26,10 @@ PYBIN=${CFD_PYTHON_BIN:-/home/efe-mantaroglu/simenv/bin/python}
 # scratch location, so ${BASH_SOURCE[0]} resolves to /var/spool/slurm/...
 SCRIPT_DIR=${CFD_PIPELINE_DIR:-/comp04-storage/efe-mantaroglu/osl/base/cfd_wind_pipeline}
 
-IDX=${SLURM_ARRAY_TASK_ID:?"must be run as a SLURM array job"}
+# Manifest index = array task id + optional offset. SLURM caps array indices
+# at MaxArraySize-1 (1000 here), so libraries > 1000 cases are submitted in
+# chunks: e.g. the 1000-1599 range goes as `--array=0-599` with CFD_ARRAY_OFFSET=1000.
+IDX=$(( ${SLURM_ARRAY_TASK_ID:?"must be run as a SLURM array job"} + ${CFD_ARRAY_OFFSET:-0} ))
 
 # Pull the case_dir for this index out of the manifest using a tiny python
 # inline call (avoids extra dep).

--- a/cfd_wind_pipeline/sbatch/run_array.sh
+++ b/cfd_wind_pipeline/sbatch/run_array.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Run blockMesh + snappyHexMesh + simpleFoam + postProcess + extract on ONE case
+# from a library manifest, selected by SLURM_ARRAY_TASK_ID.
+#
+# Usage:
+#   sbatch --array=0-199%24 run_array.sh <library-dir>
+#
+# Env vars:
+#   CFD_OPENFOAM_SQSH  path to Pyxis squashfs container (OpenFOAM)
+#   CFD_PYTHON_BIN     python interpreter with numpy + scipy (for extract step)
+#SBATCH --job-name=cfd_arr
+#SBATCH --partition=batch
+#SBATCH --time=01:00:00
+#SBATCH --mem=6G
+#SBATCH --cpus-per-task=1
+#SBATCH --ntasks=1
+#SBATCH --output=cfd_arr_%A_%a.out
+
+set -euo pipefail
+
+LIB_DIR=${1:?"usage: sbatch run_array.sh <library-dir>"}
+SQSH=${CFD_OPENFOAM_SQSH:-/comp04-storage/efe-mantaroglu/osl/opencfd+openfoam-default+latest.sqsh}
+PYBIN=${CFD_PYTHON_BIN:-/home/efe-mantaroglu/simenv/bin/python}
+# Path to the cfd_wind_pipeline/ dir. Override with CFD_PIPELINE_DIR if you move
+# the source tree. Cannot use BASH_SOURCE — SLURM stages this script to a
+# scratch location, so ${BASH_SOURCE[0]} resolves to /var/spool/slurm/...
+SCRIPT_DIR=${CFD_PIPELINE_DIR:-/comp04-storage/efe-mantaroglu/osl/base/cfd_wind_pipeline}
+
+IDX=${SLURM_ARRAY_TASK_ID:?"must be run as a SLURM array job"}
+
+# Pull the case_dir for this index out of the manifest using a tiny python
+# inline call (avoids extra dep).
+CASE_DIR=$(${PYBIN} - "$LIB_DIR" "$IDX" <<'PY'
+import json, sys
+lib, idx = sys.argv[1], int(sys.argv[2])
+m = json.load(open(f"{lib}/manifest.json"))
+print(m[idx]['case_dir'])
+PY
+)
+echo "Array task $IDX → $CASE_DIR"
+
+# Skip if already done (wind_field.npz present)
+if [ -f "${CASE_DIR}/wind_field.npz" ]; then
+    echo "Already complete: ${CASE_DIR}/wind_field.npz exists. Skipping."
+    exit 0
+fi
+
+# Step 1: write the sample dict (needs to exist before postProcess is called).
+${PYBIN} ${SCRIPT_DIR}/extract_wind.py --case-dir ${CASE_DIR} --write-dict-only
+
+# Step 2: run mesh + solver + postProcess inside the container.
+srun \
+  --container-image=${SQSH} \
+  --container-mounts=/comp04-storage:/comp04-storage \
+  bash -c "
+    set -euo pipefail
+    cd ${CASE_DIR}
+    echo '===blockMesh==='
+    blockMesh 2>&1 | tail -5
+    echo '===snappyHexMesh==='
+    snappyHexMesh -overwrite 2>&1 | tail -5
+    echo '===restore 0==='
+    rm -rf 0
+    cp -r 0.orig 0
+    echo '===simpleFoam==='
+    simpleFoam 2>&1 | tail -10
+    echo '===postProcess sample==='
+    postProcess -func sample -latestTime 2>&1 | tail -5
+"
+
+# Step 3: parse the raw output into wind_field.npz (outside container, needs scipy).
+${PYBIN} ${SCRIPT_DIR}/extract_wind.py --case-dir ${CASE_DIR} --parse-only
+
+# Step 4: prune CFD mesh artifacts unless CFD_KEEP_MESH=1. 132MB → ~400KB/case.
+# Keeps wind_field.npz + grid.npz + meta.json (everything training needs).
+if [ "${CFD_KEEP_MESH:-0}" != "1" ] && [ -f "${CASE_DIR}/wind_field.npz" ]; then
+    rm -rf ${CASE_DIR}/constant ${CASE_DIR}/system ${CASE_DIR}/0 ${CASE_DIR}/0.orig
+    rm -rf ${CASE_DIR}/postProcessing
+    find ${CASE_DIR} -maxdepth 1 -type d -regex '.*/[0-9]+\(\.[0-9]+\)?$' -exec rm -rf {} +
+fi
+
+echo "DONE: $CASE_DIR"

--- a/cfd_wind_pipeline/sbatch/run_case.sh
+++ b/cfd_wind_pipeline/sbatch/run_case.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Run blockMesh + snappyHexMesh + simpleFoam on a single OpenFOAM case.
+# Usage:  sbatch run_case.sh <abs-path-to-case-dir>
+# Env vars:
+#   CFD_OPENFOAM_SQSH  path to Pyxis squashfs container (OpenFOAM)
+#   CFD_DATA_ROOT      where to write slurm-*.out (defaults inline below)
+#SBATCH --job-name=cfd_case
+#SBATCH --partition=batch
+#SBATCH --time=00:30:00
+#SBATCH --mem=16G
+#SBATCH --cpus-per-task=4
+#SBATCH --ntasks=1
+
+set -euo pipefail
+CASE_DIR=${1:?"usage: sbatch run_case.sh <abs-path-to-case-dir>"}
+SQSH=${CFD_OPENFOAM_SQSH:-/comp04-storage/efe-mantaroglu/osl/opencfd+openfoam-default+latest.sqsh}
+
+srun \
+  --container-image=${SQSH} \
+  --container-mounts=/comp04-storage:/comp04-storage \
+  bash -c "
+    set -euo pipefail
+    cd ${CASE_DIR}
+    echo '===blockMesh==='
+    blockMesh 2>&1 | tail -10
+    echo '===snappyHexMesh==='
+    snappyHexMesh -overwrite 2>&1 | tail -20
+    echo '===restore 0 from 0.orig==='
+    rm -rf 0
+    cp -r 0.orig 0
+    echo '===simpleFoam==='
+    simpleFoam 2>&1 | tail -30
+    echo '===times produced==='
+    ls -d [0-9]* 2>/dev/null
+    LAST=\$(ls -d [0-9]* | sort -n | tail -1)
+    echo last time: \$LAST
+    echo '===cell count==='
+    checkMesh -latestTime 2>&1 | grep -E 'cells:|points:' | head -5
+"

--- a/cfd_wind_pipeline/sbatch/run_smoke.sh
+++ b/cfd_wind_pipeline/sbatch/run_smoke.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Smoke test: run the unmodified windAroundBuildings tutorial in the container.
+# Use to verify the OpenFOAM Pyxis container + cluster setup is working before
+# attempting any of our own cases.
+# Requires: copy of windAroundBuildings tutorial at ${1}/test_unmodified
+# Env vars:
+#   CFD_OPENFOAM_SQSH  path to Pyxis squashfs container (OpenFOAM)
+#SBATCH --job-name=cfd_smoke
+#SBATCH --partition=batch
+#SBATCH --time=00:20:00
+#SBATCH --mem=16G
+#SBATCH --cpus-per-task=4
+#SBATCH --ntasks=1
+
+set -euo pipefail
+CASE_DIR=${1:?"usage: sbatch run_smoke.sh <abs-path-to-test_unmodified-dir>"}
+SQSH=${CFD_OPENFOAM_SQSH:-/comp04-storage/efe-mantaroglu/osl/opencfd+openfoam-default+latest.sqsh}
+
+srun \
+  --container-image=${SQSH} \
+  --container-mounts=/comp04-storage:/comp04-storage \
+  bash -c "
+    set -euo pipefail
+    cd ${CASE_DIR}
+    echo '===Allrun.pre==='
+    ./Allrun.pre
+    echo '===restore0Dir==='
+    cp -r 0.orig 0
+    echo '===simpleFoam==='
+    simpleFoam 2>&1 | tail -30
+    echo '===check times produced==='
+    ls -d [0-9]* 2>/dev/null
+    LAST=\$(ls -d [0-9]* | sort -n | tail -1)
+    echo last time: \$LAST
+    head -50 \${LAST}/U
+"

--- a/cfd_wind_pipeline/sbatch/train_cfd_library.sh
+++ b/cfd_wind_pipeline/sbatch/train_cfd_library.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Train PPO using a CFD wind library as the training distribution.
+#
+# Usage:  sbatch train_cfd_library.sh <library-dir> <rl-package-path> [extra-train-args...]
+# Example:
+#   sbatch train_cfd_library.sh \
+#     /comp04-storage/efe-mantaroglu/osl/cfd_test/library_v2 \
+#     /comp04-storage/efe-mantaroglu/osl/friend_base_loop_spatial \
+#     --arch dual --num-envs 48 --total-timesteps 200000000
+#
+# Env vars:
+#   CFD_MIX_SYNTHETIC  fraction (0..1) of resets that use the original
+#                      MapGenerator+synthetic-wind instead of the library
+#                      (default: 0.2 — keeps some procedural diversity as safety)
+#SBATCH --job-name=ppo_cfd_lib
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=12
+#SBATCH --mem=32G
+#SBATCH --gres=gpu:1
+#SBATCH --time=23:59:00
+#SBATCH --partition=batch
+#SBATCH --output=/comp04-storage/efe-mantaroglu/osl/%x-%j.out
+
+set -euo pipefail
+
+LIB_DIR=${1:?"usage: sbatch train_cfd_library.sh <library-dir> <rl-package-path> [train-args...]"}
+RL_PKG=${2:?"need rl-package-path"}
+shift 2
+
+MIX=${CFD_MIX_SYNTHETIC:-0.2}
+VENV_PY=${CFD_PYTHON_BIN:-/home/efe-mantaroglu/simenv/bin/python}
+CFD_PKG=/comp04-storage/efe-mantaroglu/osl/base/cfd_wind_pipeline
+
+cd ${RL_PKG}
+
+${VENV_PY} -u ${CFD_PKG}/train_with_cfd_library.py \
+    --library-dir ${LIB_DIR} \
+    --rl-package-path ${RL_PKG} \
+    --mix-synthetic ${MIX} \
+    -- "$@"

--- a/cfd_wind_pipeline/sbatch/train_cfd_library.sh
+++ b/cfd_wind_pipeline/sbatch/train_cfd_library.sh
@@ -32,10 +32,26 @@ MIX=${CFD_MIX_SYNTHETIC:-0.2}
 VENV_PY=${CFD_PYTHON_BIN:-/home/efe-mantaroglu/simenv/bin/python}
 CFD_PKG=/comp04-storage/efe-mantaroglu/osl/base/cfd_wind_pipeline
 
+# Propagate the local-wind-observation flag (read by the RL package config).
+# Set OSL_LOCAL_WIND_OBS=1 in the submitting shell to train the policy on
+# local point wind instead of the spatial mean. MUST match at eval time.
+export OSL_LOCAL_WIND_OBS=${OSL_LOCAL_WIND_OBS:-0}
+echo "OSL_LOCAL_WIND_OBS=${OSL_LOCAL_WIND_OBS}"
+
+# --template-filter is a LAUNCHER arg (parsed by train_with_cfd_library.py
+# before the `--`), NOT a train.py arg. Pass it via CFD_TEMPLATE_FILTER so it
+# lands on the correct side of the `--`. e.g. CFD_TEMPLATE_FILTER=0,1,2,3,4,5
+TEMPLATE_FILTER_ARG=()
+if [ -n "${CFD_TEMPLATE_FILTER:-}" ]; then
+    TEMPLATE_FILTER_ARG=(--template-filter "${CFD_TEMPLATE_FILTER}")
+    echo "CFD_TEMPLATE_FILTER=${CFD_TEMPLATE_FILTER}"
+fi
+
 cd ${RL_PKG}
 
 ${VENV_PY} -u ${CFD_PKG}/train_with_cfd_library.py \
     --library-dir ${LIB_DIR} \
     --rl-package-path ${RL_PKG} \
     --mix-synthetic ${MIX} \
+    "${TEMPLATE_FILTER_ARG[@]}" \
     -- "$@"

--- a/cfd_wind_pipeline/train_with_cfd_library.py
+++ b/cfd_wind_pipeline/train_with_cfd_library.py
@@ -32,12 +32,17 @@ def main():
         passthrough = []
 
     p = argparse.ArgumentParser()
-    p.add_argument('--library-dir', required=True)
+    p.add_argument('--library-dir', required=True,
+                   help='CFD library dir, or comma-separated list to pool '
+                        '(e.g. hard T4-9 + easy T0-3).')
     p.add_argument('--rl-package-path', required=True,
                    help='Path to the RL package providing train.py / GasSourceEnv')
     p.add_argument('--mix-synthetic', type=float, default=0.0,
                    help='Fraction of episodes that reset to procedural+synthetic '
                         '(default 0 = always use library)')
+    p.add_argument('--template-filter', type=str, default=None,
+                   help='Comma-separated template_ids to keep (e.g. "0,1,2,3,4,5" '
+                        'to match the champ and avoid OOD template shock).')
     args = p.parse_args(launcher_argv)
 
     rl_pkg = os.path.abspath(args.rl_package_path)
@@ -50,21 +55,22 @@ def main():
     from reinforcement_learning.training import train as train_mod
     from cfd_library_env import make_cfd_env
 
-    library_dir = os.path.abspath(args.library_dir)
+    library_dirs = [os.path.abspath(d) for d in args.library_dir.split(',')]
     mix = args.mix_synthetic
-
-    orig_make_env = train_mod.make_env
+    tmpl_filter = ([int(x) for x in args.template_filter.split(',')]
+                   if args.template_filter else None)
 
     def patched_make_env(seed, rank, template_id=None):
         return make_cfd_env(seed=seed, rank=rank,
-                            library_dir=library_dir,
+                            library_dirs=library_dirs,
                             rl_package_path=rl_pkg,
                             mix_synthetic=mix,
-                            template_id=template_id)
+                            template_id=template_id,
+                            template_filter=tmpl_filter)
 
     train_mod.make_env = patched_make_env
-    print(f"[train_with_cfd_library] Patched make_env → CFD library "
-          f"({library_dir}, mix_synthetic={mix})")
+    print(f"[train_with_cfd_library] Patched make_env → CFD libraries "
+          f"({library_dirs}, mix_synthetic={mix}, template_filter={tmpl_filter})")
 
     # Hand off to train.main() with the remaining argv.
     sys.argv = [sys.argv[0]] + passthrough

--- a/cfd_wind_pipeline/train_with_cfd_library.py
+++ b/cfd_wind_pipeline/train_with_cfd_library.py
@@ -1,0 +1,75 @@
+"""Launch PPO training using a CFD wind library as the training distribution.
+
+Monkey-patches the training script's `make_env` so the VecEnv builds
+CFDLibraryEnv-wrapped envs that sample (map, wind) from `--library-dir`
+at every reset. Otherwise this is an exact pass-through to the underlying
+train.py main() — all of train.py's existing args still work.
+
+Usage:
+    python train_with_cfd_library.py \\
+        --library-dir /comp04-storage/.../cfd_test/library_v2 \\
+        --rl-package-path /comp04-storage/.../friend_base_loop_spatial \\
+        --mix-synthetic 0.2 \\
+        -- <any train.py args, e.g. --arch dual --num-envs 48 ...>
+
+Args before `--` are this launcher's. Args after `--` go to train.py untouched.
+"""
+import argparse
+import os
+import sys
+
+
+def main():
+    # Split argv on the first '--' so the launcher's args don't collide
+    # with train.py's argparse.
+    argv = sys.argv[1:]
+    if '--' in argv:
+        i = argv.index('--')
+        launcher_argv = argv[:i]
+        passthrough = argv[i+1:]
+    else:
+        launcher_argv = argv
+        passthrough = []
+
+    p = argparse.ArgumentParser()
+    p.add_argument('--library-dir', required=True)
+    p.add_argument('--rl-package-path', required=True,
+                   help='Path to the RL package providing train.py / GasSourceEnv')
+    p.add_argument('--mix-synthetic', type=float, default=0.0,
+                   help='Fraction of episodes that reset to procedural+synthetic '
+                        '(default 0 = always use library)')
+    args = p.parse_args(launcher_argv)
+
+    rl_pkg = os.path.abspath(args.rl_package_path)
+    cfd_pkg = os.path.dirname(os.path.abspath(__file__))
+    for p in (rl_pkg, cfd_pkg):
+        if p not in sys.path:
+            sys.path.insert(0, p)
+
+    # Import + patch the training module's env factory.
+    from reinforcement_learning.training import train as train_mod
+    from cfd_library_env import make_cfd_env
+
+    library_dir = os.path.abspath(args.library_dir)
+    mix = args.mix_synthetic
+
+    orig_make_env = train_mod.make_env
+
+    def patched_make_env(seed, rank, template_id=None):
+        return make_cfd_env(seed=seed, rank=rank,
+                            library_dir=library_dir,
+                            rl_package_path=rl_pkg,
+                            mix_synthetic=mix,
+                            template_id=template_id)
+
+    train_mod.make_env = patched_make_env
+    print(f"[train_with_cfd_library] Patched make_env → CFD library "
+          f"({library_dir}, mix_synthetic={mix})")
+
+    # Hand off to train.main() with the remaining argv.
+    sys.argv = [sys.argv[0]] + passthrough
+    train_mod.main()
+
+
+if __name__ == '__main__':
+    main()

--- a/cfd_wind_pipeline/viz/viz_gaden_wind.py
+++ b/cfd_wind_pipeline/viz/viz_gaden_wind.py
@@ -1,0 +1,89 @@
+"""Visualize an actual GADEN wind field for comparison with our CFD output.
+Uses the same plot style as viz_wind.py so they're directly comparable."""
+import argparse
+import sys
+from pathlib import Path
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+
+# Add parent dir to path so we can import config
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from config import RL_PACKAGE_PATH, GADEN_MAPS_ROOT, DATA_ROOT
+sys.path.insert(0, RL_PACKAGE_PATH)
+from reinforcement_learning.test.gaden_loader import DEFAULT_MAP_KEYS, load_full_map
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--map', required=True, help='GADEN map key e.g. many_rooms')
+    p.add_argument('--out', default=None)
+    p.add_argument('--gaden-root', default=GADEN_MAPS_ROOT)
+    args = p.parse_args()
+
+    gaden_root = Path(args.gaden_root)
+    yaml_path = gaden_root / 'recommended_configs.yaml'
+    fm = load_full_map(gaden_root, yaml_path, args.map)
+    wind_field = fm['wind_field']
+    grid = fm['grid']
+
+    # field is (H, W, 2) where [..., 0]=Ux, [..., 1]=Uy
+    field = wind_field.field.astype(np.float64)
+    res = wind_field.resolution
+    occ = grid.grid  # (H, W), nonzero = wall
+    H, W = field.shape[:2]
+
+    map_w = W * res
+    map_h = H * res
+    speed = np.linalg.norm(field, axis=-1)
+    free_mask = (occ == 0)
+
+    print(f"GADEN map: {args.map}")
+    print(f"  shape: {field.shape}, cell={res}, map={map_w:.2f}x{map_h:.2f} m")
+    print(f"  free cells: {free_mask.sum()} of {free_mask.size}")
+    print(f"  free-cell |U|: mean={speed[free_mask].mean():.3f}, std={speed[free_mask].std():.3f}")
+    dirs = np.arctan2(field[..., 1], field[..., 0])
+    free_dirs = dirs[free_mask]
+    sin_m = np.mean(np.sin(free_dirs)); cos_m = np.mean(np.cos(free_dirs))
+    R = np.sqrt(sin_m**2 + cos_m**2)
+    circ_std = float(np.sqrt(-2 * np.log(R))) if R > 0 else float('inf')
+    print(f"  direction circular_std = {circ_std:.3f} rad")
+
+    fig, ax = plt.subplots(figsize=(12, max(4, 12 * map_h / map_w)))
+    # Walls as grey
+    ax.imshow(occ, origin='lower', extent=(0, map_w, 0, map_h),
+              cmap='Greys', alpha=0.6, vmin=0, vmax=2)
+    # |U| as colormap
+    speed_disp = speed.copy()
+    speed_disp[~free_mask] = np.nan
+    im = ax.imshow(speed_disp, origin='lower', extent=(0, map_w, 0, map_h),
+                   cmap='viridis', alpha=0.7, vmin=0, vmax=max(0.1, speed[free_mask].max()))
+    plt.colorbar(im, ax=ax, label='|U| [m/s]')
+    # Quiver — subsample
+    skip = max(1, H // 30)
+    xs = (np.arange(W) + 0.5) * res
+    ys = (np.arange(H) + 0.5) * res
+    Xs, Ys = np.meshgrid(xs[::skip], ys[::skip], indexing='xy')
+    Ux = field[::skip, ::skip, 0]
+    Uy = field[::skip, ::skip, 1]
+    # mask walls
+    mask = (occ[::skip, ::skip] == 0)
+    Ux = np.where(mask, Ux, 0)
+    Uy = np.where(mask, Uy, 0)
+    ax.quiver(Xs, Ys, Ux, Uy, color='red', alpha=0.85, scale=20)
+    ax.set_xlabel('x [m]')
+    ax.set_ylabel('y [m]')
+    ax.set_title(f"GADEN map='{args.map}' — mean|U|={speed[free_mask].mean():.3f}, "
+                 f"speed_std={speed[free_mask].std():.3f}, dir_std={circ_std:.2f} rad")
+    ax.set_aspect('equal')
+
+    out = args.out or os.path.join(DATA_ROOT, f'gaden_{args.map}_wind.png')
+    plt.savefig(out, dpi=120, bbox_inches='tight')
+    print(f"Saved {out}")
+
+
+if __name__ == '__main__':
+    main()

--- a/cfd_wind_pipeline/viz/viz_library.py
+++ b/cfd_wind_pipeline/viz/viz_library.py
@@ -1,0 +1,113 @@
+"""Contact sheet visualization of CFD wind library cases.
+
+Renders a grid of N×M panels, each showing one case's walls + wind quiver.
+Use to spot-check the library after a build run.
+
+Usage:
+    python viz/viz_library.py --library-dir $CFD_DATA_ROOT/library_v1
+    python viz/viz_library.py --library-dir $CFD_DATA_ROOT/library_v1 \\
+        --max-cases 24 --cols 6 --out /tmp/library_sheet.png
+"""
+import argparse
+import json
+from pathlib import Path
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def plot_one(ax, case_dir: Path):
+    """Draw walls + wind quiver for a single case on the given axis."""
+    try:
+        wind = np.load(case_dir / 'wind_field.npz')
+        grid = np.load(case_dir / 'grid.npz')
+    except FileNotFoundError:
+        ax.text(0.5, 0.5, f'{case_dir.name}\n(no data)', ha='center', va='center',
+                transform=ax.transAxes, color='red')
+        ax.set_xticks([]); ax.set_yticks([])
+        return
+    field = wind['field']
+    cell = float(wind['cell_size'])
+    occ = grid['grid']
+    H, W = field.shape[:2]
+    speed = np.linalg.norm(field, axis=-1)
+
+    ax.imshow(occ, origin='lower', extent=(0, W*cell, 0, H*cell),
+              cmap='Greys', alpha=0.65, vmin=0, vmax=2)
+    ax.imshow(speed, origin='lower', extent=(0, W*cell, 0, H*cell),
+              cmap='viridis', alpha=0.45, vmin=0, vmax=max(0.1, speed.max()))
+    skip = max(1, H // 18)
+    xs = (np.arange(W) + 0.5) * cell
+    ys = (np.arange(H) + 0.5) * cell
+    Xs, Ys = np.meshgrid(xs[::skip], ys[::skip], indexing='xy')
+    Ux = field[::skip, ::skip, 0]
+    Uy = field[::skip, ::skip, 1]
+    ax.quiver(Xs, Ys, Ux, Uy, color='red', alpha=0.85, scale=18, width=0.005)
+    ax.set_aspect('equal')
+    ax.set_xticks([]); ax.set_yticks([])
+    mean_u = speed[occ == 0].mean()
+    title = f"{case_dir.name}  |U|={mean_u:.2f}"
+    ax.set_title(title, fontsize=8)
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--library-dir', required=True)
+    p.add_argument('--max-cases', type=int, default=24,
+                   help='Cap on cases to show (default 24)')
+    p.add_argument('--cols', type=int, default=4)
+    p.add_argument('--out', default=None,
+                   help='Output png (default: <library-dir>/library_contact_sheet.png)')
+    p.add_argument('--only-complete', action='store_true', default=True,
+                   help='Skip cases without wind_field.npz (default true)')
+    args = p.parse_args()
+
+    lib = Path(args.library_dir)
+    manifest_path = lib / 'manifest.json'
+    if not manifest_path.exists():
+        raise FileNotFoundError(f"No manifest.json at {lib}")
+    manifest = json.loads(manifest_path.read_text())
+
+    # Filter to completed cases (with wind_field.npz)
+    cases = []
+    for entry in manifest:
+        cd = Path(entry['case_dir'])
+        if args.only_complete and not (cd / 'wind_field.npz').exists():
+            continue
+        cases.append(cd)
+        if len(cases) >= args.max_cases:
+            break
+
+    if not cases:
+        print(f"No completed cases found in {lib}")
+        return
+
+    n = len(cases)
+    cols = args.cols
+    rows = (n + cols - 1) // cols
+    fig, axes = plt.subplots(rows, cols, figsize=(cols * 4, rows * 3))
+    if rows * cols == 1:
+        axes = np.array([[axes]])
+    elif rows == 1:
+        axes = axes.reshape(1, -1)
+    elif cols == 1:
+        axes = axes.reshape(-1, 1)
+    for ax in axes.flat:
+        ax.set_xticks([]); ax.set_yticks([])
+        for spine in ax.spines.values():
+            spine.set_visible(False)
+    for i, cd in enumerate(cases):
+        r, c = i // cols, i % cols
+        plot_one(axes[r, c], cd)
+
+    fig.suptitle(f"{lib.name} — {n} cases", fontsize=12)
+    fig.tight_layout(rect=(0, 0, 1, 0.98))
+    out = args.out or str(lib / 'library_contact_sheet.png')
+    plt.savefig(out, dpi=110, bbox_inches='tight')
+    print(f"Saved {out} ({n} cases, {rows}×{cols})")
+
+
+if __name__ == '__main__':
+    main()

--- a/cfd_wind_pipeline/viz/viz_placements.py
+++ b/cfd_wind_pipeline/viz/viz_placements.py
@@ -1,0 +1,122 @@
+"""Generate a contact sheet of procedural maps with their inlet/outlet placements
+so the user can review the placement strategy BEFORE running CFD."""
+import argparse
+import sys
+from pathlib import Path
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.patches as mpatches
+import matplotlib.pyplot as plt
+import numpy as np
+import os
+
+# Add parent dir to path so we can import placement, gen_case, config
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+from config import DATA_ROOT
+from placement import sample_map_with_openings
+from gen_case import punch_openings
+
+
+def plot_one(ax, map_data, openings, title, wall_thick_m=0.6):
+    grid = np.array(map_data['grid'].grid, dtype=np.int8)
+    cell = map_data['grid'].resolution
+    map_w = map_data['width']; map_h = map_data['height']
+    # Apply the punch so viz shows the POST-PUNCH state
+    wall_thick_cells = max(1, int(round(wall_thick_m / cell)))
+    openings_dict = {'west': [], 'east': [], 'south': [], 'north': []}
+    for o in openings:
+        openings_dict[o.side].append((o.lo, o.hi))
+    punch_openings(grid, cell, wall_thick_cells, openings_dict)
+    ax.imshow(grid, origin='lower', extent=(0, map_w, 0, map_h),
+              cmap='Greys', alpha=0.7, vmin=0, vmax=2)
+    # Map boundary
+    ax.add_patch(mpatches.Rectangle((0, 0), map_w, map_h, fill=False,
+                                     edgecolor='black', linewidth=0.5))
+    # Source + robot
+    sx, sy = map_data['source_pos']; rx, ry = map_data['robot_pos']
+    ax.scatter([sx], [sy], c='lime', s=40, marker='*', zorder=5,
+               edgecolors='black', linewidth=0.5, label='source')
+    ax.scatter([rx], [ry], c='cyan', s=30, marker='s', zorder=5,
+               edgecolors='black', linewidth=0.5, label='robot')
+    # Openings — draw as outlined rectangles (so we don't obscure the punched-out region)
+    for o in openings:
+        color = 'blue' if o.role == 'inlet' else 'red'
+        if o.side == 'west':
+            ax.add_patch(mpatches.Rectangle((0, o.lo), wall_thick_m, o.hi-o.lo,
+                                              fill=False, edgecolor=color, linewidth=2.0))
+            cx, cy = wall_thick_m, 0.5*(o.lo+o.hi)
+            dx = 0.8 if o.role == 'inlet' else -0.6
+            ax.arrow(cx, cy, dx, 0, head_width=0.35, head_length=0.25,
+                     fc=color, ec=color, alpha=0.95, linewidth=2)
+        elif o.side == 'east':
+            ax.add_patch(mpatches.Rectangle((map_w-wall_thick_m, o.lo), wall_thick_m, o.hi-o.lo,
+                                              fill=False, edgecolor=color, linewidth=2.0))
+            cx, cy = map_w-wall_thick_m, 0.5*(o.lo+o.hi)
+            dx = -0.8 if o.role == 'inlet' else 0.6
+            ax.arrow(cx, cy, dx, 0, head_width=0.35, head_length=0.25,
+                     fc=color, ec=color, alpha=0.95, linewidth=2)
+        elif o.side == 'south':
+            ax.add_patch(mpatches.Rectangle((o.lo, 0), o.hi-o.lo, wall_thick_m,
+                                              fill=False, edgecolor=color, linewidth=2.0))
+            cx, cy = 0.5*(o.lo+o.hi), wall_thick_m
+            dy = 0.8 if o.role == 'inlet' else -0.6
+            ax.arrow(cx, cy, 0, dy, head_width=0.35, head_length=0.25,
+                     fc=color, ec=color, alpha=0.95, linewidth=2)
+        else:  # north
+            ax.add_patch(mpatches.Rectangle((o.lo, map_h-wall_thick_m), o.hi-o.lo, wall_thick_m,
+                                              fill=False, edgecolor=color, linewidth=2.0))
+            cx, cy = 0.5*(o.lo+o.hi), map_h-wall_thick_m
+            dy = -0.8 if o.role == 'inlet' else 0.6
+            ax.arrow(cx, cy, 0, dy, head_width=0.35, head_length=0.25,
+                     fc=color, ec=color, alpha=0.95, linewidth=2)
+    ax.set_xlim(-1, map_w + 1)
+    ax.set_ylim(-1, map_h + 1)
+    ax.set_aspect('equal')
+    ax.set_title(title, fontsize=8)
+    ax.set_xticks([]); ax.set_yticks([])
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--n-maps', type=int, default=40)
+    p.add_argument('--cols', type=int, default=5)
+    p.add_argument('--templates', type=int, nargs='+', default=[2, 3, 4, 5, 6, 7, 8, 9])
+    p.add_argument('--seed-start', type=int, default=1000)
+    p.add_argument('--out', default=os.path.join(DATA_ROOT, 'placement_contact_sheet.png'))
+    args = p.parse_args()
+
+    samples = []
+    rng = np.random.default_rng(0)
+    attempts = 0
+    while len(samples) < args.n_maps and attempts < args.n_maps * 4:
+        seed = args.seed_start + attempts
+        template_id = int(rng.choice(args.templates))
+        map_data, ops = sample_map_with_openings(template_id, seed)
+        attempts += 1
+        if map_data is None:
+            continue
+        samples.append((template_id, seed, map_data, ops))
+
+    print(f"Got {len(samples)} valid placements in {attempts} attempts "
+          f"(reject rate {100*(1-len(samples)/attempts):.1f}%)")
+
+    rows = (len(samples) + args.cols - 1) // args.cols
+    fig, axes = plt.subplots(rows, args.cols, figsize=(args.cols * 3.5, rows * 2.8))
+    axes = np.atleast_2d(axes)
+    for idx, (tid, seed, map_data, ops) in enumerate(samples):
+        r, c = idx // args.cols, idx % args.cols
+        n_in = sum(1 for o in ops if o.role == 'inlet')
+        n_out = sum(1 for o in ops if o.role == 'outlet')
+        title = f"T{tid} seed={seed} ({n_in}in/{n_out}out)"
+        plot_one(axes[r, c], map_data, ops, title)
+    for idx in range(len(samples), rows * args.cols):
+        r, c = idx // args.cols, idx % args.cols
+        axes[r, c].axis('off')
+    plt.tight_layout()
+    plt.savefig(args.out, dpi=130, bbox_inches='tight')
+    print(f"Saved {args.out}")
+
+
+if __name__ == '__main__':
+    main()

--- a/cfd_wind_pipeline/viz/viz_robot_scenario.py
+++ b/cfd_wind_pipeline/viz/viz_robot_scenario.py
@@ -1,0 +1,129 @@
+"""Visualize ONE scenario as the env sets it up: geometry, source/robot,
+the spatial wind field that drives the plume, the gas plume after warmup,
+AND the single scalar wind vector the policy actually observes.
+
+Makes the 'spatial wind drives advection but policy sees only the mean'
+distinction concrete.
+
+Usage:
+    python viz/viz_robot_scenario.py --case-dir <case> \\
+        --rl-package-path <rl-pkg> [--out scenario.png]
+"""
+import argparse
+import os
+import sys
+from pathlib import Path
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--case-dir', required=True)
+    p.add_argument('--rl-package-path', required=True)
+    p.add_argument('--out', default=None)
+    p.add_argument('--seed', type=int, default=0)
+    args = p.parse_args()
+
+    cfd_pkg = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    for path in (cfd_pkg, args.rl_package_path):
+        if path not in sys.path:
+            sys.path.insert(0, path)
+    from cfd_library_loader import load_cfd_case
+    from reinforcement_learning.envs.gas_source_env import GasSourceEnv
+
+    case = load_cfd_case(args.case_dir, args.rl_package_path)
+    md, wf = case['map_data'], case['wind_field']
+
+    env = GasSourceEnv()
+    obs, info = env.reset(seed=args.seed,
+                          options={'map_data': md, 'wind_field': wf})
+
+    occ = md['grid'].grid
+    cell = md['grid'].resolution
+    H, W = occ.shape
+    src = env._source_pos
+    robot = env._robot_pos
+
+    # Spatial wind field (drives advection)
+    field = wf.field
+    speed = np.linalg.norm(field, axis=-1)
+
+    # What the policy observes: get_local_wind at robot (decoded back to m/s)
+    enc = env._wind.get_local_wind(robot)          # in [0,1], (Ux,Uy)
+    ms = env._wind._max_speed_uniform
+    obs_uv = (np.array(enc) * 2.0 - 1.0) * ms       # decode to m/s
+    sm_speed, sm_dir = wf.spatial_mean()
+
+    # Gas plume after warmup
+    try:
+        fdict = env._plume.get_all_filaments()
+        filaments = np.asarray(fdict['positions']) if isinstance(fdict, dict) else None
+    except Exception:
+        filaments = None
+
+    fig, axes = plt.subplots(1, 2, figsize=(20, 7))
+
+    # --- Left: spatial wind field (what drives the plume) ---
+    ax = axes[0]
+    ax.imshow(occ, origin='lower', extent=(0, W*cell, 0, H*cell),
+              cmap='Greys', alpha=0.7, vmin=0, vmax=2)
+    im = ax.imshow(speed, origin='lower', extent=(0, W*cell, 0, H*cell),
+                   cmap='viridis', alpha=0.45, vmin=0, vmax=max(0.1, speed.max()))
+    plt.colorbar(im, ax=ax, label='|U| [m/s]')
+    skip = max(1, H // 25)
+    xs = (np.arange(W) + 0.5) * cell
+    ys = (np.arange(H) + 0.5) * cell
+    Xs, Ys = np.meshgrid(xs[::skip], ys[::skip], indexing='xy')
+    ax.quiver(Xs, Ys, field[::skip, ::skip, 0], field[::skip, ::skip, 1],
+              color='white', alpha=0.8, scale=20, width=0.004)
+    ax.plot(*src, 'r*', ms=22, label='source')
+    ax.plot(*robot, 'co', ms=14, mec='k', label='robot')
+    ax.set_title(f"SPATIAL wind field (drives plume advection)\n"
+                 f"mean|U|={speed[occ==0].mean():.2f}  max={speed.max():.2f} m/s",
+                 fontsize=12)
+    ax.set_xlabel('x [m]'); ax.set_ylabel('y [m]'); ax.set_aspect('equal')
+    ax.legend(loc='upper right')
+
+    # --- Right: what the POLICY observes ---
+    ax = axes[1]
+    ax.imshow(occ, origin='lower', extent=(0, W*cell, 0, H*cell),
+              cmap='Greys', alpha=0.7, vmin=0, vmax=2)
+    if filaments is not None and len(filaments) > 0:
+        fil = np.asarray(filaments)
+        ax.scatter(fil[:, 0], fil[:, 1], s=6, c='limegreen', alpha=0.5,
+                   label=f'gas filaments (n={len(fil)})')
+    ax.plot(*src, 'r*', ms=22, label='source')
+    ax.plot(*robot, 'co', ms=14, mec='k', label='robot')
+    # The single wind vector the policy sees, drawn at robot
+    obs_speed = np.linalg.norm(obs_uv)
+    arrow_scale = max(W, H) * 0.12
+    ax.annotate('', xy=(robot[0] + obs_uv[0]*arrow_scale,
+                        robot[1] + obs_uv[1]*arrow_scale),
+                xytext=(robot[0], robot[1]),
+                arrowprops=dict(facecolor='orange', edgecolor='k', width=4,
+                                headwidth=16))
+    ax.set_title(f"What the POLICY observes\n"
+                 f"single wind vector = spatial MEAN: "
+                 f"speed={sm_speed:.2f} m/s @ {np.rad2deg(sm_dir):+.0f}°  "
+                 f"(constant everywhere, all episode)", fontsize=12)
+    ax.set_xlabel('x [m]'); ax.set_ylabel('y [m]'); ax.set_aspect('equal')
+    ax.legend(loc='upper right')
+
+    fig.suptitle(f"{Path(args.case_dir).name}  |  template={case['meta']['template_id']}  "
+                 f"inlet={case['meta']['inlet_speed']:.2f} m/s  "
+                 f"map={md['width']:.1f}×{md['height']:.1f} m", fontsize=14)
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    out = args.out or str(Path(args.case_dir) / 'robot_scenario.png')
+    plt.savefig(out, dpi=110, bbox_inches='tight')
+    print(f"Saved {out}")
+    print(f"Spatial field: mean|U|={speed[occ==0].mean():.3f}, max={speed.max():.3f}")
+    print(f"Policy observes: speed={sm_speed:.3f} m/s @ {np.rad2deg(sm_dir):+.1f}° (the mean)")
+    print(f"  decoded obs wind vector at robot: ({obs_uv[0]:+.3f}, {obs_uv[1]:+.3f}) m/s")
+
+
+if __name__ == '__main__':
+    main()

--- a/cfd_wind_pipeline/viz/viz_wind.py
+++ b/cfd_wind_pipeline/viz/viz_wind.py
@@ -1,0 +1,55 @@
+"""Visualize the extracted wind field as a quiver plot over the map."""
+import argparse
+from pathlib import Path
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import numpy as np
+
+
+def main():
+    p = argparse.ArgumentParser()
+    p.add_argument('--case-dir', required=True)
+    p.add_argument('--out', default=None)
+    args = p.parse_args()
+
+    case = Path(args.case_dir)
+    wind = np.load(case / 'wind_field.npz')
+    grid = np.load(case / 'grid.npz')
+    field = wind['field']  # (H, W, 2)
+    cell = float(wind['cell_size'])
+    occ = grid['grid']  # (H, W)
+    H, W = field.shape[:2]
+    print(f"field shape: {field.shape}, cell={cell}, H={H} W={W}")
+
+    fig, ax = plt.subplots(figsize=(12, 8))
+    # Walls
+    ax.imshow(occ, origin='lower', extent=(0, W*cell, 0, H*cell),
+              cmap='Greys', alpha=0.6, vmin=0, vmax=2)
+    # Wind speed magnitude as background
+    speed = np.linalg.norm(field, axis=-1)
+    im = ax.imshow(speed, origin='lower', extent=(0, W*cell, 0, H*cell),
+                   cmap='viridis', alpha=0.5, vmin=0, vmax=max(0.1, speed.max()))
+    plt.colorbar(im, ax=ax, label='|U| [m/s]')
+    # Quiver — subsample for clarity
+    skip = max(1, H // 30)
+    xs = (np.arange(W) + 0.5) * cell
+    ys = (np.arange(H) + 0.5) * cell
+    Xs, Ys = np.meshgrid(xs[::skip], ys[::skip], indexing='xy')
+    Ux = field[::skip, ::skip, 0]
+    Uy = field[::skip, ::skip, 1]
+    ax.quiver(Xs, Ys, Ux, Uy, color='red', alpha=0.85, scale=20)
+    ax.set_xlabel('x [m]')
+    ax.set_ylabel('y [m]')
+    ax.set_title(f"Wind field — case={case.name}, mean|U|={speed[occ==0].mean():.3f} m/s, "
+                 f"std={speed[occ==0].std():.3f}")
+    ax.set_aspect('equal')
+
+    out = args.out or str(case / 'wind_viz.png')
+    plt.savefig(out, dpi=120, bbox_inches='tight')
+    print(f"Saved {out}")
+
+
+if __name__ == '__main__':
+    main()

--- a/rl_5_channel/test/visualize_gaden_trajectories.py
+++ b/rl_5_channel/test/visualize_gaden_trajectories.py
@@ -78,15 +78,38 @@ def greedy_action(agent, spatial_t, wind_t):
         return dist.mean.cpu().numpy()
 
 
-def rollout(agent, full_map, episode_seed, device):
-    """Run one greedy episode, return (success, total_return, trajectory)."""
+def _patch_local_wind_ctx(env, wind_field):
+    """Rewrite the policy ctx wind from the local cell wind at the robot's
+    position. Returns the rebuilt wind ctx vector. Diagnostic for the
+    ctx-vs-local mismatch on real CFD wind fields."""
+    rob = env._env._robot_pos
+    local = wind_field.query(np.asarray([rob]))[0]
+    spd = float(np.hypot(local[0], local[1]))
+    dirn = float(np.arctan2(local[1], local[0]))
+    env._env._wind.set_uniform(spd, dirn)
+    time_frac = env._env._current_step / cfg.MAX_STEPS
+    return np.array([*env._env._wind.get_observation_spatial(), time_frac],
+                    dtype=np.float32)
+
+
+def rollout(agent, full_map, episode_seed, device, ctx_mode="mean"):
+    """Run one greedy episode, return (success, total_return, trajectory).
+
+    ctx_mode:
+      "mean"  — policy ctx wind = field's spatial mean (default; matches eval)
+      "local" — policy ctx wind = wind at the robot's current cell (diagnostic)
+    """
     map_data = {k: full_map[k] for k in ("grid", "source_pos", "robot_pos",
                                           "width", "height")}
+    wind_field = full_map["wind_field"]
     env = SpatialObsWrapper(GasSourceEnv())
     (spatial, wind), _ = env.reset(
         seed=episode_seed,
-        options={"map_data": map_data, "wind_field": full_map["wind_field"]},
+        options={"map_data": map_data, "wind_field": wind_field},
     )
+    if ctx_mode == "local":
+        wind = _patch_local_wind_ctx(env, wind_field)
+
     total_return = 0.0
     success = False
     while True:
@@ -95,6 +118,8 @@ def rollout(agent, full_map, episode_seed, device):
         action = greedy_action(agent, spatial_t, wind_t)[0]
         (spatial, wind), reward, terminated, truncated, _ = env.step(action)
         total_return += reward
+        if ctx_mode == "local":
+            wind = _patch_local_wind_ctx(env, wind_field)
         if terminated:
             success = True
             break
@@ -118,7 +143,8 @@ def _draw_gradient_line(ax, traj: np.ndarray, cmap_name: str, alpha: float):
 
 
 def visualize_one_map(agent, full_map, key: str, n_eps: int, device,
-                      out_path: Path, quiver_stride: int = 10) -> dict:
+                      out_path: Path, quiver_stride: int = 10,
+                      ctx_mode: str = "mean") -> dict:
     grid_arr = full_map["grid"].grid
     res      = full_map["grid"].resolution
     H, W     = grid_arr.shape
@@ -145,7 +171,7 @@ def visualize_one_map(agent, full_map, key: str, n_eps: int, device,
     lengths   = []
     for ei in range(n_eps):
         seed = 1000 * hash(key) % 100000 + ei
-        succ, ret, traj = rollout(agent, full_map, seed, device)
+        succ, ret, traj = rollout(agent, full_map, seed, device, ctx_mode=ctx_mode)
         successes.append(succ)
         rewards.append(ret)
         lengths.append(len(traj))
@@ -194,6 +220,8 @@ def main():
     parser.add_argument("--output-dir",       type=Path, default=None,
                         help="Defaults to test/gaden_trajectories/<run-name>/")
     parser.add_argument("--device",           type=str, default=None)
+    parser.add_argument("--ctx-mode",         choices=["mean", "local"], default="mean",
+                        help="Policy ctx wind: spatial mean (default) or local cell at robot.")
     args = parser.parse_args()
 
     device = torch.device(args.device or ("cuda" if torch.cuda.is_available() else "cpu"))
@@ -212,7 +240,9 @@ def main():
 
     agent = load_agent(ckpt, device)
 
-    out_root = args.output_dir or (_DEFAULT_OUT_ROOT / run_dir.name)
+    print(f"Ctx mode:   {args.ctx_mode}")
+    suffix = "" if args.ctx_mode == "mean" else f"_ctx-{args.ctx_mode}"
+    out_root = args.output_dir or (_DEFAULT_OUT_ROOT / (run_dir.name + suffix))
     print(f"Output:     {out_root}")
 
     yaml_path = args.gaden_root / "recommended_configs.yaml"
@@ -220,7 +250,8 @@ def main():
         full_map = load_full_map(args.gaden_root, yaml_path, key)
         out_path = out_root / f"{key}.png"
         stats = visualize_one_map(agent, full_map, key,
-                                  args.episodes_per_map, device, out_path)
+                                  args.episodes_per_map, device, out_path,
+                                  ctx_mode=args.ctx_mode)
         ok = sum(stats["successes"])
         print(f"  {key:18s}  {ok}/{args.episodes_per_map} success  "
               f"mean steps={np.mean(stats['lengths']):.0f}  "

--- a/rl_cfd/envs/spatial_obs_wrapper.py
+++ b/rl_cfd/envs/spatial_obs_wrapper.py
@@ -299,6 +299,14 @@ class SpatialObsWrapper:
 
         spatial = np.stack([known, wall, gas, rec, det, motion], axis=0)  # (6, 98, 98)
         time_frac = self._env._current_step / cfg.MAX_STEPS
-        wind = np.array([*self._env._wind.get_observation_spatial(), time_frac],
-                        dtype=np.float32)                                  # (4,)
+        # Local-cell ctx: query the wind field at the robot's current cell so
+        # training and deployment share the same ctx semantics. Eliminates the
+        # ctx-vs-local mismatch on real CFD wind fields where the spatial mean
+        # diverges sharply from local wind direction (see
+        # docs/notes on the GADEN-eval ctx investigation).
+        wind = np.array(
+            [*self._env._wind.get_observation_spatial_at(self._env._robot_pos),
+             time_frac],
+            dtype=np.float32,
+        )                                                                  # (4,)
         return spatial, wind

--- a/rl_cfd/envs/wind_field.py
+++ b/rl_cfd/envs/wind_field.py
@@ -168,6 +168,24 @@ class WindField:
         s, d = self._ctx_speed_dir()
         return (s / self.max_speed, float(np.cos(d)), float(np.sin(d)))
 
+    def get_observation_spatial_at(self, position):
+        """Local-cell ctx: return (speed/max, cos, sin) at a world position.
+
+        Used by the spatial obs wrapper so the policy ctx reflects the wind
+        the agent actually experiences at its current cell, not a global
+        summary. This couples ctx semantics between training (local) and
+        deployment (also local, queried from the GADEN field), eliminating
+        the ctx-vs-local mismatch we observed on real CFD wind fields.
+        """
+        local = self.local_batch(np.asarray([position], dtype=np.float64))[0]
+        spd = float(np.hypot(local[0], local[1]))
+        if spd > 1e-8:
+            return (spd / self.max_speed,
+                    float(local[0]) / spd,
+                    float(local[1]) / spd)
+        # Degenerate cell (wall or zero wind): return zero-magnitude ctx.
+        return (0.0, 1.0, 0.0)
+
     def get_dispersion_offset(self, dispersion_factor: float):
         s, d = self._ctx_speed_dir()
         dx = s * dispersion_factor * np.cos(d)

--- a/rl_cfd/test/gaden_loader.py
+++ b/rl_cfd/test/gaden_loader.py
@@ -326,6 +326,16 @@ class GadenWindField:
                 float(np.cos(self.direction)),
                 float(np.sin(self.direction)))
 
+    def get_observation_spatial_at(self, position):
+        """Local-cell ctx at a world position. Mirrors WindField.get_observation_spatial_at."""
+        local = self.query(np.asarray([position], dtype=np.float64))[0]
+        spd = float(np.hypot(local[0], local[1]))
+        if spd > 1e-8:
+            return (spd / self.max_speed,
+                    float(local[0]) / spd,
+                    float(local[1]) / spd)
+        return (0.0, 1.0, 0.0)
+
     def get_dispersion_offset(self, dispersion_factor: float):
         s, d = self.speed, self.direction
         return np.array([s * dispersion_factor * np.cos(d),

--- a/rl_cfd/train_cfd_rebalanced.sh
+++ b/rl_cfd/train_cfd_rebalanced.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+# Run B: same as train_cfd.sh (local-cell wind ctx) plus rebalanced rewards.
+# A/B comparison vs train_cfd.sh — both should be launched from the same
+# code state so only the reward profile differs.
+#
+# Reward profile:
+#   R_SUCCESS    15.0    (was 200)   — terminal bonus 5× the next-largest, doesn't dominate variance
+#   R_COLLISION  -3.0    (was -10)   — rebalanced to the new success scale
+#   R_MAX_STEPS  -3.0    (was -20)   — same
+#   R_NEW_CELL   0.05    (was 0.2)   — coverage:step ratio 1:1, no Goodhart farming
+#   R_STEP       -0.05   (was -0.1)
+#   R_DETECTION  0.1     (was 0.2)   — keep relative pressure
+#SBATCH --job-name=ppo_cfd_rb
+#SBATCH --nodes=1
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=12
+#SBATCH --mem=32G
+#SBATCH --gres=gpu:1
+#SBATCH --time=72:0:0
+#SBATCH --partition=batch
+#SBATCH --qos=users
+#SBATCH --account=users
+#SBATCH --output=/comp04-storage/efe-mantaroglu/osl/base/rl_cfd/runs/slurm-%j.out
+
+set -euo pipefail
+cd /comp04-storage/efe-mantaroglu/osl
+
+RUN_NAME="ppo_cfd_rebalanced_$(date +%Y%m%d_%H%M%S)_job${SLURM_JOB_ID:-local}"
+OUT_DIR="base/rl_cfd/runs/${RUN_NAME}"
+mkdir -p "${OUT_DIR}"
+
+VENV_PY=/home/efe-mantaroglu/simenv/bin/python
+
+${VENV_PY} -u -m base.rl_cfd.training.train \
+    --arch spatial \
+    --batched-obs \
+    --num-envs 48 \
+    --rollout-length 1024 \
+    --entropy-coeff 0.02 \
+    --entropy-coeff-end 0.005 \
+    --target-kl 0.02 \
+    --r-success 15.0 \
+    --r-collision -3.0 \
+    --r-max-steps -3.0 \
+    --r-new-cell 0.05 \
+    --r-step -0.05 \
+    --r-detection 0.1 \
+    --output-dir "${OUT_DIR}"

--- a/rl_cfd/training/train.py
+++ b/rl_cfd/training/train.py
@@ -294,7 +294,7 @@ def _thin_worker(child_conn, parent_conn, env_fn):
     def _state_snapshot(reward, done, info):
         snap = {
             "robot_pos": np.asarray(env._robot_pos, dtype=np.float32),
-            "wind_raw":  np.asarray(env._wind.get_observation_spatial(), dtype=np.float32),
+            "wind_raw":  np.asarray(env._wind.get_observation_spatial_at(env._robot_pos), dtype=np.float32),
             "step":      int(env._current_step),
             "gas":       bool(info.get("gas_reading", 0)) if info else False,
             "reward":    float(reward),
@@ -461,6 +461,18 @@ def get_template_curriculum(progress):
 def train(args):
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
     print(f"Device: {device}")
+
+    # Reward overrides — must be set BEFORE any env/worker is constructed,
+    # so forked workers inherit the patched cfg values.
+    cfg.R_SUCCESS    = float(args.r_success)
+    cfg.R_STEP       = float(args.r_step)
+    cfg.R_NEW_CELL   = float(args.r_new_cell)
+    cfg.R_COLLISION  = float(args.r_collision)
+    cfg.R_MAX_STEPS  = float(args.r_max_steps)
+    cfg.R_DETECTION  = float(args.r_detection)
+    print(f"Rewards: success={cfg.R_SUCCESS}  step={cfg.R_STEP}  "
+          f"new_cell={cfg.R_NEW_CELL}  collision={cfg.R_COLLISION}  "
+          f"max_steps={cfg.R_MAX_STEPS}  detection={cfg.R_DETECTION}")
 
     # Seeding
     np.random.seed(args.seed)
@@ -864,6 +876,14 @@ def main():
                         help="KL early stopping threshold (e.g. 0.03). None = disabled")
     parser.add_argument("--curriculum", action="store_true", default=False,
                         help="Enable room size curriculum (small → large)")
+
+    # Reward shaping (override cfg defaults — used for A/B-ing reward profiles)
+    parser.add_argument("--r-success",   type=float, default=cfg.R_SUCCESS)
+    parser.add_argument("--r-step",      type=float, default=cfg.R_STEP)
+    parser.add_argument("--r-new-cell",  type=float, default=cfg.R_NEW_CELL)
+    parser.add_argument("--r-collision", type=float, default=cfg.R_COLLISION)
+    parser.add_argument("--r-max-steps", type=float, default=cfg.R_MAX_STEPS)
+    parser.add_argument("--r-detection", type=float, default=cfg.R_DETECTION)
 
     # Resume
     parser.add_argument("--resume", type=str, default=None,


### PR DESCRIPTION
Adds a self-contained CFD wind-field pipeline (new `cfd_wind_pipeline/`) plus
training-side hooks in `rl_cfd`.

What's included
- OpenFOAM case generation for procedural maps (gen_case, gen_case_from_gaden,
  mesh pruning, door parsing, source placement)
- Library orchestrator + SLURM array runner (run_array/run_case/run_smoke),
  with CFD_ARRAY_OFFSET to handle libraries >1000 cases (MaxArraySize cap)
- Wind extraction + library loader/stats, training integration
  (train_with_cfd_library)
- Local-wind obs with multi-direction / template-filter sampler; experiment log
- rl_cfd: local-cell wind ctx + reward CLI overrides; rl_5_channel:
  --ctx-mode {mean,local} in the trajectory visualizer

Diff: 30 files, +3193/-10 (mostly new files). No conflicts with main.
Note: branch is 30 commits behind main; PR diff is clean (3-dot) and mergeable.
