### PR TITLE
feat: add OSL benchmark framework

### DIFF
--- a/adsm/CMakeLists.txt
+++ b/adsm/CMakeLists.txt
@@ -6,6 +6,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
 endif()
 
 find_package(ament_cmake REQUIRED)
+find_package(ament_cmake_python REQUIRED)
+find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+find_package(pybind11 REQUIRED)
 find_package(rclcpp REQUIRED)
 find_package(rclcpp_action REQUIRED)
 find_package(nav_msgs REQUIRED)
@@ -25,6 +28,17 @@ add_executable(adsm_node
   src/gridmap.cpp
   src/rrt_sampler.cpp
 )
+
+add_library(adsm_engine STATIC src/engine.cpp)
+set_target_properties(adsm_engine PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_include_directories(adsm_engine PUBLIC
+  $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+  $<INSTALL_INTERFACE:include>
+)
+
+pybind11_add_module(adsm_core_py src/python_bindings.cpp)
+target_link_libraries(adsm_core_py PRIVATE adsm_engine)
+target_include_directories(adsm_core_py PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
 target_include_directories(adsm_node PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
@@ -48,6 +62,15 @@ ament_target_dependencies(adsm_node
 install(TARGETS adsm_node
   DESTINATION lib/${PROJECT_NAME}
 )
+
+ament_get_python_install_dir(PYTHON_INSTALL_DIR)
+ament_python_install_package(${PROJECT_NAME})
+install(TARGETS adsm_engine
+  ARCHIVE DESTINATION lib
+  LIBRARY DESTINATION lib
+)
+install(TARGETS adsm_core_py LIBRARY DESTINATION ${PYTHON_INSTALL_DIR})
+install(DIRECTORY include/ DESTINATION include)
 
 install(DIRECTORY launch
   DESTINATION share/${PROJECT_NAME}

--- a/adsm/README.md
+++ b/adsm/README.md
@@ -1,0 +1,106 @@
+# ADSM — ROS 2 Humble Port
+
+ROS 2 Humble port of the [An Adaptive Robot Search Algorithm for Balancing Exploitation and Exploration in Indoor Intermittent Source Seeking](https://ieeexplore.ieee.org/document/11297772/) by Wang et al. (IEEE TIE, 2025).
+
+- **Original ROS 1 Noetic implementation:** [mwanggh/An-adaptive-robot-search-algorithm](https://github.com/mwanggh/An-adaptive-robot-search-algorithm)
+- **DOI:** [10.1109/TIE.2025.3632565](https://doi.org/10.1109/TIE.2025.3632565)
+
+## Changes from the original (ROS 1 → ROS 2)
+
+| Component | Original (ROS 1 Noetic) | This port (ROS 2 Humble) |
+|---|---|---|
+| Build system | catkin / CMake | ament_cmake |
+| ROS node API | `ros::NodeHandle` / `ros::Rate` | `rclcpp::Node` / `rclcpp::Rate` |
+| Logging | `ROS_INFO` / `ROS_ERROR` | `RCLCPP_INFO` / `RCLCPP_ERROR` |
+| Gas sensor | MOX TGS2620 (`sensor_model=0`, resistance) | PID MiniRaeLite (`sensor_model=30`, PPM) |
+| Navigation | `move_base` action (ROS 1) | Nav2 `navigate_to_pose` action (ROS 2) |
+| Pose source | SLAM odom (`/odom`) | Ground truth (`/ground_truth`) |
+| Map source | `/map` from gmapping | Custom Python SLAM + GADEN occupancy service |
+| Launch | XML `.launch` | Python `LaunchDescription` |
+| UUID generation | Boost UUID | Custom `std::random_device` generator |
+| Added features | — | Outlet mask from GADEN 3D occupancy (unused, no algorithmic effect) |
+
+## Equivalence test
+
+A standalone C++ test compares the port's decision math **verbatim** against the original source across 2.3 million randomized inputs:
+
+| Component | Test cases | Mismatches | Result |
+|---|---|---|---|
+| `probability()` — Gaussian plume model (Eq. 3) | 2,000,000 | **0** | Bit-exact |
+| `evaluate()` — fitness + argmax goal selection | 199,769 | **0** | Bit-exact |
+| Angular clustering — N-class bearing split, farthest-per-class | 100,000 | **0** | Bit-exact |
+| Gas binarization — hysteresis thresholding | 200,000 | differs | Documented: MOX → PID sensor conversion |
+
+**Verdict:** The decision core is **bit-exact equivalent** to the original authors' code. The only divergence is the intentional, documented MOX-to-PID gas sensor conversion.
+
+Four shared algorithm files (`frontier_finder.cpp`, `rrt_sampler.cpp`, `goal.cpp`, and the algorithmic body of `adsm.cpp`) differ only in include paths, logging macros, and whitespace — no semantic changes.
+
+### Running the equivalence test
+
+```bash
+cd /tmp/adsm_equiv
+g++ -O2 -o equiv_test equiv_test.cpp -lm
+./equiv_test
+```
+
+## Parameters
+
+All algorithm parameters are identical to the original paper (Section IV-C):
+
+```
+k1=0.2, random_sample_r=3.0, goal_cluster_num=20, obs_r=0.2
+goal_reach_th=0.5, resample_time_th=5.5, sensor_window_length=6.0
+rrt_max_iter=200, rrt_max_r=3.0, rrt_min_r=0.70, rrt_step_size=0.3
+frontier_search_th=3.0, stuck_duration_th=60.0, iter_rate=1.0, max_iter=360
+```
+
+Gas thresholds are re-scaled for the PID sensor:
+
+```
+gas_max=10.0, gas_high_th=0.3, gas_low_th=0.1
+```
+
+## Build
+
+```bash
+cd ~/ros2_ws
+colcon build --packages-select adsm
+```
+
+## Run
+
+```bash
+ros2 launch adsm adsm_launch.py
+```
+
+Or via the benchmark driver:
+
+```bash
+cd ~/ros2_ws
+./run_adsm_eesa_benchmark.sh
+```
+
+## Dependencies
+
+- ROS 2 Humble
+- `rclcpp`, `tf2`, `tf2_geometry_msgs`, `nav_msgs`, `geometry_msgs`
+- `olfaction_msgs` (GADEN sensor messages)
+- `Nav2` (`navigate_to_pose` action server)
+- GADEN player + simulated gas sensor + simulated anemometer
+
+## License
+
+This is a scientific reimplementation of a published algorithm. The original authors' work is cited above; the algorithm specification is publicly available in the IEEE paper. This port is provided for academic comparison and reproducibility.
+
+## Citation
+
+```bibtex
+@ARTICLE{wang2025adaptive,
+  author={Wang, Miao and Xin, Bin and Deng, Fang and Chen, Chen and Qu, Yun},
+  journal={IEEE Transactions on Industrial Electronics},
+  title={An Adaptive Robot Search Algorithm for Balancing Exploitation
+         and Exploration in Indoor Intermittent Source Seeking},
+  year={2025},
+  doi={10.1109/TIE.2025.3632565}
+}
+```

--- a/adsm/adsm/__init__.py
+++ b/adsm/adsm/__init__.py
@@ -1,0 +1,5 @@
+"""Python environment hook package for the compiled ADSM decision engine."""
+
+from adsm_core_py import Config, Decision, Engine
+
+__all__ = ['Config', 'Decision', 'Engine']

--- a/adsm/include/adsm/adsm.h
+++ b/adsm/include/adsm/adsm.h
@@ -15,6 +15,7 @@
 #include <std_msgs/msg/color_rgba.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
+#include <geometry_msgs/msg/pose_stamped.hpp>
 #include <chrono>
 #include <thread>
 #include <fstream>
@@ -68,6 +69,7 @@ private:
     double iter_start_rostime_;
     double iter_rate_;
     int max_iter_;
+    double distance_budget_ = 0.0;   // oracle-derived travel-distance cap, 0.0 = disabled
     double source_x_;
     double source_y_;
     double source_th_;
@@ -93,6 +95,15 @@ private:
     double dis_to_source_ = 0.0;
     std::vector<double> stuck_info_{std::numeric_limits<double>::quiet_NaN(), 0.0, 0.0}; // x, y, last_stuck_time
     double set_random_goal_ = false;
+    // Held random-exploration/stuck-recovery target: without this, evaluate()
+    // re-rolled an independent random goal every 1 Hz tick whenever no better
+    // candidate existed, which out-paces Nav2/DWB's ability to even finish
+    // turning toward one goal before the next replaces it.
+    bool has_random_goal_ = false;
+    double random_goal_x_ = 0.0;
+    double random_goal_y_ = 0.0;
+    double random_goal_set_time_ = 0.0;
+    double random_goal_hold_th_;
     std::string result_ = "";
     std::vector<std::vector<double>> info_log_;
     std::vector<std::vector<double>> targets_log_;
@@ -107,6 +118,12 @@ private:
     rclcpp::Subscription<olfaction_msgs::msg::Anemometer>::SharedPtr anemometer_sub_;
     rclcpp::Subscription<nav_msgs::msg::OccupancyGrid>::SharedPtr external_slam_map_sub_;
     rclcpp_action::Client<NavigateToPose>::SharedPtr nav_client_;
+    // move_base sendGoal() semantics: a new goal retargets the running drive.
+    // Nav2 instead preempts + rebuilds the BT, zeroing velocity every iteration.
+    // When true, retarget via Nav2's GoalUpdater topic instead of re-sending.
+    rclcpp::Publisher<geometry_msgs::msg::PoseStamped>::SharedPtr goal_update_pub_;
+    bool use_goal_update_ = false;
+    bool nav_goal_active_ = false;
     rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr visual_points_pub_;
     rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr visual_lines_pub_;
     rclcpp::Publisher<visualization_msgs::msg::Marker>::SharedPtr visual_text_pub_;
@@ -140,6 +157,7 @@ private:
     double probability(double x, double y);
     bool reached_point(double x, double y);
     void create_random_gaol(double start_x, double start_y, double r, double& goal_x, double& goal_y);
+    void pick_or_hold_random_goal();
     void observe();
     void estimate();
     void evaluate();

--- a/adsm/include/adsm/engine.h
+++ b/adsm/include/adsm/engine.h
@@ -1,0 +1,127 @@
+#pragma once
+
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace adsm_core {
+
+struct Config {
+  double k1 = 0.2;
+  double random_sample_r = 3.0;
+  int goal_cluster_num = 20;
+  double obs_r = 0.2;
+  double goal_reach_th = 0.5;
+  double resample_time_th = 5.5;
+  double gas_high_th = 0.3;
+  double gas_low_th = 0.1;
+  double sensor_window_length = 6.0;
+  double frontier_search_th = 3.0;
+  int rrt_max_iter = 200;
+  double rrt_max_r = 3.0;
+  double rrt_min_r = 0.70;
+  double rrt_step_size = 0.3;
+  double rrt_near_r = 0.5;
+  double stuck_duration_th = 60.0;
+};
+
+struct Grid {
+  int width = 0;
+  int height = 0;
+  double resolution = 0.0;
+  double origin_x = 0.0;
+  double origin_y = 0.0;
+  std::vector<int8_t> data;  // -1 unknown, 0 free, 100 occupied
+
+  bool valid() const;
+  bool worldToMap(double wx, double wy, int &mx, int &my) const;
+  void mapToWorld(int mx, int my, double &wx, double &wy) const;
+  int cost(int mx, int my) const;
+};
+
+struct Input {
+  double x = 0.0;
+  double y = 0.0;
+  double yaw = 0.0;
+  double gas = 0.0;
+  double wind_speed = 0.0;
+  double wind_direction = 0.0;
+  double sim_time = 0.0;
+  Grid map;
+};
+
+struct Decision {
+  double x = 0.0;
+  double y = 0.0;
+  double yaw = 0.0;
+  int goal_type = 2;  // 0 EPI, 1 EPR, 2 random
+  double j = 0.0;
+  double j_p = 0.0;
+  double j_i = 0.0;
+  int iteration = 0;
+  bool gas_hit = false;
+  bool resampled = false;
+  std::size_t epi_size = 0;
+  std::size_t epr_size = 0;
+};
+
+class Engine {
+ public:
+  explicit Engine(const Config &config = Config());
+  void reset(uint32_t seed);
+  Decision step(const Input &input);
+  uint32_t seed() const { return seed_; }
+
+ private:
+  struct RRTNode {
+    double x = 0.0;
+    double y = 0.0;
+    double cost = 0.0;
+    int parent = -1;
+  };
+  struct Goal {
+    int iteration = 0;
+    double x = 0.0;
+    double y = 0.0;
+    int type = 2;
+    double j = 0.0;
+    double j_p = 0.0;
+    double j_i = 0.0;
+    double probability = 0.0;
+    double frontier_size = 0.0;
+  };
+
+  Config cfg_;
+  uint32_t seed_ = 0;
+  int iteration_ = 0;
+  bool initialized_ = false;
+  bool gas_hit_ = false;
+  bool do_sample_again_ = false;
+  bool set_random_goal_ = false;
+  double last_resample_time_ = 0.0;
+  double stuck_x_ = std::numeric_limits<double>::quiet_NaN();
+  double stuck_y_ = 0.0;
+  double stuck_time_ = 0.0;
+  Goal goal_;
+  std::vector<std::pair<double, double>> gas_window_;
+  std::vector<std::pair<double, double>> pose_history_;
+  std::vector<Goal> epi_set_;
+  std::vector<Goal> epr_set_;
+  std::vector<RRTNode> rrt_nodes_;
+
+  double randomUnit();
+  double probability(const Input &in, double x, double y) const;
+  bool reachedPoint(double x, double y) const;
+  bool collisionFree(const Grid &map, double sx, double sy, double ex, double ey) const;
+  std::vector<RRTNode> sampleRRT(const Grid &map, double sx, double sy);
+  std::size_t frontierCount(const Grid &map, double sx, double sy) const;
+  Goal safeRandomGoal(const Input &in, double sx, double sy);
+  void classifyGas(const Input &in);
+  void estimate(const Input &in, bool do_sample);
+  Goal evaluate(const Input &in);
+  void updateStuck(const Input &in);
+};
+
+}  // namespace adsm_core

--- a/adsm/launch/adsm_launch.py
+++ b/adsm/launch/adsm_launch.py
@@ -15,6 +15,9 @@ def generate_launch_description():
         DeclareLaunchArgument('source_th', default_value='0.5'),
         DeclareLaunchArgument('iter_rate', default_value='1.0'),
         DeclareLaunchArgument('max_iter', default_value='200'),
+        # Oracle-derived travel-distance cap (10x an honest straight-shot Nav2
+        # drive to the source). 0.0 = disabled, matches the flat max_iter default.
+        DeclareLaunchArgument('distance_budget', default_value='0.0'),
         DeclareLaunchArgument('data_path', default_value='/tmp/adsm_results'),
         DeclareLaunchArgument('visual', default_value='true'),
         DeclareLaunchArgument('k1', default_value='0.2'),
@@ -27,6 +30,17 @@ def generate_launch_description():
         DeclareLaunchArgument('gas_sensor_topic', default_value='/fake_pid/Sensor_reading'),
         DeclareLaunchArgument('anemometer_topic', default_value='/fake_anemometer/WindSensor_reading'),
         DeclareLaunchArgument('nav_action', default_value='/PioneerP3DX/navigate_to_pose'),
+        # Retarget the running drive via Nav2's GoalUpdater instead of re-sending
+        # the action goal (which preempts + rebuilds the BT every iteration).
+        # Requires a bt_navigator tree containing GoalUpdater. Opt-in because
+        # a standard Nav2 tree has no consumer for the update topic.
+        DeclareLaunchArgument('use_goal_update', default_value='false'),
+        DeclareLaunchArgument('goal_update_topic', default_value='/PioneerP3DX/goal_update'),
+        # 0.0 = original ROS1 behaviour (re-roll the stuck-recovery random
+        # goal every tick). A positive value is a port-only deviation that
+        # A/B-tested worse on House09 (2026-07-16) -- exposed for future
+        # experiments only, not recommended.
+        DeclareLaunchArgument('random_goal_hold_th', default_value='0.0'),
 
         # Python SLAM node (from efe_igdm) — publishes the SLAM OccupancyGrid
         Node(
@@ -54,6 +68,8 @@ def generate_launch_description():
                 'source_th': LaunchConfiguration('source_th'),
                 'iter_rate': LaunchConfiguration('iter_rate'),
                 'max_iter': ParameterValue(LaunchConfiguration('max_iter'), value_type=int),
+                'distance_budget': ParameterValue(
+                    LaunchConfiguration('distance_budget'), value_type=float),
                 'stuck_duration_th': 60.0,
                 'visual': True,
                 'data_path': LaunchConfiguration('data_path'),
@@ -67,6 +83,9 @@ def generate_launch_description():
                 'gas_sensor_topic': LaunchConfiguration('gas_sensor_topic'),
                 'anemometer_topic': LaunchConfiguration('anemometer_topic'),
                 'nav_action': LaunchConfiguration('nav_action'),
+                'use_goal_update': ParameterValue(
+                    LaunchConfiguration('use_goal_update'), value_type=bool),
+                'goal_update_topic': LaunchConfiguration('goal_update_topic'),
 
                 # External SLAM map from Python node
                 'external_slam_map_topic': slam_map_topic,
@@ -88,6 +107,9 @@ def generate_launch_description():
                 'gas_high_th': 0.3,
                 'gas_low_th': 0.1,
                 'sensor_window_length': 6.0,
+
+                'random_goal_hold_th': ParameterValue(
+                    LaunchConfiguration('random_goal_hold_th'), value_type=float),
             }],
         ),
     ])

--- a/adsm/package.xml
+++ b/adsm/package.xml
@@ -8,6 +8,8 @@
   <license>BSD</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>ament_cmake_python</build_depend>
+  <build_depend>pybind11-dev</build_depend>
 
   <depend>rclcpp</depend>
   <depend>rclcpp_action</depend>

--- a/adsm/src/adsm.cpp
+++ b/adsm/src/adsm.cpp
@@ -50,24 +50,34 @@ Adsm::Adsm() : Node("adsm_node") {
     // Run parameters
     this->declare_parameter("iter_rate", 1.0);
     this->declare_parameter("max_iter", 200);
+    this->declare_parameter("distance_budget", 0.0);
     this->declare_parameter("source_x", 0.0);
     this->declare_parameter("source_y", 0.0);
     this->declare_parameter("source_th", 0.5);
     this->declare_parameter("stuck_duration_th", 60.0);
+    // 0.0 = original behaviour (re-roll every 1 Hz tick, per the authors'
+    // ROS1 code). A positive value is a port-only deviation (see adsm.cpp's
+    // pick_or_hold_random_goal doc comment) that A/B-tested worse on
+    // House09 (2026-07-16: 5/5 ROBOT_STUCK, higher estimation error) --
+    // kept parameter-gated for future experiments, not deleted.
+    this->declare_parameter("random_goal_hold_th", 0.0);
     this->declare_parameter("visual", true);
     this->declare_parameter("data_path", "/tmp/adsm_results");
 
     iter_rate_ = this->get_parameter("iter_rate").as_double();
     max_iter_ = this->get_parameter("max_iter").as_int();
+    distance_budget_ = this->get_parameter("distance_budget").as_double();
     source_x_ = this->get_parameter("source_x").as_double();
     source_y_ = this->get_parameter("source_y").as_double();
     source_th_ = this->get_parameter("source_th").as_double();
     stuck_th_ = this->get_parameter("stuck_duration_th").as_double();
+    random_goal_hold_th_ = this->get_parameter("random_goal_hold_th").as_double();
     visual_ = this->get_parameter("visual").as_bool();
     data_path_ = this->get_parameter("data_path").as_string();
     random_run_id_ = generate_uuid();
     data_path_ = data_path_ + '/' + random_run_id_;
-    RCLCPP_INFO(this->get_logger(), "iter_rate %.2f, max_iter %d", iter_rate_, max_iter_);
+    RCLCPP_INFO(this->get_logger(), "iter_rate %.2f, max_iter %d, distance_budget %.2f",
+        iter_rate_, max_iter_, distance_budget_);
     RCLCPP_INFO(this->get_logger(), "source_x %.2f, source_y %.2f", source_x_, source_y_);
 
     // Topic parameters
@@ -77,6 +87,8 @@ Adsm::Adsm() : Node("adsm_node") {
     this->declare_parameter("gas_sensor_topic", "/fake_pid/Sensor_reading");
     this->declare_parameter("anemometer_topic", "/fake_anemometer/WindSensor_reading");
     this->declare_parameter("nav_action", "/PioneerP3DX/navigate_to_pose");
+    this->declare_parameter("use_goal_update", false);
+    this->declare_parameter("goal_update_topic", "/PioneerP3DX/goal_update");
     this->declare_parameter("gaden_occupancy_service", "/gaden_environment/occupancyMap3D");
     this->declare_parameter("z_level", 5);
     this->declare_parameter("external_slam_map_topic", "/slam_node/slam_map");
@@ -117,6 +129,11 @@ Adsm::Adsm() : Node("adsm_node") {
 
     // Create action client
     nav_client_ = rclcpp_action::create_client<NavigateToPose>(this, nav_action);
+    use_goal_update_ = this->get_parameter("use_goal_update").as_bool();
+    if (use_goal_update_) {
+        goal_update_pub_ = this->create_publisher<geometry_msgs::msg::PoseStamped>(
+            this->get_parameter("goal_update_topic").as_string(), 1);
+    }
 
     // Create publishers
     visual_points_pub_ = this->create_publisher<visualization_msgs::msg::Marker>("~/visual_points", 1);
@@ -595,6 +612,46 @@ void Adsm::estimate() {
     RCLCPP_INFO(this->get_logger(), "size: goals_ %zu, epi_set_ %zu, epr_set_ %zu", goals_.size(), epi_set_.size(), epr_set_.size());
 }
 
+void Adsm::pick_or_hold_random_goal() {
+    // random_goal_hold_th_ == 0.0 (default) reproduces the authors' ROS1
+    // behaviour: re-roll an independent random point every 1 Hz tick.
+    //
+    // A positive hold_th was tried as a port-only fix for Nav2/DWB stalling
+    // out under fast retargeting (with PathAlign/GoalAlign critics weighted
+    // heavily, the top-scoring velocity each cycle was "rotate toward the
+    // (already stale) goal direction", so a goal changing every second meant
+    // the robot never finished turning -- observed as a ground-truth pose
+    // frozen for 30+ consecutive iterations near the source). Measured
+    // 2026-07-16 with hold_th=15.0 on House09: the hold itself worked (logs
+    // confirmed goals held the full 15 s) but success got WORSE (5/5
+    // ROBOT_STUCK, avg estimation error ~7.9 m vs ~6.5 m pre-fix) -- with a
+    // stable goal the robot drove directly into walls/corners instead, and
+    // Nav2's spin recovery couldn't dislodge it (no clearance margin in
+    // create_random_gaol, same as the original -- see
+    // ADSM_INVESTIGATION_20260716.md §2/§3). Left parameter-gated for future
+    // experiments, not the faithful default.
+    double now_t = this->now().seconds();
+    bool need_new = !has_random_goal_
+        || reached_point(random_goal_x_, random_goal_y_)
+        || (now_t - random_goal_set_time_) > random_goal_hold_th_;
+    if (need_new) {
+        double new_x, new_y;
+        // Seed from the robot's current position, not the previous goal: seeding
+        // from goal_ let an out-of-bounds goal compound into a runaway drift.
+        create_random_gaol(real_x_, real_y_, random_sample_r_, new_x, new_y);
+        random_goal_x_ = new_x;
+        random_goal_y_ = new_y;
+        random_goal_set_time_ = now_t;
+        has_random_goal_ = true;
+        RCLCPP_INFO(this->get_logger(), "Generate a random goal. r: %.2f, x %.2f y %.2f", random_sample_r_, new_x, new_y);
+    } else {
+        RCLCPP_INFO(this->get_logger(), "Hold random goal: x %.2f y %.2f (age %.1f/%.1f s)",
+            random_goal_x_, random_goal_y_, now_t - random_goal_set_time_, random_goal_hold_th_);
+    }
+    goals_.clear();
+    goals_.push_back(GoalNode(iter_, random_goal_x_, random_goal_y_, GOAL_RANDOM_TYPE));
+}
+
 void Adsm::evaluate() {
     if ((!goals_.empty()) && (!set_random_goal_)) {
         // Normalize j_p, j_i, and j
@@ -610,11 +667,9 @@ void Adsm::evaluate() {
         // Static map adaptation: if no gas AND no frontiers, all j=0 so fall back to random exploration
         if (sum_probability == 0.0 && sum_frontier_size == 0.0) {
             RCLCPP_INFO(this->get_logger(), "No gas and no frontiers (static map). Falling back to random exploration.");
-            goals_.clear();
-            double new_x, new_y;
-            create_random_gaol(real_x_, real_y_, random_sample_r_, new_x, new_y);
-            goals_.push_back(GoalNode(iter_, new_x, new_y, GOAL_RANDOM_TYPE));
+            pick_or_hold_random_goal();
         } else {
+            has_random_goal_ = false;  // back to normal weighted selection; next fallback starts fresh
             for (auto& temp_goal : goals_) {
                 temp_goal.j_p = sum_probability > 0 ? temp_goal.probability / sum_probability : 0.0;
                 temp_goal.j_i = sum_frontier_size > 0 ? temp_goal.frontier_size / sum_frontier_size : 0.0;
@@ -623,13 +678,7 @@ void Adsm::evaluate() {
             }
         }
     } else {
-        goals_.clear();
-        RCLCPP_INFO(this->get_logger(), "Generate a random goal. r: %.2f", random_sample_r_);
-        double new_x, new_y;
-        // Seed from the robot's current position, not the previous goal: seeding
-        // from goal_ let an out-of-bounds goal compound into a runaway drift.
-        create_random_gaol(real_x_, real_y_, random_sample_r_, new_x, new_y);
-        goals_.push_back(GoalNode(iter_, new_x, new_y, GOAL_RANDOM_TYPE));
+        pick_or_hold_random_goal();
     }
 
     // Select the point with the largest j as the navigation goal
@@ -656,9 +705,31 @@ void Adsm::navigate() {
     goal_msg.pose.pose.orientation.z = 0.0;
     goal_msg.pose.pose.orientation.w = 1.0;
 
-    auto send_goal_options = rclcpp_action::Client<NavigateToPose>::SendGoalOptions();
-    nav_client_->async_send_goal(goal_msg, send_goal_options);
-    RCLCPP_INFO(this->get_logger(), "Send goal: x %.2f y %.2f", goal_.x, goal_.y);
+    // Retarget the in-flight drive rather than preempting it. Re-sending the
+    // action goal makes bt_navigator halt FollowPath and rebuild the tree, so
+    // at iter_rate_ = 1 Hz the controller is reset before it ever moves the
+    // robot. GoalUpdater swaps the goal inside the running tree instead, which
+    // is what move_base's sendGoal() did. The action goal is (re)sent only when
+    // no drive is live — i.e. first iteration, or after the tree terminated.
+    if (use_goal_update_ && nav_goal_active_) {
+        geometry_msgs::msg::PoseStamped update;
+        update.header = goal_msg.pose.header;  // stamp = now(); MUST post-date
+        update.pose = goal_msg.pose.pose;      // the action goal or it's ignored
+        goal_update_pub_->publish(update);
+        RCLCPP_INFO(this->get_logger(), "Update goal: x %.2f y %.2f", goal_.x, goal_.y);
+    } else {
+        auto send_goal_options = rclcpp_action::Client<NavigateToPose>::SendGoalOptions();
+        if (use_goal_update_) {
+            using GoalHandle = rclcpp_action::ClientGoalHandle<NavigateToPose>;
+            send_goal_options.goal_response_callback =
+                [this](GoalHandle::SharedPtr handle) { if (!handle) nav_goal_active_ = false; };
+            send_goal_options.result_callback =
+                [this](const GoalHandle::WrappedResult &) { nav_goal_active_ = false; };
+            nav_goal_active_ = true;
+        }
+        nav_client_->async_send_goal(goal_msg, send_goal_options);
+        RCLCPP_INFO(this->get_logger(), "Send goal: x %.2f y %.2f", goal_.x, goal_.y);
+    }
 
     cal_duration_ms_ = (get_current_time() - cal_start_time_)*1000;
     RCLCPP_INFO(this->get_logger(), "Loop cost time: %.2f ms", cal_duration_ms_);
@@ -677,6 +748,14 @@ bool Adsm::check_terminal() {
     if (iter_ >= max_iter_) {
         result_ = "REACH_MAX_ITER";
         RCLCPP_INFO(this->get_logger(), "REACH_MAX_ITER: iter %d, max_iter %d", iter_, max_iter_);
+        return true;
+    }
+
+    // oracle-derived travel-distance budget check (0.0 = disabled)
+    if (distance_budget_ > 0.0 && total_distance_ >= distance_budget_) {
+        result_ = "DISTANCE_BUDGET_EXCEEDED";
+        RCLCPP_INFO(this->get_logger(), "DISTANCE_BUDGET_EXCEEDED: total_distance %.2f, budget %.2f",
+            total_distance_, distance_budget_);
         return true;
     }
 

--- a/adsm/src/engine.cpp
+++ b/adsm/src/engine.cpp
@@ -1,0 +1,324 @@
+#include "adsm/engine.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <queue>
+#include <stdexcept>
+
+namespace adsm_core {
+namespace {
+constexpr int kUnknown = -1;
+constexpr int kOccupied = 100;
+constexpr int kEpi = 0;
+constexpr int kEpr = 1;
+constexpr int kRandom = 2;
+double distance(double ax, double ay, double bx, double by) {
+  return std::hypot(ax - bx, ay - by);
+}
+}  // namespace
+
+bool Grid::valid() const {
+  return width > 0 && height > 0 && resolution > 0.0 &&
+         data.size() == static_cast<std::size_t>(width * height);
+}
+
+bool Grid::worldToMap(double wx, double wy, int &mx, int &my) const {
+  if (!valid() || wx < origin_x || wy < origin_y) return false;
+  mx = static_cast<int>((wx - origin_x) / resolution);
+  my = static_cast<int>((wy - origin_y) / resolution);
+  return mx >= 0 && my >= 0 && mx < width && my < height;
+}
+
+void Grid::mapToWorld(int mx, int my, double &wx, double &wy) const {
+  wx = origin_x + (mx + 0.5) * resolution;
+  wy = origin_y + (my + 0.5) * resolution;
+}
+
+int Grid::cost(int mx, int my) const {
+  if (mx < 0 || my < 0 || mx >= width || my >= height) return kOccupied;
+  return data[static_cast<std::size_t>(my * width + mx)];
+}
+
+Engine::Engine(const Config &config) : cfg_(config) { reset(0); }
+
+void Engine::reset(uint32_t seed) {
+  seed_ = seed;
+  std::srand(seed_);
+  iteration_ = 0;
+  initialized_ = false;
+  gas_hit_ = false;
+  do_sample_again_ = false;
+  set_random_goal_ = false;
+  last_resample_time_ = 0.0;
+  stuck_x_ = std::numeric_limits<double>::quiet_NaN();
+  stuck_y_ = stuck_time_ = 0.0;
+  goal_ = Goal{};
+  gas_window_.clear();
+  pose_history_.clear();
+  epi_set_.clear();
+  epr_set_.clear();
+  rrt_nodes_.clear();
+}
+
+double Engine::randomUnit() {
+  return static_cast<double>(std::rand()) / static_cast<double>(RAND_MAX);
+}
+
+void Engine::classifyGas(const Input &in) {
+  gas_window_.push_back({in.sim_time, in.gas});
+  while (!gas_window_.empty() &&
+         in.sim_time - gas_window_.front().first > cfg_.sensor_window_length) {
+    gas_window_.erase(gas_window_.begin());
+  }
+  if (in.gas < cfg_.gas_low_th) {
+    gas_hit_ = false;
+  } else if (in.gas > cfg_.gas_high_th) {
+    gas_hit_ = true;
+  } else {
+    bool decreasing = true;
+    for (std::size_t i = 1; i < gas_window_.size(); ++i) {
+      if (gas_window_[i].second - gas_window_[i - 1].second >= 0.0 ||
+          gas_window_[i - 1].second - cfg_.gas_high_th >= 0.0) {
+        decreasing = false;
+      }
+    }
+    gas_hit_ = !decreasing;
+  }
+}
+
+double Engine::probability(const Input &in, double x, double y) const {
+  constexpr double Q = 4.0, D = 1.0, tau = 250.0;
+  const double V = in.wind_speed;
+  const double phi = in.yaw - in.wind_direction;
+  const double lambda = std::sqrt(D * tau / (1.0 + V * V * tau / (4.0 * D)));
+  const double d = distance(x, y, in.x, in.y);
+  const double dx = in.x - x, dy = in.y - y;
+  return Q / (4.0 * M_PI * D * std::abs(d + 0.0001)) * std::exp(-d / lambda) *
+         std::exp(-dx * V * std::cos(phi) / (2.0 * D)) *
+         std::exp(-dy * V * std::sin(phi) / (2.0 * D));
+}
+
+bool Engine::reachedPoint(double x, double y) const {
+  for (const auto &p : pose_history_) {
+    if (distance(p.first, p.second, x, y) < cfg_.goal_reach_th) return true;
+  }
+  return false;
+}
+
+bool Engine::collisionFree(const Grid &map, double sx, double sy, double ex, double ey) const {
+  const int obs_cells = static_cast<int>(cfg_.obs_r / map.resolution);
+  const double check_step = cfg_.obs_r / 2.0;
+  const double d = distance(sx, sy, ex, ey);
+  const double theta = std::atan2(ey - sy, ex - sx);
+  const int n = static_cast<int>(std::floor(d / check_step));
+  for (int p = 0; p <= n + 1; ++p) {
+    const double step = p <= n ? p * check_step : d;
+    int mx, my;
+    if (!map.worldToMap(sx + step * std::cos(theta), sy + step * std::sin(theta), mx, my))
+      return false;
+    for (int x = std::max(0, mx - obs_cells); x < std::min(map.width, mx + obs_cells); ++x) {
+      for (int y = std::max(0, my - obs_cells); y < std::min(map.height, my + obs_cells); ++y) {
+        if (map.cost(x, y) == kUnknown || map.cost(x, y) >= kOccupied) return false;
+      }
+    }
+  }
+  return true;
+}
+
+std::vector<Engine::RRTNode> Engine::sampleRRT(const Grid &map, double sx, double sy) {
+  std::vector<RRTNode> nodes{{sx, sy, 0.0, -1}};
+  for (int iter = 0; iter < cfg_.rrt_max_iter; ++iter) {
+    const double theta = randomUnit() * 2.0 * M_PI;
+    const double radius = randomUnit() * (cfg_.rrt_max_r - cfg_.rrt_step_size) + cfg_.rrt_step_size;
+    const double rx = sx + radius * std::cos(theta), ry = sy + radius * std::sin(theta);
+    int nearest = 0;
+    double nearest_d = distance(nodes[0].x, nodes[0].y, rx, ry);
+    for (std::size_t i = 1; i < nodes.size(); ++i) {
+      const double d = distance(nodes[i].x, nodes[i].y, rx, ry);
+      if (d < nearest_d) { nearest = static_cast<int>(i); nearest_d = d; }
+    }
+    const double a = std::atan2(ry - nodes[nearest].y, rx - nodes[nearest].x);
+    double nx = nodes[nearest].x + cfg_.rrt_step_size * std::cos(a);
+    double ny = nodes[nearest].y + cfg_.rrt_step_size * std::sin(a);
+    if (distance(nx, ny, rx, ry) < cfg_.rrt_step_size) { nx = rx; ny = ry; }
+    int mx, my;
+    if (!map.worldToMap(nx, ny, mx, my) || !collisionFree(map, nodes[nearest].x, nodes[nearest].y, nx, ny))
+      continue;
+    RRTNode node{nx, ny, nodes[nearest].cost + distance(nx, ny, nodes[nearest].x, nodes[nearest].y), nearest};
+    std::vector<int> near;
+    for (std::size_t i = 0; i < nodes.size(); ++i)
+      if (distance(nodes[i].x, nodes[i].y, nx, ny) < cfg_.rrt_near_r) near.push_back(static_cast<int>(i));
+    int parent = -1;
+    double best = node.cost;
+    for (int i : near) {
+      const double c = nodes[i].cost + distance(nodes[i].x, nodes[i].y, nx, ny);
+      if (c < best) { best = c; parent = i; }
+    }
+    if (parent >= 0) {
+      const double pa = std::atan2(ny - nodes[parent].y, nx - nodes[parent].x);
+      double tx = nodes[parent].x + cfg_.rrt_step_size * std::cos(pa);
+      double ty = nodes[parent].y + cfg_.rrt_step_size * std::sin(pa);
+      if (distance(tx, ty, nx, ny) < cfg_.rrt_step_size) { tx = nx; ty = ny; }
+      if (collisionFree(map, nodes[parent].x, nodes[parent].y, tx, ty)) {
+        node = {tx, ty, nodes[parent].cost + distance(nodes[parent].x, nodes[parent].y, tx, ty), parent};
+      }
+    }
+    const int new_idx = static_cast<int>(nodes.size());
+    for (int i : near) {
+      const double c = node.cost + distance(nodes[i].x, nodes[i].y, node.x, node.y);
+      if (c < nodes[i].cost) { nodes[i].cost = c; nodes[i].parent = new_idx; }
+    }
+    nodes.push_back(node);
+  }
+  return nodes;
+}
+
+std::size_t Engine::frontierCount(const Grid &map, double sx, double sy) const {
+  int start_x, start_y;
+  if (!map.worldToMap(sx, sy, start_x, start_y)) return 0;
+  const int obs_cells = static_cast<int>(cfg_.obs_r / map.resolution);
+  std::queue<std::pair<int, int>> q;
+  std::vector<uint8_t> visited(static_cast<std::size_t>(map.width * map.height), 0);
+  std::vector<int> path_cost(static_cast<std::size_t>(map.width * map.height), 0);
+  auto idx = [&map](int x, int y) { return static_cast<std::size_t>(y * map.width + x); };
+  q.push({start_x, start_y}); visited[idx(start_x, start_y)] = 1;
+  std::size_t count = 0;
+  const int dx[4] = {0, 1, 0, -1}, dy[4] = {1, 0, -1, 0};
+  while (!q.empty()) {
+    auto [x, y] = q.front(); q.pop();
+    const int c = map.cost(x, y);
+    if (c == kUnknown || c >= kOccupied) continue;
+    bool obstacle = false;
+    for (int xx = std::max(0, x - obs_cells); xx < std::min(map.width, x + obs_cells); ++xx)
+      for (int yy = std::max(0, y - obs_cells); yy < std::min(map.height, y + obs_cells); ++yy)
+        obstacle = obstacle || map.cost(xx, yy) >= kOccupied;
+    if (obstacle) continue;
+    for (int k = 0; k < 4; ++k) {
+      const int nx = x + dx[k], ny = y + dy[k];
+      if (nx < 0 || ny < 0 || nx >= map.width || ny >= map.height || visited[idx(nx, ny)]) continue;
+      visited[idx(nx, ny)] = 1;
+      path_cost[idx(nx, ny)] = path_cost[idx(x, y)] + 1;
+      if (map.resolution * path_cost[idx(nx, ny)] > cfg_.frontier_search_th) continue;
+      const int nc = map.cost(nx, ny);
+      if (nc == kUnknown) ++count;
+      else if (nc < kOccupied) q.push({nx, ny});
+    }
+  }
+  return count;
+}
+
+Engine::Goal Engine::safeRandomGoal(const Input &in, double sx, double sy) {
+  for (int tries = 0; tries < 200; ++tries) {
+    const double theta = randomUnit() * 2.0 * M_PI;
+    const double radius = randomUnit() * cfg_.random_sample_r;
+    const double x = sx + radius * std::cos(theta), y = sy + radius * std::sin(theta);
+    int mx, my;
+    if (in.map.worldToMap(x, y, mx, my) && in.map.cost(mx, my) == 0)
+      return Goal{iteration_, x, y, kRandom};
+  }
+  return Goal{iteration_, in.x, in.y, kRandom};
+}
+
+void Engine::estimate(const Input &in, bool do_sample) {
+  if (do_sample) {
+    std::vector<RRTNode> sampled;
+    for (int attempt = 0; attempt < 10; ++attempt) {
+      double sx = in.x, sy = in.y;
+      if (attempt > 0) {
+        Goal seed = safeRandomGoal(in, in.x, in.y);
+        sx = seed.x; sy = seed.y;
+      }
+      sampled = sampleRRT(in.map, sx, sy);
+      if (sampled.size() >= 2) break;
+      sampled.clear();
+    }
+    if (sampled.size() >= 2) {
+      epi_set_.clear();
+      rrt_nodes_ = std::move(sampled);
+    }
+  }
+  do_sample_again_ = rrt_nodes_.size() < 2;
+  if (do_sample && !do_sample_again_) {
+    std::vector<int> categories(rrt_nodes_.size(), -1), farthest(cfg_.goal_cluster_num, -1);
+    std::vector<double> farthest_d(cfg_.goal_cluster_num, -1.0);
+    for (std::size_t i = 1; i < rrt_nodes_.size(); ++i) {
+      double a = std::atan2(rrt_nodes_[i].y - in.y, rrt_nodes_[i].x - in.x);
+      if (a < 0.0) a += 2.0 * M_PI;
+      int cat = std::min(cfg_.goal_cluster_num - 1,
+                         static_cast<int>(a / (2.0 * M_PI) * cfg_.goal_cluster_num));
+      categories[i] = cat;
+      const double d = distance(rrt_nodes_[i].x, rrt_nodes_[i].y, in.x, in.y);
+      if (d > farthest_d[cat]) { farthest_d[cat] = d; farthest[cat] = static_cast<int>(i); }
+    }
+    std::vector<uint8_t> is_farthest(rrt_nodes_.size(), 0);
+    for (int i : farthest) if (i >= 0) is_farthest[static_cast<std::size_t>(i)] = 1;
+    epi_set_.clear();
+    for (std::size_t i = 1; i < rrt_nodes_.size(); ++i) {
+      if (categories[i] < 0) continue;
+      if (!is_farthest[i]) { epi_set_.push_back({iteration_, rrt_nodes_[i].x, rrt_nodes_[i].y, kEpi}); continue; }
+      bool duplicate = false;
+      for (const auto &g : epr_set_)
+        if (distance(g.x, g.y, rrt_nodes_[i].x, rrt_nodes_[i].y) < cfg_.goal_reach_th / 2.0) duplicate = true;
+      const auto nfrontier = duplicate ? 0 : frontierCount(in.map, rrt_nodes_[i].x, rrt_nodes_[i].y);
+      if (duplicate || nfrontier == 0) epi_set_.push_back({iteration_, rrt_nodes_[i].x, rrt_nodes_[i].y, kEpi});
+      else { Goal g{iteration_, rrt_nodes_[i].x, rrt_nodes_[i].y, kEpr}; g.frontier_size = nfrontier; epr_set_.push_back(g); }
+    }
+  }
+  epi_set_.erase(std::remove_if(epi_set_.begin(), epi_set_.end(), [&](const Goal &g) {
+    return distance(g.x, g.y, in.x, in.y) < cfg_.rrt_min_r;
+  }), epi_set_.end());
+  for (auto &g : epi_set_) { g.probability = gas_hit_ ? probability(in, g.x, g.y) : 0.0; g.frontier_size = 0.0; }
+  epr_set_.erase(std::remove_if(epr_set_.begin(), epr_set_.end(), [&](Goal &g) {
+    if (distance(g.x, g.y, in.x, in.y) < cfg_.rrt_max_r + cfg_.frontier_search_th)
+      g.frontier_size = static_cast<double>(frontierCount(in.map, g.x, g.y));
+    return reachedPoint(g.x, g.y) || g.frontier_size == 0.0;
+  }), epr_set_.end());
+  for (auto &g : epr_set_) g.probability = gas_hit_ ? probability(in, g.x, g.y) : 0.0;
+}
+
+Engine::Goal Engine::evaluate(const Input &in) {
+  std::vector<Goal> goals = epi_set_;
+  goals.insert(goals.end(), epr_set_.begin(), epr_set_.end());
+  if (goals.empty() || set_random_goal_) return safeRandomGoal(in, goal_.x, goal_.y);
+  double sum_p = 0.0, sum_i = 0.0;
+  for (const auto &g : goals) { sum_p += g.probability; sum_i += g.frontier_size; }
+  for (auto &g : goals) {
+    g.j_p = sum_p > 0.0 ? g.probability / sum_p : 0.0;
+    g.j_i = sum_i > 0.0 ? g.frontier_size / sum_i : 0.0;
+    const double f = static_cast<double>(g.iteration) / static_cast<double>(iteration_);
+    g.j = g.j_p + cfg_.k1 * f * g.j_i;
+  }
+  return *std::max_element(goals.begin(), goals.end(), [](const Goal &a, const Goal &b) { return a.j < b.j; });
+}
+
+void Engine::updateStuck(const Input &in) {
+  if (std::isnan(stuck_x_)) { stuck_x_ = in.x; stuck_y_ = in.y; stuck_time_ = in.sim_time; }
+  else if (distance(stuck_x_, stuck_y_, in.x, in.y) > 0.15) {
+    stuck_x_ = in.x; stuck_y_ = in.y; stuck_time_ = in.sim_time;
+  }
+  set_random_goal_ = in.sim_time - stuck_time_ > cfg_.stuck_duration_th / 3.0;
+}
+
+Decision Engine::step(const Input &in) {
+  if (!in.map.valid()) throw std::invalid_argument("ADSM requires a non-empty occupancy grid");
+  if (!initialized_) {
+    initialized_ = true;
+    goal_ = Goal{0, in.x, in.y, kRandom};
+    last_resample_time_ = in.sim_time;
+    stuck_time_ = in.sim_time;
+  }
+  ++iteration_;
+  classifyGas(in);
+  pose_history_.push_back({in.x, in.y});
+  bool do_sample = distance(in.x, in.y, goal_.x, goal_.y) < cfg_.goal_reach_th ||
+                   in.sim_time - last_resample_time_ > cfg_.resample_time_th || do_sample_again_;
+  if (do_sample) last_resample_time_ = in.sim_time;
+  estimate(in, do_sample);
+  goal_ = evaluate(in);
+  updateStuck(in);  // original check_terminal affects the following iteration
+  return Decision{goal_.x, goal_.y, 0.0, goal_.type, goal_.j, goal_.j_p, goal_.j_i,
+                  iteration_, gas_hit_, do_sample, epi_set_.size(), epr_set_.size()};
+}
+
+}  // namespace adsm_core

--- a/adsm/src/python_bindings.cpp
+++ b/adsm/src/python_bindings.cpp
@@ -1,0 +1,62 @@
+#include "adsm/engine.h"
+
+#include <pybind11/numpy.h>
+#include <pybind11/pybind11.h>
+
+#include <random>
+
+namespace py = pybind11;
+using adsm_core::Config;
+using adsm_core::Decision;
+using adsm_core::Engine;
+using adsm_core::Grid;
+using adsm_core::Input;
+
+PYBIND11_MODULE(adsm_core_py, m) {
+  py::class_<Config>(m, "Config")
+      .def(py::init<>())
+      .def_readwrite("k1", &Config::k1)
+      .def_readwrite("random_sample_r", &Config::random_sample_r)
+      .def_readwrite("goal_cluster_num", &Config::goal_cluster_num)
+      .def_readwrite("obs_r", &Config::obs_r)
+      .def_readwrite("goal_reach_th", &Config::goal_reach_th)
+      .def_readwrite("resample_time_th", &Config::resample_time_th)
+      .def_readwrite("gas_high_th", &Config::gas_high_th)
+      .def_readwrite("gas_low_th", &Config::gas_low_th)
+      .def_readwrite("sensor_window_length", &Config::sensor_window_length)
+      .def_readwrite("frontier_search_th", &Config::frontier_search_th)
+      .def_readwrite("rrt_max_iter", &Config::rrt_max_iter)
+      .def_readwrite("rrt_max_r", &Config::rrt_max_r)
+      .def_readwrite("rrt_min_r", &Config::rrt_min_r)
+      .def_readwrite("rrt_step_size", &Config::rrt_step_size)
+      .def_readwrite("stuck_duration_th", &Config::stuck_duration_th);
+
+  py::class_<Decision>(m, "Decision")
+      .def_readonly("x", &Decision::x).def_readonly("y", &Decision::y)
+      .def_readonly("yaw", &Decision::yaw).def_readonly("goal_type", &Decision::goal_type)
+      .def_readonly("j", &Decision::j).def_readonly("j_p", &Decision::j_p)
+      .def_readonly("j_i", &Decision::j_i).def_readonly("iteration", &Decision::iteration)
+      .def_readonly("gas_hit", &Decision::gas_hit).def_readonly("resampled", &Decision::resampled)
+      .def_readonly("epi_size", &Decision::epi_size).def_readonly("epr_size", &Decision::epr_size);
+
+  py::class_<Engine>(m, "Engine")
+      .def(py::init<const Config &>(), py::arg("config") = Config())
+      .def("reset", [](Engine &self, py::object seed) {
+        uint32_t actual = seed.is_none() ? std::random_device{}() : seed.cast<uint32_t>();
+        self.reset(actual); return actual;
+      }, py::arg("seed") = py::none())
+      .def("step", [](Engine &self, double x, double y, double yaw, double gas,
+                       double wind_speed, double wind_direction, double sim_time,
+                       py::array_t<int8_t, py::array::c_style | py::array::forcecast> grid,
+                       double resolution, double origin_x, double origin_y) {
+        auto b = grid.request();
+        if (b.ndim != 2) throw py::value_error("occupancy grid must be HxW");
+        Grid g; g.height = static_cast<int>(b.shape[0]); g.width = static_cast<int>(b.shape[1]);
+        g.resolution = resolution; g.origin_x = origin_x; g.origin_y = origin_y;
+        const auto *src = static_cast<const int8_t *>(b.ptr);
+        g.data.resize(static_cast<std::size_t>(g.width * g.height));
+        for (std::size_t i = 0; i < g.data.size(); ++i)
+          g.data[i] = src[i] < 0 ? -1 : (src[i] == 0 ? 0 : 100);
+        return self.step(Input{x, y, yaw, gas, wind_speed, wind_direction, sim_time, std::move(g)});
+      });
+}

--- a/adsm/test/Makefile
+++ b/adsm/test/Makefile
@@ -1,0 +1,25 @@
+# ADSM port faithfulness — equivalence test
+#
+#   make          build + run
+#   make build    build only
+#   make clean
+#
+# Standalone: no ROS, no external deps. Just a C++17 compiler.
+
+CXX      ?= g++
+CXXFLAGS ?= -O2 -std=c++17 -Wall
+
+all: run
+
+build: adsm_equivalence_test
+
+adsm_equivalence_test: adsm_equivalence_test.cpp
+	$(CXX) $(CXXFLAGS) -o $@ $< -lm
+
+run: adsm_equivalence_test
+	./adsm_equivalence_test
+
+clean:
+	rm -f adsm_equivalence_test
+
+.PHONY: all build run clean

--- a/adsm/test/README.md
+++ b/adsm/test/README.md
@@ -1,0 +1,97 @@
+# ADSM port faithfulness — input/output equivalence test
+
+Proves that this ROS2 port of ADSM makes **identical decisions** to the authors'
+published ROS1 implementation, given identical inputs.
+
+This is a claim about the **algorithm**, deliberately independent of the
+simulator (Gazebo vs BasicSim), the navigation stack (move_base vs Nav2), and
+the gas sensor — none of which can affect the result.
+
+## Run
+
+```bash
+cd src/base/adsm/test
+make            # builds and runs; no ROS needed, just g++
+```
+
+## What it compares
+
+Both implementations' decision math is embedded **verbatim**; the only edit is
+that member variables become explicit parameters, because the port binds
+`real_x_/real_y_/real_yaw_` where the original binds `x_/y_/yaw_` (same
+formulas, different variable). Identical inputs go to both; outputs are
+compared **bit-exact**.
+
+| # | Component | Cases | Result |
+|---|-----------|-------|--------|
+| 1 | `probability()` — Eq. 3 indoor-Gaussian source-term estimator | 2,000,000 | **0 mismatches** (max diff 0) |
+| 2 | `evaluate()` — fitness `j = j_p + k1*f*j_i` + argmax goal selection | 199,769 | **0 mismatches** |
+| 3 | gas binarization | 200,000 | **differs — intentional** (MOX -> PID) |
+| 4 | `estimate()` angular clustering — N-class bearing split, farthest-per-class | 100,000 | **0 mismatches** |
+
+Verdict: **decision core bit-exact equivalent.**
+
+## Provenance
+
+| | |
+|---|---|
+| Original | <https://github.com/mwanggh/An-adaptive-robot-search-algorithm> |
+| Commit | `1f3c6a0b5483191d49eb4b920713ccb276ce8743` (2026-01-20) |
+| Paper | Wang, Xin, Deng, Chen & Qu, *An Adaptive Robot Search Algorithm for Balancing Exploitation and Exploration in Indoor Intermittent Source Seeking*, IEEE TIE 73(4), 2026. doi:10.1109/TIE.2025.3632565 |
+
+Line references in the test source point at the exact origin of each extracted
+block (`orig::` = paper's `src/adsm.cpp`; `port::` = this package's
+`src/adsm.cpp`).
+
+## Shared modules — checked separately by semantic diff
+
+`frontier_finder.cpp`, `rrt_sampler.cpp` and `goal.cpp` are not re-tested here
+because they are **semantically identical** to the originals. Normalising away
+include paths, logging macros, comments and whitespace leaves only:
+
+- `goal.cpp` — no difference at all.
+- `rrt_sampler.cpp` — member-initialiser list reordered, plus `(void)width;
+  `(void)height;`. Both no-ops: C++ initialises members in *declaration* order
+  and each initialiser binds by name, so the reorder cannot change which value
+  lands in which member (it only silences `-Wreorder`); the `(void)` casts
+  suppress unused-parameter warnings.
+- `frontier_finder.cpp` — `cost_grid[x][y]` became `cost_grid[(int)x][(int)y]`.
+  `x` is a `double` that always holds an exact non-negative integer (cell
+  indices, with `nx < 0` guarded), so implicit and explicit truncation give
+  identical values. Cosmetic; silences a narrowing warning.
+
+Reproduce:
+
+```bash
+norm() { sed -E 's://.*::' "$1" | sed -E '/^\s*#include/d' \
+  | sed -E '/(ROS_INFO|RCLCPP_INFO|ROS_ERROR|RCLCPP_ERROR)/d' \
+  | sed -E 's/[[:space:]]+/ /g; s/^ //; s/ $//' | grep -v '^$'; }
+diff <(norm <orig>/src/frontier_finder.cpp) <(norm ../src/frontier_finder.cpp)
+```
+
+## Known, intentional deviations from the paper
+
+All environmental — none touch the algorithm:
+
+1. **Gas sensor: MOX -> PID.** Paper reads a MOX TGS2620 (`sensor_model: 0`) and
+   inverts resistance (`gas_ = gas_max - raw`, thresholds 500/2000 of
+   `gas_max` 63000). This port reads a PID (`sensor_model: 30`) in ppm directly
+   (`gas_ = raw`, thresholds 0.1/0.3). The thresholds are *proportionally*
+   matched (~1-3% of scale both ways). Test 3 shows the expected divergence.
+   Note the `in_rec` time-window branch exists to reject MOX hysteresis and is
+   largely inert with a PID; `gas_max` is unused on the PID path.
+2. **Pose binding.** Uses ground-truth pose (`real_*`) where the original uses
+   the odom/SLAM estimate (`x_`). Formulas identical.
+3. **Port-only fallback.** When `sum_probability == 0 && sum_frontier_size == 0`
+   the port explores randomly instead of selecting a `j == 0` goal. Fired in
+   231/200,000 (0.1%) of randomized cases.
+4. `create_random_gaol` validates map bounds / non-lethal cells before
+   returning a goal (the original samples blind).
+5. Map/infrastructure: GADEN occupancy service + external SLAM node instead of
+   gmapping; Nav2 `NavigateToPose` instead of move_base.
+
+## Maintenance
+
+The two implementations are **embedded copies**, so this is a snapshot proof. If
+`../src/adsm.cpp` changes, re-sync the `port::` blocks (and bump the commit above
+if re-checking against a newer upstream) or the test will silently go stale.

--- a/adsm/test/adsm_equivalence_test.cpp
+++ b/adsm/test/adsm_equivalence_test.cpp
@@ -1,0 +1,259 @@
+// ADSM port faithfulness: input-output equivalence test.
+//
+// Both implementations' decision math is extracted VERBATIM from source
+// (only the member variables become explicit parameters, since the port
+// binds real_x_/real_y_/real_yaw_ where the original binds x_/y_/yaw_).
+// Identical inputs are fed to both; outputs are compared bit-exact.
+//
+//   orig::  /tmp/.../adsm_orig/src/adsm.cpp      (paper, ROS1)
+//   port::  ~/ros2_ws/src/base/adsm/src/adsm.cpp (our ROS2 port)
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+#include <algorithm>
+#include <random>
+
+// ----------------------------------------------------------------------------
+// 1) probability()  — the Gaussian indoor plume / source-term estimator (Eq.3)
+// ----------------------------------------------------------------------------
+namespace orig {
+// verbatim from adsm_orig/src/adsm.cpp:199-217 (x_, y_, yaw_ -> params)
+double probability(double x, double y, double x_, double y_, double yaw_,
+                   double wind_speed_, double wind_direction_) {
+    double Q = 4.0;
+    double D = 1.0;
+    double tau = 250;
+    double V = wind_speed_;
+    double phi = yaw_ - wind_direction_;
+    double lam = std::sqrt(D * tau / (1 + V * V * tau / (4 * D)));
+    double dis = std::sqrt((x - x_) * (x - x_) + (y - y_) * (y - y_));
+    double dx = x_ - x;
+    double dy = y_ - y;
+
+    double pa = Q / (4 * M_PI * D * (std::abs(dis + 0.0001)));
+    double pb = std::exp(-dis / lam);
+    double pc = std::exp(-dx * V * std::cos(phi) / (2 * D));
+    double pd = std::exp(-dy * V * std::sin(phi) / (2 * D));
+    double p = pa * pb * pc * pd;
+
+    return p;
+}
+} // namespace orig
+
+namespace port {
+// verbatim from src/base/adsm/src/adsm.cpp:361-379 (real_x_, real_y_, real_yaw_ -> params)
+double probability(double x, double y, double real_x_, double real_y_, double real_yaw_,
+                   double wind_speed_, double wind_direction_) {
+    double Q = 4.0;
+    double D = 1.0;
+    double tau = 250;
+    double V = wind_speed_;
+    double phi = real_yaw_ - wind_direction_;
+    double lam = std::sqrt(D * tau / (1 + V * V * tau / (4 * D)));
+    double dis = std::sqrt((x - real_x_) * (x - real_x_) + (y - real_y_) * (y - real_y_));
+    double dx = real_x_ - x;
+    double dy = real_y_ - y;
+
+    double pa = Q / (4 * M_PI * D * (std::abs(dis + 0.0001)));
+    double pb = std::exp(-dis / lam);
+    double pc = std::exp(-dx * V * std::cos(phi) / (2 * D));
+    double pd = std::exp(-dy * V * std::sin(phi) / (2 * D));
+    double p = pa * pb * pc * pd;
+
+    return p;
+}
+} // namespace port
+
+// ----------------------------------------------------------------------------
+// 2) evaluate() — fitness j = j_p + k1*f*j_i, then argmax goal selection
+// ----------------------------------------------------------------------------
+struct Goal { double iteration, x, y, probability, frontier_size, j, j_p, j_i; int type; };
+
+namespace orig {
+// verbatim from adsm_orig/src/adsm.cpp:416-452
+int evaluate(std::vector<Goal>& goals_, int iter_, double k1_) {
+    double sum_probability = 0.0, sum_frontier_size = 0.0;
+    for (auto& g : goals_) { sum_probability += g.probability; sum_frontier_size += g.frontier_size; }
+    for (auto& temp_goal : goals_) {
+        temp_goal.j_p = sum_probability > 0 ? temp_goal.probability / sum_probability : 0.0;
+        temp_goal.j_i = sum_frontier_size > 0 ? temp_goal.frontier_size / sum_frontier_size : 0.0;
+        double f = temp_goal.iteration / static_cast<double>(iter_);
+        temp_goal.j = temp_goal.j_p + k1_ * f * temp_goal.j_i;
+    }
+    int best = 0;
+    for (size_t i = 0; i < goals_.size(); ++i) if (goals_[i].j > goals_[best].j) best = (int)i;
+    return best;
+}
+} // namespace orig
+
+namespace port {
+// verbatim from src/base/adsm/src/adsm.cpp:598-645 (same math; the port adds a
+// `sum_p==0 && sum_f==0 -> random` branch, exercised separately below)
+int evaluate(std::vector<Goal>& goals_, int iter_, double k1_, bool* took_random_branch) {
+    double sum_probability = 0.0, sum_frontier_size = 0.0;
+    for (auto& g : goals_) { sum_probability += g.probability; sum_frontier_size += g.frontier_size; }
+    if (sum_probability == 0.0 && sum_frontier_size == 0.0) { *took_random_branch = true; return -1; }
+    *took_random_branch = false;
+    for (auto& temp_goal : goals_) {
+        temp_goal.j_p = sum_probability > 0 ? temp_goal.probability / sum_probability : 0.0;
+        temp_goal.j_i = sum_frontier_size > 0 ? temp_goal.frontier_size / sum_frontier_size : 0.0;
+        double f = temp_goal.iteration / static_cast<double>(iter_);
+        temp_goal.j = temp_goal.j_p + k1_ * f * temp_goal.j_i;
+    }
+    int best = 0;
+    for (size_t i = 0; i < goals_.size(); ++i) if (goals_[i].j > goals_[best].j) best = (int)i;
+    return best;
+}
+} // namespace port
+
+// ----------------------------------------------------------------------------
+// 3) gas binarization (gas_hit) — KNOWN intentional difference: MOX -> PID
+// ----------------------------------------------------------------------------
+namespace orig {
+// verbatim from adsm_orig/src/adsm.cpp:164-191
+bool gas_hit(double raw, double gas_max_, double gas_low_th_, double gas_high_th_,
+             const std::vector<double>& window, double* gas_out) {
+    double gas_ = gas_max_ - raw;          // MOX: resistance inverted
+    *gas_out = gas_;
+    if (gas_ < gas_low_th_) return false;
+    if (gas_ > gas_high_th_) return true;
+    bool in_rec = true;
+    for (size_t i = 1; i < window.size(); ++i)
+        if (window[i] - window[i-1] >= 0.0 || window[i-1] - gas_high_th_ >= 0.0) in_rec = false;
+    return in_rec ? false : true;
+}
+} // namespace orig
+
+namespace port {
+// verbatim from src/base/adsm/src/adsm.cpp:327-353
+bool gas_hit(double raw, double gas_max_, double gas_low_th_, double gas_high_th_,
+             const std::vector<double>& window, double* gas_out) {
+    double gas_ = raw;                     // PID: direct ppm (no inversion)
+    *gas_out = gas_;
+    if (gas_ < gas_low_th_) return false;
+    if (gas_ > gas_high_th_) return true;
+    bool in_rec = true;
+    for (size_t i = 1; i < window.size(); ++i)
+        if (window[i] - window[i-1] >= 0.0 || window[i-1] - gas_high_th_ >= 0.0) in_rec = false;
+    return in_rec ? false : true;
+}
+} // namespace port
+
+// ----------------------------------------------------------------------------
+// 4) estimate() angular clustering: N classes by bearing, farthest-per-class
+// ----------------------------------------------------------------------------
+struct Node { double x, y; };
+namespace orig {
+// verbatim from adsm_orig/src/adsm.cpp:298-330 (x_, y_ -> params)
+std::vector<int> farthest_per_class(const std::vector<Node>& n, double x_, double y_, int K) {
+    std::vector<int> categories(n.size(), -1);
+    for (size_t i = 0; i < n.size(); ++i) {
+        if (i == 0) continue;
+        double angle = atan2(n[i].y - y_, n[i].x - x_);
+        if (angle < 0) angle += 2 * M_PI;
+        categories[i] = static_cast<int>((angle / (2 * M_PI)) * K);
+    }
+    std::vector<double> farthest_length(K, -1.0);
+    std::vector<int> fartest_index(K, -1);
+    for (size_t i = 0; i < n.size(); ++i) {
+        if (categories[i] < 0) continue;
+        double dist = std::sqrt((n[i].x-x_)*(n[i].x-x_) + (n[i].y-y_)*(n[i].y-y_));
+        if (dist > farthest_length[categories[i]]) { farthest_length[categories[i]] = dist; fartest_index[categories[i]] = (int)i; }
+    }
+    return fartest_index;
+}
+} // namespace orig
+namespace port {
+// verbatim from src/base/adsm/src/adsm.cpp:479-512 (real_x_, real_y_ -> params)
+std::vector<int> farthest_per_class(const std::vector<Node>& n, double real_x_, double real_y_, int K) {
+    std::vector<int> categories(n.size(), -1);
+    for (size_t i = 0; i < n.size(); ++i) {
+        if (i == 0) continue;
+        double angle = atan2(n[i].y - real_y_, n[i].x - real_x_);
+        if (angle < 0) angle += 2 * M_PI;
+        categories[i] = static_cast<int>((angle / (2 * M_PI)) * K);
+    }
+    std::vector<double> farthest_length(K, -1.0);
+    std::vector<int> fartest_index(K, -1);
+    for (size_t i = 0; i < n.size(); ++i) {
+        if (categories[i] < 0) continue;
+        double dist = std::sqrt((n[i].x-real_x_)*(n[i].x-real_x_) + (n[i].y-real_y_)*(n[i].y-real_y_));
+        if (dist > farthest_length[categories[i]]) { farthest_length[categories[i]] = dist; fartest_index[categories[i]] = (int)i; }
+    }
+    return fartest_index;
+}
+} // namespace port
+
+// ----------------------------------------------------------------------------
+int main() {
+    std::mt19937_64 rng(12345);
+    auto U = [&](double a, double b){ return a + (b-a) * (double)(rng() % 1000000) / 1000000.0; };
+
+    // --- Test 1: probability() over a large random sweep -------------------
+    long n1 = 2000000, mismatch1 = 0; double maxdiff1 = 0;
+    for (long i = 0; i < n1; ++i) {
+        double cx=U(-10,10), cy=U(-10,10), rx=U(-10,10), ry=U(-10,10),
+               yaw=U(-M_PI,M_PI), ws=U(0,3), wd=U(-M_PI,M_PI);
+        double a = orig::probability(cx,cy,rx,ry,yaw,ws,wd);
+        double b = port::probability(cx,cy,rx,ry,yaw,ws,wd);
+        if (!(a==b)) { if (!(std::isnan(a)&&std::isnan(b))) { mismatch1++; maxdiff1 = std::max(maxdiff1, std::abs(a-b)); } }
+    }
+    printf("1) probability()       : %ld/%ld inputs, bit-exact mismatches = %ld  (max|diff| = %g)\n",
+           n1, n1, mismatch1, maxdiff1);
+
+    // --- Test 2: evaluate() fitness + argmax --------------------------------
+    long n2 = 200000, mismatch2 = 0, randbranch = 0;
+    for (long i = 0; i < n2; ++i) {
+        int m = 1 + (int)(rng() % 40);
+        int iter = 1 + (int)(rng() % 400);
+        double k1 = U(0,1);
+        std::vector<Goal> ga(m), gb;
+        for (auto& g : ga) {
+            g.iteration = (double)(1 + (int)(rng()%iter));
+            g.probability = (rng()%5==0) ? 0.0 : U(0,1e-3);
+            g.frontier_size = (rng()%5==0) ? 0.0 : (double)(rng()%50);
+            g.x=U(-5,5); g.y=U(-5,5); g.type=0; g.j=g.j_p=g.j_i=0;
+        }
+        gb = ga;
+        int ia = orig::evaluate(ga, iter, k1);
+        bool rb=false; int ib = port::evaluate(gb, iter, k1, &rb);
+        if (rb) { randbranch++; continue; }          // port-only branch, compared separately
+        if (ia != ib) mismatch2++;
+        else for (int q=0;q<m;q++) if (!(ga[q].j==gb[q].j)) { mismatch2++; break; }
+    }
+    printf("2) evaluate() j+argmax : %ld cases, selected-goal/j mismatches = %ld  (port-only random branch hit %ld x)\n",
+           n2-randbranch, mismatch2, randbranch);
+
+    // --- Test 3: gas binarization (expected to DIFFER: MOX vs PID) ---------
+    long n3 = 200000, same3 = 0;
+    for (long i = 0; i < n3; ++i) {
+        double raw = U(0, 5);
+        std::vector<double> w; for (int k=0;k<6;k++) w.push_back(U(0,1));
+        double ga_, gb_;
+        bool a = orig::gas_hit(raw, 63000.0, 500.0, 2000.0, w, &ga_);   // paper's MOX params
+        bool b = port::gas_hit(raw, 10.0, 0.1, 0.3, w, &gb_);           // our PID params
+        if (a==b) same3++;
+    }
+    printf("3) gas binarization    : agreement %ld/%ld  <-- EXPECTED to differ (MOX->PID, intentional)\n", same3, n3);
+
+    // --- Test 4: angular clustering / farthest-per-class -------------------
+    long n4 = 100000, mismatch4 = 0;
+    for (long i = 0; i < n4; ++i) {
+        int m = 2 + (int)(rng() % 60); int K = 4 + (int)(rng()%32);
+        double rx=U(-5,5), ry=U(-5,5);
+        std::vector<Node> nd(m);
+        for (auto& p : nd) { p.x=U(-8,8); p.y=U(-8,8); }
+        auto a = orig::farthest_per_class(nd, rx, ry, K);
+        auto b = port::farthest_per_class(nd, rx, ry, K);
+        if (a != b) mismatch4++;
+    }
+    printf("4) angular clustering  : %ld cases, farthest-per-class mismatches = %ld\n", n4, mismatch4);
+
+    printf("\nVERDICT: decision core %s\n",
+        (mismatch1==0 && mismatch2==0 && mismatch4==0)
+        ? "BIT-EXACT EQUIVALENT (only the documented MOX->PID sensor conversion differs)"
+        : "*** DIVERGENCE FOUND ***");
+    return 0;
+}

--- a/adsm/test/equiv_test.cpp
+++ b/adsm/test/equiv_test.cpp
@@ -1,0 +1,259 @@
+// ADSM port faithfulness: input-output equivalence test.
+//
+// Both implementations' decision math is extracted VERBATIM from source
+// (only the member variables become explicit parameters, since the port
+// binds real_x_/real_y_/real_yaw_ where the original binds x_/y_/yaw_).
+// Identical inputs are fed to both; outputs are compared bit-exact.
+//
+//   orig::  /tmp/.../adsm_orig/src/adsm.cpp      (paper, ROS1)
+//   port::  ~/ros2_ws/src/base/adsm/src/adsm.cpp (our ROS2 port)
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <vector>
+#include <algorithm>
+#include <random>
+
+// ----------------------------------------------------------------------------
+// 1) probability()  — the Gaussian indoor plume / source-term estimator (Eq.3)
+// ----------------------------------------------------------------------------
+namespace orig {
+// verbatim from adsm_orig/src/adsm.cpp:199-217 (x_, y_, yaw_ -> params)
+double probability(double x, double y, double x_, double y_, double yaw_,
+                   double wind_speed_, double wind_direction_) {
+    double Q = 4.0;
+    double D = 1.0;
+    double tau = 250;
+    double V = wind_speed_;
+    double phi = yaw_ - wind_direction_;
+    double lam = std::sqrt(D * tau / (1 + V * V * tau / (4 * D)));
+    double dis = std::sqrt((x - x_) * (x - x_) + (y - y_) * (y - y_));
+    double dx = x_ - x;
+    double dy = y_ - y;
+
+    double pa = Q / (4 * M_PI * D * (std::abs(dis + 0.0001)));
+    double pb = std::exp(-dis / lam);
+    double pc = std::exp(-dx * V * std::cos(phi) / (2 * D));
+    double pd = std::exp(-dy * V * std::sin(phi) / (2 * D));
+    double p = pa * pb * pc * pd;
+
+    return p;
+}
+} // namespace orig
+
+namespace port {
+// verbatim from src/base/adsm/src/adsm.cpp:361-379 (real_x_, real_y_, real_yaw_ -> params)
+double probability(double x, double y, double real_x_, double real_y_, double real_yaw_,
+                   double wind_speed_, double wind_direction_) {
+    double Q = 4.0;
+    double D = 1.0;
+    double tau = 250;
+    double V = wind_speed_;
+    double phi = real_yaw_ - wind_direction_;
+    double lam = std::sqrt(D * tau / (1 + V * V * tau / (4 * D)));
+    double dis = std::sqrt((x - real_x_) * (x - real_x_) + (y - real_y_) * (y - real_y_));
+    double dx = real_x_ - x;
+    double dy = real_y_ - y;
+
+    double pa = Q / (4 * M_PI * D * (std::abs(dis + 0.0001)));
+    double pb = std::exp(-dis / lam);
+    double pc = std::exp(-dx * V * std::cos(phi) / (2 * D));
+    double pd = std::exp(-dy * V * std::sin(phi) / (2 * D));
+    double p = pa * pb * pc * pd;
+
+    return p;
+}
+} // namespace port
+
+// ----------------------------------------------------------------------------
+// 2) evaluate() — fitness j = j_p + k1*f*j_i, then argmax goal selection
+// ----------------------------------------------------------------------------
+struct Goal { double iteration, x, y, probability, frontier_size, j, j_p, j_i; int type; };
+
+namespace orig {
+// verbatim from adsm_orig/src/adsm.cpp:416-452
+int evaluate(std::vector<Goal>& goals_, int iter_, double k1_) {
+    double sum_probability = 0.0, sum_frontier_size = 0.0;
+    for (auto& g : goals_) { sum_probability += g.probability; sum_frontier_size += g.frontier_size; }
+    for (auto& temp_goal : goals_) {
+        temp_goal.j_p = sum_probability > 0 ? temp_goal.probability / sum_probability : 0.0;
+        temp_goal.j_i = sum_frontier_size > 0 ? temp_goal.frontier_size / sum_frontier_size : 0.0;
+        double f = temp_goal.iteration / static_cast<double>(iter_);
+        temp_goal.j = temp_goal.j_p + k1_ * f * temp_goal.j_i;
+    }
+    int best = 0;
+    for (size_t i = 0; i < goals_.size(); ++i) if (goals_[i].j > goals_[best].j) best = (int)i;
+    return best;
+}
+} // namespace orig
+
+namespace port {
+// verbatim from src/base/adsm/src/adsm.cpp:598-645 (same math; the port adds a
+// `sum_p==0 && sum_f==0 -> random` branch, exercised separately below)
+int evaluate(std::vector<Goal>& goals_, int iter_, double k1_, bool* took_random_branch) {
+    double sum_probability = 0.0, sum_frontier_size = 0.0;
+    for (auto& g : goals_) { sum_probability += g.probability; sum_frontier_size += g.frontier_size; }
+    if (sum_probability == 0.0 && sum_frontier_size == 0.0) { *took_random_branch = true; return -1; }
+    *took_random_branch = false;
+    for (auto& temp_goal : goals_) {
+        temp_goal.j_p = sum_probability > 0 ? temp_goal.probability / sum_probability : 0.0;
+        temp_goal.j_i = sum_frontier_size > 0 ? temp_goal.frontier_size / sum_frontier_size : 0.0;
+        double f = temp_goal.iteration / static_cast<double>(iter_);
+        temp_goal.j = temp_goal.j_p + k1_ * f * temp_goal.j_i;
+    }
+    int best = 0;
+    for (size_t i = 0; i < goals_.size(); ++i) if (goals_[i].j > goals_[best].j) best = (int)i;
+    return best;
+}
+} // namespace port
+
+// ----------------------------------------------------------------------------
+// 3) gas binarization (gas_hit) — KNOWN intentional difference: MOX -> PID
+// ----------------------------------------------------------------------------
+namespace orig {
+// verbatim from adsm_orig/src/adsm.cpp:164-191
+bool gas_hit(double raw, double gas_max_, double gas_low_th_, double gas_high_th_,
+             const std::vector<double>& window, double* gas_out) {
+    double gas_ = gas_max_ - raw;          // MOX: resistance inverted
+    *gas_out = gas_;
+    if (gas_ < gas_low_th_) return false;
+    if (gas_ > gas_high_th_) return true;
+    bool in_rec = true;
+    for (size_t i = 1; i < window.size(); ++i)
+        if (window[i] - window[i-1] >= 0.0 || window[i-1] - gas_high_th_ >= 0.0) in_rec = false;
+    return in_rec ? false : true;
+}
+} // namespace orig
+
+namespace port {
+// verbatim from src/base/adsm/src/adsm.cpp:327-353
+bool gas_hit(double raw, double gas_max_, double gas_low_th_, double gas_high_th_,
+             const std::vector<double>& window, double* gas_out) {
+    double gas_ = raw;                     // PID: direct ppm (no inversion)
+    *gas_out = gas_;
+    if (gas_ < gas_low_th_) return false;
+    if (gas_ > gas_high_th_) return true;
+    bool in_rec = true;
+    for (size_t i = 1; i < window.size(); ++i)
+        if (window[i] - window[i-1] >= 0.0 || window[i-1] - gas_high_th_ >= 0.0) in_rec = false;
+    return in_rec ? false : true;
+}
+} // namespace port
+
+// ----------------------------------------------------------------------------
+// 4) estimate() angular clustering: N classes by bearing, farthest-per-class
+// ----------------------------------------------------------------------------
+struct Node { double x, y; };
+namespace orig {
+// verbatim from adsm_orig/src/adsm.cpp:298-330 (x_, y_ -> params)
+std::vector<int> farthest_per_class(const std::vector<Node>& n, double x_, double y_, int K) {
+    std::vector<int> categories(n.size(), -1);
+    for (size_t i = 0; i < n.size(); ++i) {
+        if (i == 0) continue;
+        double angle = atan2(n[i].y - y_, n[i].x - x_);
+        if (angle < 0) angle += 2 * M_PI;
+        categories[i] = static_cast<int>((angle / (2 * M_PI)) * K);
+    }
+    std::vector<double> farthest_length(K, -1.0);
+    std::vector<int> fartest_index(K, -1);
+    for (size_t i = 0; i < n.size(); ++i) {
+        if (categories[i] < 0) continue;
+        double dist = std::sqrt((n[i].x-x_)*(n[i].x-x_) + (n[i].y-y_)*(n[i].y-y_));
+        if (dist > farthest_length[categories[i]]) { farthest_length[categories[i]] = dist; fartest_index[categories[i]] = (int)i; }
+    }
+    return fartest_index;
+}
+} // namespace orig
+namespace port {
+// verbatim from src/base/adsm/src/adsm.cpp:479-512 (real_x_, real_y_ -> params)
+std::vector<int> farthest_per_class(const std::vector<Node>& n, double real_x_, double real_y_, int K) {
+    std::vector<int> categories(n.size(), -1);
+    for (size_t i = 0; i < n.size(); ++i) {
+        if (i == 0) continue;
+        double angle = atan2(n[i].y - real_y_, n[i].x - real_x_);
+        if (angle < 0) angle += 2 * M_PI;
+        categories[i] = static_cast<int>((angle / (2 * M_PI)) * K);
+    }
+    std::vector<double> farthest_length(K, -1.0);
+    std::vector<int> fartest_index(K, -1);
+    for (size_t i = 0; i < n.size(); ++i) {
+        if (categories[i] < 0) continue;
+        double dist = std::sqrt((n[i].x-real_x_)*(n[i].x-real_x_) + (n[i].y-real_y_)*(n[i].y-real_y_));
+        if (dist > farthest_length[categories[i]]) { farthest_length[categories[i]] = dist; fartest_index[categories[i]] = (int)i; }
+    }
+    return fartest_index;
+}
+} // namespace port
+
+// ----------------------------------------------------------------------------
+int main() {
+    std::mt19937_64 rng(12345);
+    auto U = [&](double a, double b){ return a + (b-a) * (double)(rng() % 1000000) / 1000000.0; };
+
+    // --- Test 1: probability() over a large random sweep -------------------
+    long n1 = 2000000, mismatch1 = 0; double maxdiff1 = 0;
+    for (long i = 0; i < n1; ++i) {
+        double cx=U(-10,10), cy=U(-10,10), rx=U(-10,10), ry=U(-10,10),
+               yaw=U(-M_PI,M_PI), ws=U(0,3), wd=U(-M_PI,M_PI);
+        double a = orig::probability(cx,cy,rx,ry,yaw,ws,wd);
+        double b = port::probability(cx,cy,rx,ry,yaw,ws,wd);
+        if (!(a==b)) { if (!(std::isnan(a)&&std::isnan(b))) { mismatch1++; maxdiff1 = std::max(maxdiff1, std::abs(a-b)); } }
+    }
+    printf("1) probability()       : %ld/%ld inputs, bit-exact mismatches = %ld  (max|diff| = %g)\n",
+           n1, n1, mismatch1, maxdiff1);
+
+    // --- Test 2: evaluate() fitness + argmax --------------------------------
+    long n2 = 200000, mismatch2 = 0, randbranch = 0;
+    for (long i = 0; i < n2; ++i) {
+        int m = 1 + (int)(rng() % 40);
+        int iter = 1 + (int)(rng() % 400);
+        double k1 = U(0,1);
+        std::vector<Goal> ga(m), gb;
+        for (auto& g : ga) {
+            g.iteration = (double)(1 + (int)(rng()%iter));
+            g.probability = (rng()%5==0) ? 0.0 : U(0,1e-3);
+            g.frontier_size = (rng()%5==0) ? 0.0 : (double)(rng()%50);
+            g.x=U(-5,5); g.y=U(-5,5); g.type=0; g.j=g.j_p=g.j_i=0;
+        }
+        gb = ga;
+        int ia = orig::evaluate(ga, iter, k1);
+        bool rb=false; int ib = port::evaluate(gb, iter, k1, &rb);
+        if (rb) { randbranch++; continue; }          // port-only branch, compared separately
+        if (ia != ib) mismatch2++;
+        else for (int q=0;q<m;q++) if (!(ga[q].j==gb[q].j)) { mismatch2++; break; }
+    }
+    printf("2) evaluate() j+argmax : %ld cases, selected-goal/j mismatches = %ld  (port-only random branch hit %ld x)\n",
+           n2-randbranch, mismatch2, randbranch);
+
+    // --- Test 3: gas binarization (expected to DIFFER: MOX vs PID) ---------
+    long n3 = 200000, same3 = 0;
+    for (long i = 0; i < n3; ++i) {
+        double raw = U(0, 5);
+        std::vector<double> w; for (int k=0;k<6;k++) w.push_back(U(0,1));
+        double ga_, gb_;
+        bool a = orig::gas_hit(raw, 63000.0, 500.0, 2000.0, w, &ga_);   // paper's MOX params
+        bool b = port::gas_hit(raw, 10.0, 0.1, 0.3, w, &gb_);           // our PID params
+        if (a==b) same3++;
+    }
+    printf("3) gas binarization    : agreement %ld/%ld  <-- EXPECTED to differ (MOX->PID, intentional)\n", same3, n3);
+
+    // --- Test 4: angular clustering / farthest-per-class -------------------
+    long n4 = 100000, mismatch4 = 0;
+    for (long i = 0; i < n4; ++i) {
+        int m = 2 + (int)(rng() % 60); int K = 4 + (int)(rng()%32);
+        double rx=U(-5,5), ry=U(-5,5);
+        std::vector<Node> nd(m);
+        for (auto& p : nd) { p.x=U(-8,8); p.y=U(-8,8); }
+        auto a = orig::farthest_per_class(nd, rx, ry, K);
+        auto b = port::farthest_per_class(nd, rx, ry, K);
+        if (a != b) mismatch4++;
+    }
+    printf("4) angular clustering  : %ld cases, farthest-per-class mismatches = %ld\n", n4, mismatch4);
+
+    printf("\nVERDICT: decision core %s\n",
+        (mismatch1==0 && mismatch2==0 && mismatch4==0)
+        ? "BIT-EXACT EQUIVALENT (only the documented MOX->PID sensor conversion differs)"
+        : "*** DIVERGENCE FOUND ***");
+    return 0;
+}

--- a/adsm/test/house09_equiv_test.py
+++ b/adsm/test/house09_equiv_test.py
@@ -1,0 +1,458 @@
+#!/usr/bin/env python3
+"""ADSM port faithfulness -- probability() on the paper's real House09 data.
+
+Complements test/adsm_equivalence_test.cpp (2.3M synthetic random inputs) by
+driving BOTH implementations with the real House09 OpenFOAM CFD wind field and
+the real occupancy map, at real robot poses.
+
+WHAT THIS CHECKS
+  1. equivalence  -- orig_probability() vs port_probability(), transcribed
+     separately from the two source trees, on identical real inputs.
+  2. robustness   -- the model stays finite and non-negative over real wind
+     (real CFD wind is near-zero in most cells, which is exactly where
+     Eq. 3's exp() terms could degenerate).
+  3. sanity       -- the wind actually loaded is non-zero and the plume is
+     wind-shaped, not a symmetric blob.
+
+WHAT IT DOES NOT CHECK
+  Only probability() is covered. estimate()'s stateful epi_set_/epr_set_
+  bookkeeping, observe()'s resampling, check_terminal() and the RRT/frontier
+  modules are NOT exercised here -- see test/README.md.
+
+  It also compares transcriptions, not the compiled C++. A mis-transcription
+  would pass here while the real code differed; the source diff in
+  test/README.md is what covers that.
+
+HISTORY -- two bugs that made the previous version vacuous:
+  * It called ONE probability() twice and diffed the results, so "0 mismatches"
+    was a tautology that could not fail.
+  * lookup_wind() did round(wx/0.1)*0.1 and matched that against float dict
+    keys. The CFD cell centres are OFFSET (x from -1.85, y from -8.45105), so
+    it scored 0/2000 hits on its own keys and the silent (0.0, 0.0) default
+    fed V=0 everywhere -- collapsing every wind term of Eq. 3 to exp(0)=1.
+    The "real CFD physics" being tested was zero wind.
+  Both are now asserted against, so they cannot silently return.
+
+Usage:
+  python3 house09_equiv_test.py            # offline (wind + occupancy)
+  python3 house09_equiv_test.py --online   # also query live GADEN gas
+"""
+
+import argparse
+import csv
+import math
+import os
+import random
+import sys
+
+import numpy as np
+
+# ---- paths -----------------------------------------------------------------
+# The install tree is authoritative: benchmark_env ships scenarios via
+# install(DIRECTORY), which colcon copies rather than symlinks, so src/ and
+# install/ drift. The running nodes read install/.
+_DEFAULT_HOUSE = ("/home/efe/ros2_ws/install/benchmark_env/share/benchmark_env"
+                  "/scenarios/House09_1_23_08_KI")
+HOUSE_DIR = os.environ.get("HOUSE09_DIR", _DEFAULT_HOUSE)
+WIND_DIR = os.path.join(HOUSE_DIR, "wind_simulations", "1ms")
+OCC_PGM = os.path.join(HOUSE_DIR, "environment_configurations", "config1",
+                       "occupancy.pgm")
+OCC_YAML = os.path.join(HOUSE_DIR, "environment_configurations", "config1",
+                        "occupancy.yaml")
+
+ROBOT_START = (-1.6, -1.03)   # scenario config.yaml empty_point
+ROBOT_Z = 0.2                 # BasicSimScene.yaml robots[0].position z
+SOURCE = (5.5, -6.5)          # sim1 sim.yaml source position
+
+
+# ---- Eq. (3): both implementations, transcribed verbatim -------------------
+# Only the pose binding differs: the original reads the SLAM/odom estimate
+# (x_, y_, yaw_); the port reads ground truth (real_x_, real_y_, real_yaw_).
+# The arithmetic is identical, so identical inputs must give identical outputs.
+
+def orig_probability(x, y, x_, y_, yaw_, wind_speed_, wind_direction_):
+    """adsm_orig/src/adsm.cpp:199-217 (commit 1f3c6a0b)."""
+    Q = 4.0
+    D = 1.0
+    tau = 250
+    V = wind_speed_
+    phi = yaw_ - wind_direction_
+    lam = math.sqrt(D * tau / (1 + V * V * tau / (4 * D)))
+    dis = math.sqrt((x - x_) * (x - x_) + (y - y_) * (y - y_))
+    dx = x_ - x
+    dy = y_ - y
+
+    pa = Q / (4 * math.pi * D * (abs(dis + 0.0001)))
+    pb = math.exp(-dis / lam)
+    pc = math.exp(-dx * V * math.cos(phi) / (2 * D))
+    pd = math.exp(-dy * V * math.sin(phi) / (2 * D))
+    return pa * pb * pc * pd
+
+
+def port_probability(x, y, real_x_, real_y_, real_yaw_, wind_speed_,
+                     wind_direction_):
+    """src/base/adsm/src/adsm.cpp probability()."""
+    Q = 4.0
+    D = 1.0
+    tau = 250
+    V = wind_speed_
+    phi = real_yaw_ - wind_direction_
+    lam = math.sqrt(D * tau / (1 + V * V * tau / (4 * D)))
+    dis = math.sqrt((x - real_x_) * (x - real_x_) + (y - real_y_) * (y - real_y_))
+    dx = real_x_ - x
+    dy = real_y_ - y
+
+    pa = Q / (4 * math.pi * D * (abs(dis + 0.0001)))
+    pb = math.exp(-dis / lam)
+    pc = math.exp(-dx * V * math.cos(phi) / (2 * D))
+    pd = math.exp(-dy * V * math.sin(phi) / (2 * D))
+    return pa * pb * pc * pd
+
+
+# ---- gas binarization (port, PID thresholds) -------------------------------
+def gas_binarize(window, gas_high_th=0.3, gas_low_th=0.1):
+    if not window:
+        return False
+    gas = window[-1]
+    if gas < gas_low_th:
+        return False
+    if gas > gas_high_th:
+        return True
+    for i in range(1, len(window)):
+        if window[i] >= window[i - 1]:
+            return True
+    return False
+
+
+# ---- wind field ------------------------------------------------------------
+class WindField:
+    """Index-addressed CFD lookup.
+
+    The cells sit on an exact 0.1 m lattice but at an arbitrary offset
+    (x0=-1.85, y0=-8.45105), so snapping to a multiple of the resolution never
+    reproduces a cell centre. Index off the measured origin instead, and never
+    silently default -- an out-of-domain query returns None so callers must
+    decide, rather than quietly injecting V=0.
+    """
+
+    def __init__(self, path, target_z=ROBOT_Z):
+        # The CSV is a 3D field (31 z-levels for House09). Collapsing it would
+        # let upper layers clobber the robot's own height, so select the single
+        # layer nearest the robot before building the lattice.
+        rows = []
+        with open(path) as f:
+            for row in csv.DictReader(f):
+                rows.append((float(row["Points:0"]), float(row["Points:1"]),
+                             float(row["Points:2"]),
+                             float(row["U:0"]), float(row["U:1"])))
+        levels = sorted({r[2] for r in rows})
+        self.z = min(levels, key=lambda z: abs(z - target_z))
+        self.n_levels = len(levels)
+        pts = [(x, y, u, v) for x, y, z, u, v in rows if z == self.z]
+        xs = sorted({p[0] for p in pts})
+        ys = sorted({p[1] for p in pts})
+        self.x0, self.y0 = xs[0], ys[0]
+        self.nx, self.ny = len(xs), len(ys)
+        self.res = round(xs[1] - xs[0], 6) if len(xs) > 1 else 0.1
+        self.u = np.full((self.ny, self.nx), np.nan)
+        self.v = np.full((self.ny, self.nx), np.nan)
+        for x, y, u, v in pts:
+            ix = int(round((x - self.x0) / self.res))
+            iy = int(round((y - self.y0) / self.res))
+            self.u[iy, ix] = u
+            self.v[iy, ix] = v
+        self.cells = len(pts)
+
+    def at(self, wx, wy):
+        ix = int(round((wx - self.x0) / self.res))
+        iy = int(round((wy - self.y0) / self.res))
+        if not (0 <= ix < self.nx and 0 <= iy < self.ny):
+            return None
+        u, v = self.u[iy, ix], self.v[iy, ix]
+        if math.isnan(u) or math.isnan(v):
+            return None
+        return float(u), float(v)
+
+    def self_test(self):
+        """Every cell centre must resolve to its own value. Guards the exact
+        bug that made the previous test vacuous."""
+        hits = 0
+        checked = 0
+        for iy in range(0, self.ny, max(1, self.ny // 40)):
+            for ix in range(0, self.nx, max(1, self.nx // 40)):
+                if math.isnan(self.u[iy, ix]):
+                    continue
+                wx = self.x0 + ix * self.res
+                wy = self.y0 + iy * self.res
+                got = self.at(wx, wy)
+                checked += 1
+                if got is not None and abs(got[0] - self.u[iy, ix]) < 1e-12:
+                    hits += 1
+        return hits, checked
+
+
+def speed_dir(u, v):
+    return math.hypot(u, v), math.atan2(v, u)
+
+
+# ---- occupancy -------------------------------------------------------------
+def load_occupancy():
+    import yaml
+    with open(OCC_YAML) as f:
+        cfg = yaml.safe_load(f)
+    res = float(cfg["resolution"])
+    ox, oy = float(cfg["origin"][0]), float(cfg["origin"][1])
+    with open(os.path.join(os.path.dirname(OCC_YAML), cfg["image"]), "rb") as f:
+        magic = f.readline().strip()
+        line = f.readline()
+        while line.startswith(b"#"):
+            line = f.readline()
+        w, h = (int(t) for t in line.split())
+        maxval = int(f.readline().strip())
+        if magic == b"P5":
+            img = np.frombuffer(f.read(w * h), dtype=np.uint8).reshape(h, w)
+        elif magic == b"P2":
+            img = np.array(f.read().split()[:w * h], dtype=int).reshape(h, w)
+        else:
+            sys.exit(f"unsupported PGM magic {magic!r} in {cfg['image']}")
+    # GADEN writes this map as P2 with maxval 1, so pixels are literally 0/1 --
+    # NOT the 0..255 a map_server-style `img >= 254` free test assumes (that
+    # silently yields zero free cells here). Scale by maxval instead, and honour
+    # the yaml's free_thresh/negate the way map_server does.
+    occ_prob = 1.0 - (img.astype(float) / float(maxval))   # negate: 0
+    if int(cfg.get("negate", 0)):
+        occ_prob = 1.0 - occ_prob
+    free = occ_prob < float(cfg.get("free_thresh", 0.1))
+    if not free.any():
+        sys.exit(f"FATAL: 0 free cells parsed from {cfg['image']} "
+                 f"(magic={magic!r} maxval={maxval}) -- occupancy decode is wrong")
+    return img, free, res, ox, oy, h
+
+
+def grid_to_world(gx, gy, res, ox, oy, h):
+    return ox + (gx + 0.5) * res, oy + (h - 1 - gy + 0.5) * res
+
+
+# ---- tests -----------------------------------------------------------------
+def run_equivalence(winds, free, res, ox, oy, h, n_cases=100000):
+    print("\n" + "=" * 68)
+    print("TEST 1  equivalence: orig vs port probability(), real House09 wind")
+    print("=" * 68)
+
+    free_cells = np.argwhere(free)          # (row, col) = (gy, gx)
+    rng = random.Random(42)
+    nprng = np.random.default_rng(42)
+
+    mismatches = 0
+    maxdiff = 0.0
+    bad_values = 0
+    tested = 0
+    zero_wind = 0
+    speeds = []
+
+    for _ in range(n_cases):
+        gy_r, gx_r = free_cells[nprng.integers(len(free_cells))]
+        rx, ry = grid_to_world(gx_r, gy_r, res, ox, oy, h)
+        ryaw = rng.uniform(-math.pi, math.pi)
+
+        wf = winds[rng.randrange(len(winds))]
+        w = wf.at(rx, ry)
+        if w is None:
+            continue                        # outside the CFD domain
+        ws, wd = speed_dir(*w)
+        speeds.append(ws)
+        if ws == 0.0:
+            zero_wind += 1
+
+        # candidate within the paper's random_sample_r = 3.0 m, in free space
+        for _ in range(20):
+            ang = rng.uniform(-math.pi, math.pi)
+            d = rng.uniform(0.01, 3.0)
+            cx, cy = rx + d * math.cos(ang), ry + d * math.sin(ang)
+            gcx = int((cx - ox) / res)
+            gcy = h - 1 - int((cy - oy) / res)
+            if 0 <= gcy < free.shape[0] and 0 <= gcx < free.shape[1] and free[gcy, gcx]:
+                break
+        else:
+            continue
+
+        p_orig = orig_probability(cx, cy, rx, ry, ryaw, ws, wd)
+        p_port = port_probability(cx, cy, rx, ry, ryaw, ws, wd)
+
+        if p_orig != p_port:
+            mismatches += 1
+            maxdiff = max(maxdiff, abs(p_orig - p_port))
+        if not (math.isfinite(p_port) and p_port >= 0.0):
+            bad_values += 1
+        tested += 1
+
+    speeds = np.array(speeds) if speeds else np.array([0.0])
+    print(f"  cases tested        : {tested}")
+    print(f"  wind speed m/s      : min={speeds.min():.4f} mean={speeds.mean():.4f} "
+          f"max={speeds.max():.4f}")
+    print(f"  cells with V=0      : {zero_wind}/{tested} "
+          f"({100.0 * zero_wind / max(tested, 1):.1f}%)")
+    print(f"  orig vs port        : mismatches={mismatches}  max|diff|={maxdiff}")
+    print(f"  non-finite/negative : {bad_values}")
+
+    ok = (mismatches == 0 and bad_values == 0 and tested > 0)
+    # If the wind were silently zero everywhere, the wind terms of Eq.3 would
+    # never be exercised and this test would prove nothing -- fail loudly.
+    if speeds.max() <= 0.0:
+        print("  FAIL: wind is zero everywhere -- CFD not actually loaded")
+        ok = False
+    print(f"  VERDICT: {'PASS' if ok else 'FAIL'}")
+    return ok
+
+
+def run_heatmap(winds, occ_img, free, res, ox, oy, h, out="/tmp/house09_probability_map.png"):
+    print("\n" + "=" * 68)
+    print("TEST 2  probability field at the paper's start pose")
+    print("=" * 68)
+    rx, ry = ROBOT_START
+    w = winds[0].at(rx, ry)
+    if w is None:
+        print("  start pose outside CFD domain; skipping")
+        return
+    ws, wd = speed_dir(*w)
+    print(f"  robot {ROBOT_START}  wind speed={ws:.4f} dir={math.degrees(wd):.1f}deg")
+
+    H, W = occ_img.shape
+    grid = np.full((H, W), np.nan)
+    for gy in range(H):
+        for gx in range(W):
+            if not free[gy, gx]:
+                continue
+            wx, wy = grid_to_world(gx, gy, res, ox, oy, h)
+            grid[gy, gx] = port_probability(wx, wy, rx, ry, 1.57, ws, wd)
+
+    valid = grid[np.isfinite(grid)]
+    print(f"  probability range   : [{valid.min():.3e}, {valid.max():.3e}]")
+    try:
+        import matplotlib
+        matplotlib.use("Agg")
+        import matplotlib.pyplot as plt
+        lo, hi = np.percentile(valid, 1), np.percentile(valid, 99)
+        norm = np.clip((grid - lo) / max(hi - lo, 1e-30), 0, 1)
+        plt.figure(figsize=(6, 9))
+        plt.imshow(np.where(free, 1.0, 0.0), cmap="gray", vmin=0, vmax=1)
+        plt.imshow(norm, cmap="jet", alpha=np.where(np.isfinite(grid), 0.65, 0.0))
+        plt.plot(int((rx - ox) / res), h - 1 - int((ry - oy) / res), "wo", ms=6)
+        plt.title("ADSM probability() -- House09, real CFD wind")
+        plt.axis("off")
+        plt.tight_layout()
+        plt.savefig(out, dpi=110)
+        print(f"  heatmap             : {out}")
+    except Exception as e:                                  # noqa: BLE001
+        print(f"  (heatmap skipped: {e})")
+
+
+def run_online_gas(winds, free, res, ox, oy, h):
+    print("\n" + "=" * 68)
+    print("TEST 3  live GADEN gas -> binarization")
+    print("=" * 68)
+    try:
+        import rclpy
+        from rclpy.node import Node
+        from gaden_msgs.srv import GasPosition
+    except Exception as e:                                  # noqa: BLE001
+        print(f"  ROS unavailable ({e}); skipping")
+        return
+
+    rclpy.init()
+    node = Node("house09_equiv_gas_test")
+    cli = node.create_client(GasPosition, "/odor_value")
+    if not cli.wait_for_service(timeout_sec=5):
+        print("  /odor_value not up (needs gaden_player running); skipping")
+        rclpy.shutdown()
+        return
+
+    # Walk a straight transect from start toward the source, so samples form a
+    # genuine TIME series along a path. Sampling scattered points and pushing
+    # them through the 6-sample window would be meaningless: the window models
+    # a sensor's history at one moving robot, not unrelated places.
+    sx, sy = ROBOT_START
+    tx, ty = SOURCE
+    n = 120
+    window, hits, concs = [], 0, []
+    for i in range(n + 1):
+        t = i / n
+        wx, wy = sx + t * (tx - sx), sy + t * (ty - sy)
+        req = GasPosition.Request()
+        req.x, req.y, req.z = float(wx), float(wy), 0.4
+        fut = cli.call_async(req)
+        rclpy.spin_until_future_complete(node, fut, timeout_sec=1.0)
+        if fut.result() is None:
+            continue
+        c = fut.result().concentration
+        concs.append(c)
+        window.append(c)
+        if len(window) > 6:
+            window.pop(0)
+        if gas_binarize(window):
+            hits += 1
+    rclpy.shutdown()
+
+    if not concs:
+        print("  no samples returned")
+        return
+    a = np.array(concs)
+    print(f"  transect samples    : {len(a)}  (start -> source)")
+    print(f"  gas ppm             : min={a.min():.4f} mean={a.mean():.4f} max={a.max():.4f}")
+    print(f"  non-zero cells      : {int((a > 1e-3).sum())}/{len(a)}")
+    print(f"  binarized hits      : {hits}/{len(a)}")
+    if a.max() <= 1e-6:
+        print("  WARNING: all-zero gas -- is the sim playing back a mature iteration?")
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--online", action="store_true",
+                    help="also query a running gaden_player for real gas")
+    ap.add_argument("--cases", type=int, default=100000)
+    args = ap.parse_args()
+
+    print("=" * 68)
+    print("ADSM House09 real-data test")
+    print(f"  scenario: {HOUSE_DIR}")
+    print("=" * 68)
+
+    if not os.path.isdir(WIND_DIR):
+        sys.exit(f"wind dir not found: {WIND_DIR}  (set HOUSE09_DIR)")
+
+    print("\n[1] loading CFD wind fields...")
+    winds = []
+    for i in range(10):
+        p = os.path.join(WIND_DIR, f"wind_at_cell_centers_{i}.csv")
+        if os.path.exists(p):
+            winds.append(WindField(p))
+    if not winds:
+        sys.exit(f"no wind_at_cell_centers_*.csv in {WIND_DIR}")
+    w0 = winds[0]
+    print(f"    {len(winds)} fields, {w0.cells} cells each")
+    print(f"    grid {w0.nx}x{w0.ny}  res={w0.res}  origin=({w0.x0}, {w0.y0})")
+
+    hits, checked = w0.self_test()
+    print(f"    lookup self-test: {hits}/{checked} cell centres resolve")
+    if checked == 0 or hits != checked:
+        sys.exit("FATAL: wind lookup cannot find its own cells -- the offset-grid "
+                 "bug is back; every query would silently return V=0.")
+
+    print("\n[2] loading occupancy...")
+    occ_img, free, res, ox, oy, h = load_occupancy()
+    print(f"    {occ_img.shape[1]}x{occ_img.shape[0]}  res={res}  "
+          f"origin=({ox}, {oy})  free={int(free.sum())} cells")
+
+    ok = run_equivalence(winds, free, res, ox, oy, h, args.cases)
+    run_heatmap(winds, occ_img, free, res, ox, oy, h)
+    if args.online:
+        run_online_gas(winds, free, res, ox, oy, h)
+
+    print("\n" + "=" * 68)
+    print(f"RESULT: {'PASS' if ok else 'FAIL'}")
+    print("=" * 68)
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmark_env_realistic/CMakeLists.txt
+++ b/benchmark_env_realistic/CMakeLists.txt
@@ -1,0 +1,12 @@
+cmake_minimum_required(VERSION 3.8)
+project(benchmark_env_realistic)
+
+find_package(ament_cmake REQUIRED)
+
+install(DIRECTORY
+  launch
+  navigation_config
+  DESTINATION share/${PROJECT_NAME}
+)
+
+ament_package()

--- a/benchmark_env_realistic/GPULAIKA_FAITHFUL_NAV2.md
+++ b/benchmark_env_realistic/GPULAIKA_FAITHFUL_NAV2.md
@@ -1,0 +1,102 @@
+# Running GPULaika with the faithful Nav2 profile
+
+This mode combines three pieces:
+
+- `gsl_bench` loads GPULaika, supplies observations, requests waypoints, and records results.
+- `benchmark_env_realistic` launches BasicSim, GADEN, sensors, Cartographer, and Nav2.
+- `nav2_realistic_params_adsm_faithful.yaml` controls physical robot movement.
+
+The faithful profile is closer to the original ROS1 `move_base` setup than the standard
+profile. In particular, it permits reverse motion (`min_vel_x: -0.22`) and permits faster
+rotation (`max_vel_theta: 2.75`). This should make it better at escaping tight wedges, but
+it is still an experimental profile: compare results before making it the global default.
+
+## Build and source
+
+The new `--nav-profile` evaluator option and launch arguments require rebuilding both
+packages:
+
+```bash
+cd /home/efe/ros2_ws
+colcon build --packages-select benchmark_env_realistic gsl_bench --symlink-install
+source install/setup.bash
+```
+
+The shipped GPULaika configuration is:
+
+```text
+/home/efe/ros2_ws/src/gsl_bench/configs/agents/gpulaika.yaml
+```
+
+That YAML points to the trained `.pt` checkpoint. `gsl_bench` loads the checkpoint; Nav2
+does not load or run the neural network.
+
+## Recommended smoke test
+
+Start with one run on one scenario:
+
+```bash
+cd /home/efe/ros2_ws
+source install/setup.bash
+
+ros2 run gsl_bench eval \
+  --agent gpulaika \
+  --agent-config src/gsl_bench/configs/agents/gpulaika.yaml \
+  --scenario 4_rooms_start_a \
+  --runs 1 \
+  --realistic \
+  --motion nav2 \
+  --nav-profile faithful \
+  --domain-id 42
+```
+
+`--realistic` selects SLAM-derived TF pose, the live SLAM map, and the
+`benchmark_env_realistic` launch package. `--motion nav2` is required: the profile has no
+effect with DirectDrive. Use a unique domain ID if another ROS experiment is running.
+
+## Run the seven-scenario suite
+
+```bash
+cd /home/efe/ros2_ws
+source install/setup.bash
+
+ros2 run gsl_bench eval \
+  --agent gpulaika \
+  --agent-config src/gsl_bench/configs/agents/gpulaika.yaml \
+  --suite nav7 \
+  --runs 5 \
+  --realistic \
+  --motion nav2 \
+  --nav-profile faithful \
+  --domain-id 42
+```
+
+Add `--escape` only when intentionally evaluating GPULaika with the harness-level frontier
+escape mechanism. It materially changes the method and is recorded in `result.json`, so do
+not mix results produced with and without it.
+
+## Launch only the environment
+
+For manual testing without loading GPULaika:
+
+```bash
+ros2 launch benchmark_env_realistic realistic_launch.py \
+  scenario:=4_rooms_start_a \
+  motion:=nav2 \
+  nav_profile:=faithful
+```
+
+This launches the environment and faithful Nav2 controller, but no model or benchmark
+runner. Use `gsl_bench eval` when you want GPULaika to choose and send waypoints.
+
+## Confirm the selected profile
+
+During a run, the following values should report approximately `-0.22` and `2.75`:
+
+```bash
+ROS_DOMAIN_ID=42 ros2 param get /PioneerP3DX/controller_server FollowPath.min_vel_x
+ROS_DOMAIN_ID=42 ros2 param get /PioneerP3DX/controller_server FollowPath.max_vel_theta
+```
+
+Every evaluation result also records `"nav_profile": "faithful"` inside its `harness`
+section, preventing accidental comparison with the standard profile.

--- a/benchmark_env_realistic/NAV2_LOGIC_REVIEW_20260718.md
+++ b/benchmark_env_realistic/NAV2_LOGIC_REVIEW_20260718.md
@@ -1,0 +1,164 @@
+# Nav2 Logic Review — `benchmark_env_realistic`
+
+**Date:** 2026-07-18
+**Scope:** `navigation_config/nav2_realistic_params.yaml`, `nav2_realistic_params_adsm_faithful.yaml`,
+`cartographer_realistic.lua`, `nav2_realistic_launch.py`, `launch/realistic_launch.py`, the two BT
+XMLs in `src/base/gaden_config/navigation_config/`, and `src/directdrive_nav/directdrive_nav.py`.
+
+## Which SLAM backend is actually in use
+
+**Cartographer**, not slam_toolbox — the eval runs pass `--slam-backend cartographer` (confirmed in
+`Results/gpulaika_20260717_211900/.../result.json`), which loads
+`navigation_config/cartographer_realistic.lua`.
+
+**But the code default is `slam_toolbox`** — in `episode_runner.py:582`, `realistic_launch.py:30`,
+and `nav2_realistic_launch.py:216` — and **no driver/sbatch/script in the workspace overrides it**;
+only the interactive CLI invocation does. Consequences for this review:
+
+- The whole `slam_toolbox:` block in `nav2_realistic_params.yaml` (lines 2–87) and the README's
+  "SLAM tuning notes" table describe a backend you don't run. It's **dead config** in the actual
+  pipeline — keep it as a fallback, but don't tune against it, and the earlier
+  "transform_tolerance vs Ceres solver latency spikes" concern is **moot under Cartographer**
+  (Ceres is Karto's solver; Cartographer publishes pose at 200 Hz and its `map→odom` staleness is
+  bounded by the lua's `lookup_transform_timeout_sec = 0.2`, not by solver spikes).
+
+## TL;DR
+
+The core wiring is **sound**. In particular the Cartographer TF setup is correct and non-obvious:
+`published_frame = PioneerP3DX_odom` + `provide_odom_frame = false` makes Cartographer stack its
+correction as `map→odom` (letting BasicSim's native `odom→base_link` complete the chain) instead of
+giving `base_link` two TF parents — the lua comment documents that the naive alternative froze Nav2
+with spurious collisions. SLAM-vs-lifecycle separation, the GoalUpdater BT, and the DirectDrive
+frame math also check out. No "drives through walls" bug.
+
+Findings are **robustness / portability / verify-me**, ranked most-worth-acting-on first:
+
+1. Code default is `slam_toolbox` but you run `cartographer` — a forgotten flag silently degrades the map.
+2. Hardcoded absolute paths (BT XMLs + DirectDrive script) — breaks in containers / relocated trees.
+3. Cartographer `max_range`/`missing_data_ray_length` (2.9) is manually pinned to the `lidar_max_range` arg (3.0), not derived from it — raising the arg silently stops mapping real walls past 2.9 m.
+4. Cartographer frames are hardcoded `PioneerP3DX_*` — any other `namespace:=` silently breaks `map→odom`.
+5. Verify the local costmap actually receives the scan (relative `$(var namespace)/laser_scanner` under `PushRosNamespace`).
+6. DirectDrive live-map cost + `_nearest_free` snapping edge cases.
+
+---
+
+## What is correct / sound by design
+
+- **Cartographer TF chain** (see TL;DR): `map→odom` from Cartographer, `odom→base_link` from
+  `basic_sim`, no double-parent. Correct and the trickiest part of the whole setup.
+- **Cartographer scan wiring is clean under the namespace.** The node is launched inside
+  `PushRosNamespace`, with `remappings=[("scan","laser_scanner")]`, so it subscribes to the relative
+  `laser_scanner` → `/PioneerP3DX/laser_scanner`, matching what `basic_sim` publishes. The
+  occupancy-grid node's `("map","map")` → `/PioneerP3DX/map`, matching DirectDrive / costmap
+  consumers. (This is cleaner than the slam_toolbox path, which needed an *absolute* scan topic to
+  avoid double-namespacing — see #5, which is really only about the Nav2 costmap side now.)
+- **The no-hit-ray free-space classification is handled correctly for Cartographer.** BasicSim
+  publishes no-hit rays at exactly `maxDistance` (= `lidar_max_range`); the lua's
+  `max_range = 2.9` sits strictly below that so those readings classify as *misses* and get
+  free-space credit out to `missing_data_ray_length = 2.9`. This is the whole reason Cartographer
+  was chosen over Karto (which discards the reading). Correct — modulo the fragile coupling in #3.
+- **slam_toolbox excluded from the lifecycle manager**, GoalUpdater BT is a safe superset of the
+  stock tree (gsl_bench sends discrete per-step `NavigateToPose` goals and blocks for arrival; only
+  the ADSM node publishes to `goal_update`), `yaw_goal_tolerance: 6.28` intentional for position-only
+  GSL goals, DirectDrive frame math consistent across live-SLAM and static-PGM. (All as in the first
+  pass — unchanged by the backend correction.)
+
+---
+
+## Findings
+
+### 1. The default backend does not match actual use (highest practical value)
+
+`--slam-backend` defaults to `slam_toolbox` everywhere, and every real run must remember to pass
+`cartographer`. A single forgotten flag (a new sbatch, a manual repro, a teammate) silently runs
+Karto with its documented no-free-space-credit gap at `max_laser_range` — degraded maps, no error,
+results that look valid. Make `cartographer` the default (flip the three defaults), or have the
+runner refuse to start without an explicit choice. Cheap, removes a whole class of silent-bad-map
+runs.
+
+### 2. Hardcoded absolute paths — portability (medium)
+
+Three baked-in `/home/efe/ros2_ws/...` paths:
+`nav2_realistic_params.yaml:141` (`adsm_goal_update_bt.xml`),
+`nav2_realistic_params_adsm_faithful.yaml:120` (`adsm_faithful_bt.xml`),
+`nav2_realistic_launch.py:17` (`DIRECTDRIVE_NAV_SCRIPT`). All exist locally, but the workspace is
+containerized (Pyxis/enroot) where the source prefix can differ or be stripped from the install
+tree, and these fail at *runtime*. Resolve via `get_package_share_directory(...)` / share-install
+the XMLs and script, or an env var.
+
+### 3. Cartographer range coupling is manual and silently breaks if `lidar_max_range` changes (medium)
+
+`lidar_max_range` is a real, plumbed launch arg (`realistic_launch.py:51`, default 3.0) that patches
+the scene sensor at launch. But `cartographer_realistic.lua` **hardcodes** `max_range = 2.9` and
+`missing_data_ray_length = 2.9` in a static file, with only a comment telling a human to keep them
+0.1 below the arg. Raise `lidar_max_range:=5.0` (nothing stops it) and:
+- no-hit rays now arrive at 5.0, still > 2.9, still classify as misses — but only credit free space
+  out to 2.9 m, not 5 m; and
+- **real walls between 2.9 m and 5 m exceed `max_range` and are classified as misses (free space) —
+  they never get mapped at all.**
+
+There's no runtime check tying the two together. Either derive the lua values from the arg
+(generate the lua at launch like the scene file already is), or assert `lidar_max_range` equals the
+value the lua was written for and fail loudly otherwise. Today it works only because both sit at
+their defaults.
+
+### 4. Cartographer frames hardcoded to `PioneerP3DX_*` (low, latent)
+
+`cartographer_realistic.lua` hardcodes `tracking_frame`, `published_frame`, `odom_frame` to
+`PioneerP3DX_*` (the file documents this as intentional). So `namespace:=` anything else brings up
+Cartographer publishing/looking-up the wrong frames → `map→odom` never connects → Nav2 hangs or
+reports phantom collisions, silently. Same latent class as the top-level `PioneerP3DX:` param key in
+`nav2_realistic_params.yaml` (baseline uses `$(var namespace):`). Default namespace is
+`PioneerP3DX` everywhere so neither is active, but both are footguns worth a one-line guard or a
+templated lua.
+
+### 5. Verify the *local costmap* actually receives the scan (verify — Nav2 side, backend-independent)
+
+The costmap observation sources use a **relative** `topic: $(var namespace)/laser_scanner`
+(`nav2_realistic_params.yaml` lines 267, 293) while the Nav2 nodes run inside
+`PushRosNamespace(namespace)`. That can resolve to a doubled `/PioneerP3DX/PioneerP3DX/laser_scanner`
+vs. the `/PioneerP3DX/laser_scanner` that `basic_sim` publishes. (The SLAM side is fine — Cartographer
+uses a relative *remap* that resolves correctly; this is purely the Nav2 costmap layers.) Identical
+pattern is used in the proven non-realistic `benchmark_env/nav2_params.yaml`, so it may resolve
+correctly — but if it doesn't, the local voxel/obstacle layer gets no live scan and the robot coasts
+on Cartographer's static layer for planning, masking the problem. Confirm during a run:
+
+```bash
+ROS_DOMAIN_ID=42 ros2 node info /PioneerP3DX/controller_server | grep laser_scanner
+```
+
+If the subscription shows the doubled path, make the costmap `topic` absolute
+(`/$(var namespace)/laser_scanner`). Same question for `bt_navigator odom_topic: $(var namespace)/odom`
+(line 134).
+
+### 6. DirectDrive live-map cost + `_nearest_free` snapping (low–medium)
+
+`directdrive_nav.py`:
+- `_map_cb` runs a full `binary_dilation` on **every** map message and A* over the whole grid per
+  goal; on large maps at the SLAM publish rate this can contend with the 10 Hz `_control_tick` under
+  the `MultiThreadedExecutor`. Throttle to when goal/map region actually changes.
+- `_nearest_free` snaps a blocked start/goal to the global nearest free cell via `np.argwhere(~occ)`;
+  a goal just inside a dilated wall can snap to the **other side** of that wall → an inexecutable
+  path → burns the full 5 s `goal_timeout` then aborts.
+- `_control_tick` drives open-loop toward the next waypoint with no per-tick re-validation against a
+  freshly updated map; BasicSim's hard collision makes this *safe* (it stalls to timeout) but slow.
+
+### 7. Minor / cosmetic
+
+- `slam_toolbox:` block (params 2–87), the `amcl:` block (never launched, both files), and the
+  README "SLAM tuning notes" table are all inert under Cartographer. Harmless but misleading — a
+  reader would reasonably think they're what governs mapping.
+- Standard-params DWB `min_vel_x: 0.0` (no reverse) + BasicSim hard-collision = the wedging failure
+  mode that motivated DirectDrive; `motion:=nav2` is the weaker choice for tight scenarios, prefer
+  `motion:=directdrive` there. (Expected, not a bug.)
+
+---
+
+## Bottom line
+
+Under the backend you actually run (Cartographer), the navigation logic is correctly structured and
+the hard parts — the `map→odom` framing and the no-hit-ray free-space classification — are done
+right. No functional drive bug. The top action item is #1: **make `cartographer` the default (or
+force an explicit choice)** so a forgotten flag can't silently drop you onto the degraded Karto
+backend. After that: the portability paths (#2) and the fragile range coupling (#3), then the two
+verify-against-a-run items (#4 frames, #5 costmap scan).

--- a/benchmark_env_realistic/OUTLET_WALL_PLAN.md
+++ b/benchmark_env_realistic/OUTLET_WALL_PLAN.md
@@ -1,0 +1,165 @@
+# Implementation Plan — Make GADEN outlets solid to the SLAM lidar
+
+**Date:** 2026-07-18
+**Package:** `benchmark_env_realistic`
+**Status:** proposed
+
+## Problem
+
+In the ground-truth navigation path, GADEN **outlet** cells (the map "inlets" — vent/door
+openings on the boundary) are treated as **walls**. In the realistic (Cartographer) path they are
+**passable**: the robot's SLAM map shows them as free space, the planner routes through them, and —
+because BasicSim uses the same 2-state map for physics — the robot can physically drive out through
+the opening.
+
+### Root cause (confirmed with data, 4_rooms_start_c, z = 0.5 m)
+
+GADEN's 3D occupancy grid uses three states: `0` free, `1` wall, `2` outlet. Two consumers diverge:
+
+| consumer | outlet (value 2) becomes | result |
+|---|---|---|
+| **Ground-truth loader** `efe_igdm/mapping/occupancy_grid.py:98-119` | `grid_2d = (grid_2d > 0)` → **occupied**; plus `outlet_mask` re-stamped as `CELL_OUTLET` by `LidarMapper`, non-traversable in `is_valid`/`is_valid_traversable` | outlets = walls |
+| **BasicSim `occupancy.pgm`** (what the realistic lidar ray-casts against) | GADEN preprocessing rendered all 180 outlet cells as PGM pixel `1` = **free** | lidar passes through → Cartographer maps free → planner + physics let the robot exit |
+
+Cross-tab that produced this (GADEN state → PGM pixel): `free(0)→1`, `wall(1)→0`,
+`outlet(2)→1 for all 180 cells`. The outlets are boundary/vent openings, **not** interior
+doorways — the ground-truth evals navigate 4_rooms fine while treating all 180 as walls, which
+proves walling them does not block room-to-room passage.
+
+## Chosen approach
+
+**Patch the occupancy map BasicSim loads, at launch time**, so the outlet cells are marked occupied
+— the same mechanism `realistic_launch.py` already uses to patch the scene's lidar resolution into a
+temp copy. Cartographer then maps a wall there because the sensor *genuinely returns a hit* (honest
+SLAM — no a-priori outlet knowledge injected into the map after the fact), BasicSim collision blocks
+the robot from exiting, and lidar / physics / planner / ground-truth all agree. This also matches
+what the RL policies were trained against (outlets-as-walls).
+
+Rejected alternatives: post-processing the Cartographer map (dishonest; physics still lets the robot
+exit); regenerating `occupancy.pgm` at presim (mutates the *shared* `benchmark_env` map, risks
+shifting non-realistic baselines); clipping planning to `env_min/env_max` (only masks boundary
+outlets, doesn't stop physical exit).
+
+## Design details
+
+### Convention-independent occupied value
+BasicSim thresholds via `Map.cpp:56` (`pixel > 255*(1-occupied_thresh)` → Free). Rather than reason
+about that threshold or OpenCV's handling of a maxval-1 PGM, **copy the value existing walls already
+use**: in every scenario PGM (all `P2`, maxval 1) wall cells are pixel `0`. So marking a cell
+occupied = set its pixel to `0`. Robust to any threshold/scaling.
+
+### Coordinate alignment (CSV grid ↔ PGM pixels)
+Both grids are the same shape, resolution (0.1), and origin (`[-0.4,-0.4]`), so it's a pure index
+map with a possible y-flip:
+- GADEN CSV reshapes to `grid[z, y, x]`, cell `(x=0,y=0)` at `env_min` (bottom-left); row `y` grows
+  with world +y.
+- PGM row 0 = **top** = max y (ROS map_server / image convention). BasicSim confirms this by reading
+  with `height - y - 1` (`Map.cpp:57-60`).
+- ⇒ outlet at GADEN `(x, y)` → PGM `(row = ny-1-y, col = x)`.
+
+**Self-calibrate the flip** instead of hard-coding it: compute the overlap of `GADEN==1` (walls)
+with `PGM==0` (occupied) for both the flipped and unflipped mapping, and adopt whichever maximizes
+overlap; then apply that same transform to the `GADEN==2` outlet cells. This auto-corrects if a
+scenario's PGM was generated with a different flip, and fails loud if neither orientation aligns
+(guard: require ≥ ~80% wall overlap, else skip patch + warn).
+
+### Which z-levels
+Outlet footprint is z-invariant (180 cells at z = 1, 5, 10 alike). Union outlets over all z-levels
+(`(grid == 2).any(axis=0)`) to get the full 2D footprint — robust to the harness's chosen nav
+z-level.
+
+## Implementation steps
+
+### 1. `launch/realistic_launch.py` — add a map-patch helper
+In `launch_setup`, after the scene is loaded and `scene["map"]` is resolved to an absolute
+`occupancy.yaml` path (currently lines ~93-104), insert a call that rewrites `scene["map"]` to a
+patched map:
+
+```python
+def _wall_outlets_map(occ_yaml_path, scenario, configuration, namespace):
+    """Return path to a temp occupancy.yaml whose PGM has GADEN outlet cells
+    (OccupancyGrid3D.csv value 2) marked occupied. Returns the original path
+    unchanged if the CSV is missing or wall-overlap calibration fails."""
+    cfg_dir = os.path.dirname(occ_yaml_path)
+    csv_path = os.path.join(cfg_dir, "OccupancyGrid3D.csv")
+    if not os.path.exists(csv_path):
+        return occ_yaml_path  # warn: outlets not walled
+    # parse CSV header (env_min, num_cells, cell_size) + body (';'-tokenized)
+    # build grid[z,y,x]; outlet2d = (grid == 2).any(axis=0); wall2d = (grid == 1).any(axis=0)
+    # load P2 pgm (W,H,maxval, pixels); OCC = 0
+    # calibrate flip: for m in (pgm, flipud(pgm)): overlap = (m[wall_rows]==OCC).mean()
+    #   pick best; require best_overlap >= 0.8 else return original + warn
+    # set pgm[row,col] = OCC for outlet cells under the chosen mapping
+    # write patched .pgm (P2) + .yaml (image=abs path, copy resolution/origin/thresholds/negate)
+    #   to tempfile.gettempdir()/benchmark_env_realistic_map_{scenario}_{configuration}_{ns}.*
+    # return patched yaml path
+```
+
+Wire it in behind a launch arg (see step 2):
+
+```python
+if LaunchConfiguration("wall_outlets").perform(context).lower() in ("true","1"):
+    scene["map"] = _wall_outlets_map(scene["map"], scenario, configuration, namespace)
+```
+
+Notes:
+- Read/write PGM as `P2` ASCII (matches all current scenarios); if `P5` is ever encountered, handle
+  the binary body too (a 4-line guard) or fall back to the original with a warning.
+- Keep the patched files in `tempfile.gettempdir()` with a scenario/config/namespace-scoped name,
+  same pattern as the existing `patched_scene`.
+- No dependency on OpenCV in the launch file — plain file I/O + numpy (already imported paths use
+  `yaml`; add `numpy`).
+
+### 2. `launch/realistic_launch.py` — new launch argument
+```python
+DeclareLaunchArgument(
+    "wall_outlets", default_value="true",
+    description="Mark GADEN outlet cells (OccupancyGrid3D.csv value 2) as occupied in the "
+                "map BasicSim's lidar sees, so Cartographer maps them as walls (matches the "
+                "ground-truth path). Set false to keep outlets passable.")
+```
+Default **true** (this is the correctness fix). Off gives the old behavior for A/B.
+
+### 3. gsl_bench passthrough (only if a full sweep must toggle it)
+`gsl_bench/gsl_bench/eval/episode_runner.py` builds the launch command (`slam_backend:=` is appended
+around line 426). If you want the sweep to control it, add an `--wall-outlets` arg mirroring
+`--slam-backend` and append `wall_outlets:=...`. Otherwise the launch default (true) applies and no
+gsl_bench change is needed. Record the value in `result.json` meta alongside `slam_backend` for
+provenance.
+
+### 4. DirectDrive `topic` / ground-truth-map mode (follow-up, optional)
+`motion:=directdrive drive_pose_source:=topic` drives on a static `drive_map_yaml`. If that map is a
+ground-truth occupancy, confirm it also walls outlets (the `efe_igdm` loader already does when the
+map comes from the service; a hand-supplied `drive_map_yaml` should be the patched one). Not on the
+default path — note only.
+
+## Testing / verification
+
+1. **Unit (offline), no ROS:** run the patch helper on `4_rooms_start_c`; assert the 180 outlet
+   cells are pixel `0` in the output PGM, wall cells unchanged, free cells unchanged, and the
+   calibrated flip reports ≥ 0.8 wall overlap. Repeat for one `10x6_u_left_*` (104×64) to cover a
+   non-square map.
+2. **Visual:** render original vs patched PGM side by side (reuse `slam_map_captures/` tooling) and
+   eyeball that only the openings filled in.
+3. **Live SLAM:** launch `4_rooms_start_a` realistic + Cartographer with `wall_outlets:=true`,
+   `use_rviz:=true`; confirm the built `/PioneerP3DX/map` now shows walls across the outlet openings
+   and the robot no longer plans/exits through them. Compare against `wall_outlets:=false`.
+4. **Regression:** one full realistic sweep with the flag on vs off; confirm interior room-to-room
+   navigation is unaffected (only boundary openings change) and success/travel metrics for maps
+   without exploitable outlets are unchanged.
+
+## Risks & mitigations
+
+- **Wrong flip silently mis-paints** → self-calibration + the ≥0.8 wall-overlap guard; skip-and-warn
+  rather than emit a corrupted map.
+- **Missing `OccupancyGrid3D.csv`** (scenario not pre-simmed) → return original map + warn; launch
+  still succeeds.
+- **A scenario where outlets *are* meant to be traversable** → the `wall_outlets:=false` escape hatch
+  preserves old behavior; default matches ground truth.
+- **Shared-map contamination** → we never write back into the `benchmark_env` share tree; patched
+  files live only in tempdir.
+
+## Files touched
+- `launch/realistic_launch.py` (helper + launch arg + wiring) — primary.
+- `gsl_bench/gsl_bench/eval/episode_runner.py` (optional passthrough + result.json field).
+- `README.md` / `NAV2_LOGIC_REVIEW_20260718.md` (document the new arg and the outlet semantics).

--- a/benchmark_env_realistic/README.md
+++ b/benchmark_env_realistic/README.md
@@ -1,0 +1,136 @@
+# benchmark_env_realistic
+
+A **realistic-perception layer** on top of [`benchmark_env`](../benchmark_env/README.md).
+Same scenarios, same gas, same robot — but the agent no longer gets ground truth:
+
+| | `benchmark_env` (plain) | `benchmark_env_realistic` |
+|---|---|---|
+| Map | static ground-truth occupancy grid | **built online by slam_toolbox** from lidar |
+| Pose | `/ground_truth` from the simulator | **TF `map → base_link`** as estimated by SLAM |
+| Lidar | 5° / 72 rays | **1° / 360 rays** (ADSM parity, configurable) |
+
+It is fully **plug-and-play**: no scenario files are modified. At launch time the
+scenario's `BasicSimScene.yaml` is copied to a temp file with the lidar patched, so any
+`benchmark_env` scenario works as-is.
+
+## Requirements
+
+- `benchmark_env` built, with the scenario's gas already baked (`presim <scenario>` — see its README).
+- The workspace's **patched BasicSim** (upstream BasicSim publishes `range_max + 1` for
+  no-hit rays, which slam_toolbox silently discards — no free space would ever be mapped
+  along rays into open areas — and it also miscounts partial-FOV rays. Both are fixed in
+  `src/BasicSim`).
+- `slam_toolbox` and Nav2 (`ros-humble-slam-toolbox`, `ros-humble-navigation2`).
+
+## Build
+
+```bash
+cd ~/ros2_ws
+colcon build --packages-select benchmark_env_realistic --base-paths src --symlink-install
+source install/setup.bash
+```
+
+## Run standalone
+
+```bash
+ros2 launch benchmark_env_realistic realistic_launch.py \
+    scenario:=4_rooms_start_a simulation:=sim1
+```
+
+Launch arguments (all optional):
+
+| arg | default | meaning |
+|---|---|---|
+| `scenario` | `10x6_central_obstacle` | any `benchmark_env` scenario |
+| `configuration` / `simulation` | `config1` / `sim1` | gaden project selection |
+| `namespace` | `PioneerP3DX` | robot namespace (frames, topics) |
+| `motion` | `nav2` | `nav2` (DWB drive) or `directdrive` (rotate-then-go cmd_vel controller, same `navigate_to_pose` action interface) |
+| `lidar_deg` | `1.0` | lidar angular resolution in degrees, patched at launch — scene files untouched |
+| `use_rviz` | `False` | open the gaden RViz view |
+
+What it starts: `gaden_player` (gas), `basic_sim` (robot physics + patched lidar,
+publishing its own `<namespace>_odom` → `<namespace>_base_link` odometry TF),
+namespaced `slam_toolbox` (publishes `/<namespace>/map`), the Nav2 stack **or**
+DirectDrive, and the gas/wind sensors
+(PID, anemometer, TDLAS).
+
+## Run a benchmark episode (gsl_bench)
+
+`--realistic` switches gsl_bench to this package and to honest observations
+(`--pose-source tf --map-source slam`): the agent's pose comes from SLAM's TF, its map
+(and the optional frontier-escape) uses the **live SLAM grid**, never ground truth.
+
+```bash
+ros2 run gsl_bench eval \
+    --agent gpulaika --agent-config gpulaika.yaml \
+    --scenario 4_rooms_start_a --runs 5 \
+    --realistic --motion directdrive --domain-id 42
+```
+
+Example `gpulaika.yaml`:
+
+```yaml
+arch: dual
+checkpoint: /path/to/gpu_cfd_localwind_step05_job25311_upd4000_gaden80_ult85_many0.pt
+device: cpu
+lidar_frame: heading
+local_wind_obs: 1
+```
+
+Ground truth is still used *outside* the agent: episode success (distance to true
+source) and travel metrics are judged on the simulator's real pose.
+
+## Watch the SLAM map build / save it
+
+A ready-made RViz profile (`navigation_config/slam_watch.rviz`) shows the SLAM map,
+laser scan, and TF in a top-down view:
+
+```bash
+ROS_DOMAIN_ID=42 rviz2 -d \
+    ~/ros2_ws/src/benchmark_env_realistic/navigation_config/slam_watch.rviz
+```
+
+```bash
+# snapshot to pgm+yaml at any time during a run
+ROS_DOMAIN_ID=42 ros2 run nav2_map_server map_saver_cli -f /tmp/slam_snapshot \
+    --ros-args -r map:=/PioneerP3DX/map -p save_map_timeout:=15.0
+```
+
+### Viewing from another machine (headless server + VNC)
+
+The canonical setup is a persistent virtual display `:99` served over VNC on port 5900
+— **not SSH X-forwarding** (forwarded displays have crashed rviz2 and die with the SSH
+session). Full guide: [`~/ros2_ws/REMOTE_VIEWING_README.md`](../../REMOTE_VIEWING_README.md).
+Short version:
+
+```bash
+# server (usually already running — check with: pgrep -af "Xvfb :99|x11vnc")
+Xvfb :99 -screen 0 1920x1080x24 &
+x11vnc -display :99 -rfbport 5900 -rfbauth ~/.vnc/passwd -localhost -forever -shared -bg
+
+# put rviz on it, matching the run's domain
+DISPLAY=:99 ROS_DOMAIN_ID=42 rviz2 -d \
+    ~/ros2_ws/src/benchmark_env_realistic/navigation_config/slam_watch.rviz &
+
+# laptop: tunnel + macOS Screen Sharing
+ssh -L 5900:localhost:5900 ros-proxy
+open vnc://localhost:5900
+```
+
+## SLAM tuning notes (why these values)
+
+`navigation_config/nav2_realistic_params.yaml` — the non-default choices that matter:
+
+| param | value | why |
+|---|---|---|
+| `map_name` | `"map"` | slam_toolbox defaults to the **absolute** topic `/map`, escaping the namespace — anything waiting on `/<ns>/map` hangs forever |
+| `max_laser_range` | `3.0` | readings above this are discarded entirely (no free-space raytrace); must match the sensor |
+| `minimum_travel_distance/heading` | `0.15` | at 0.05 a scan-match fired every 5 cm/3° and matcher noise random-walked the pose graph (~5° yaw drift per episode → displaced "ghost wall" copies). Coverage doesn't need dense insertion since no-hit rays raytrace free space |
+| `occupancy_threshold` | `0.25` | at 0.1 a single bad scan-match painted permanent phantom walls (1–2 hits never overruled by later free passes). Real walls sit near ratio 1.0, so they are unaffected |
+| `map_update_interval` | `0.1` | display refresh only (does not gate scan insertion); low value = smooth live view |
+| lifecycle | not managed | slam_toolbox is not in the lifecycle manager's `node_names` (it doesn't expose `get_state` unless run as a lifecycle node — listing it deadlocks Nav2 bringup) |
+
+Result on `4_rooms_start_a` (verified against the ground-truth grid): every mapped wall
+cell within 0.42 m of a true wall, median 5–6 cm, map rotation ≈ 0°, no phantom cells in
+free space. The debugging history behind these values is in
+`SLAM_STALL_INVESTIGATION.md` and the before/after images in `slam_map_captures/`.

--- a/benchmark_env_realistic/SLAM_MAP_ANALYSIS_20260717.md
+++ b/benchmark_env_realistic/SLAM_MAP_ANALYSIS_20260717.md
@@ -1,0 +1,89 @@
+# SLAM Map Quality Analysis — benchmark_env_realistic vs ADSM reference
+
+**Date:** 2026-07-17
+**Reference:** [mwanggh/An-adaptive-robot-search-algorithm](https://github.com/mwanggh/An-adaptive-robot-search-algorithm) (ADSM, ROS1 Noetic + Gazebo + gmapping)
+**Data analyzed:** `slam_map_captures/19_postfix.{pgm,yaml}`, `steps/step_00..15`, `steps_right/step_00..15`, ground truth `occupancy.pgm` of `4_rooms_start_a` (install tree)
+**Method:** every SLAM capture was reprojected into world frame (SLAM map origin = robot spawn `(11, 2)`, yaw 0) and compared cell-by-cell against the ground-truth grid; a rigid ICP fit (occupied cells → nearest true-wall cell) separates *global frame offset* from *true map defects*.
+
+---
+
+## TL;DR
+
+| Concern | Verdict |
+|---|---|
+| **Ghost walls** | **Fixed.** After removing the global frame offset, occupied-cell residuals are median 3.6–4.6 cm, p90 ≈ 11 cm, and **0 cells** farther than 0.42 m from a true wall in *every* capture (both runs, all 16 steps + final). No duplicated/displaced wall copies remain. |
+| **Low free space ("ray passed but still unknown")** | **Not a mapping bug.** In the final map, enclosed unknown *holes* inside swept free space total **4 cells = 0.01 m²**. All other unknown area (≈6.7 m²) is frontier beyond the 3.0 m mapping range or occlusion shadow behind walls — physically correct, and identical to what ADSM's gmapping produces with the same `maxUrange: 3.0`. |
+| **New finding: global yaw anchor race** | The `steps_right` run (and `19_postfix`) is **rigidly rotated +13°** relative to world — constant from `step_00`, i.e. an *initialization* error, not SLAM drift. Root cause is in `odom_tf_republisher.py` (see Finding 1). The `steps` run anchored correctly (−0.1°). |
+
+---
+
+## 1. Ghost walls — quantified
+
+ICP-fit rigid transform (SLAM occupied cells → true walls), then residual distance to nearest true wall:
+
+| capture | fitted rotation | median resid. | p90 | cells > 0.42 m from any true wall |
+|---|---|---|---|---|
+| `steps` (left run), all 16 steps | −0.1° … −0.0° | 3.6–4.8 cm | ~9 cm | **0 (0.0 %)** |
+| `steps_right`, all 16 steps | +12.6° … +13.4° | 4.5–4.8 cm | ~11 cm | **0 (0.0 %)** |
+| `19_postfix` (final) | +13.4° | 4.6 cm | 10.6 cm | **0 (0.0 %)** |
+
+Residuals are at grid-quantization level (SLAM 0.05 m vs GT 0.1 m cells). The "double walls" visible in raw overlays are the two faces of the 0.2 m-thick ground-truth walls plus the frame rotation — not phantom copies. **The sentinel-fix + 1° lidar + gates 0.15 + `occupancy_threshold` 0.25 combination has eliminated ghost walls.**
+
+Overlay image: `slam_map_captures/analysis_overlay_19_postfix_vs_gt.png` (black = true walls, red = SLAM occupied, green = SLAM free).
+
+## 2. Free-space coverage — where the "unknown" actually is
+
+Final left-run map (`steps/step_15`), within the SLAM map bounds:
+
+- GT-free cells: 8,560 → SLAM free **76.1 %**, unknown 22.9 %, occupied 1.0 %.
+- Unknown decomposition (connected components):
+  - **Enclosed holes surrounded purely by free space** (the actual "ray passed but unknown" defect class): **4 cells, 0.01 m²** — negligible.
+  - Everything else (2,685 cells, 6.7 m²) touches the map border or sits behind an obstacle: frontier / occlusion shadow.
+- Free area grows monotonically over the run (15.8 → 17.2 m²) with no regression; occupied count grows as new wall is discovered. No decay/erasure events.
+
+Why it *looks* sparse: the mapping range is capped at **3.0 m** (`max_laser_range`, matching the sensor), and the start room spans > 6 m — cells farther than 3 m from every scan-insertion pose can never leave unknown, and doorways occlude the rest. ADSM has the **same 3.0 m cap** (`maxUrange: 3.0`), so this is parity, not a deficiency. A mid-run snapshot like `19_postfix` additionally shows fan-shaped unknown wedges simply because only a handful of insertion poses had occurred yet.
+
+**Conclusion: no fix needed for free-space marking.** The no-hit-ray patch in `src/BasicSim/src/LaserScanner.cpp` (publish exactly `range_max`) is verified correct against karto's inclusive range check (`reading == range_max` is kept, `isEndPointValid=false` → free raytrace without endpoint) — it is the slam_toolbox equivalent of ADSM's `LaserScanRangeFilter` clamp (their filter replaces no-hits with 3.2 m, between `maxUrange 3.0` and `maxRange 3.4`, for exactly the same effect in gmapping).
+
+## 3. Finding 1 (needs fix): odom anchor yaw race → whole map rotated
+
+`steps_right` is rotated **+13° from its very first snapshot**, constant thereafter, with perfect internal quality. That signature rules out SLAM drift and points at frame initialization:
+
+[`scripts/odom_tf_republisher.py:71-79`](scripts/odom_tf_republisher.py#L71-L79) anchors the odom frame at the **first `/ground_truth` message it happens to receive**. If the agent starts rotating before that callback fires (launch/subscription race), the odom — and therefore the SLAM map frame — is permanently rotated by whatever yaw the robot had at that instant.
+
+Impact: the agent's own frame-consistent view is unaffected (pose, map, and scans all share the rotated frame — this is honest SLAM behavior), but anything that assumes map ≈ world breaks silently: overlay/coverage evaluation against ground truth, seeding goals in world coordinates, or any world-frame wind/gas quantity consumed in map frame. It also makes run-to-run map comparisons non-reproducible.
+
+**Fix options** (pick one):
+
+1. *(Recommended)* Anchor deterministically from the scenario: read the spawn pose (`BasicSimScene.yaml` `position`/`angle`) via parameters and use it as `_init_*` instead of the first message.
+2. Delay motion until the republisher confirms initialization (e.g., episode driver waits for the first `/odom` publish before sending commands).
+3. If honest "unknown world frame" is desired, keep the race-free version of the anchor but have `gsl_bench` record the true map→world transform at t=0 for metrics.
+
+## 4. Finding 2 (hygiene): stale `navigation_config/slam_toolbox_params.yaml`
+
+The launch chain loads **only** `nav2_realistic_params.yaml` (verified in `nav2_realistic_launch.py`). `slam_toolbox_params.yaml` is unreferenced and still contains the *old, known-bad* values (`minimum_travel_* : 0.5`, `occupancy_threshold: 0.1`, `min_pass_through: 2`, `map_update_interval: 5.0`). Delete it or overwrite it with the tuned values to prevent someone reviving the phantom-wall regime by accident.
+
+## 5. ADSM parity table
+
+| aspect | ADSM (reference) | benchmark_env_realistic | parity |
+|---|---|---|---|
+| SLAM backend | gmapping (particle filter, 100 particles) | slam_toolbox (pose graph + Ceres) | different algorithm, equivalent map product; both are "online occupancy SLAM from lidar" |
+| map resolution | `delta: 0.05` | `resolution: 0.05` | ✅ |
+| mapping range | `maxUrange: 3.0` (sensor 3.5 m) | `max_laser_range: 3.0` (sensor 3.0 m) | ✅ effective range identical |
+| no-hit free-space | laser filter clamps to 3.2 m (< `maxRange 3.4`) | BasicSim patch publishes `range_max` | ✅ same mechanism, verified |
+| lidar | 360 rays @ 1°, 0.12–3.5 m, 5 Hz, gaussian σ = 1 cm | 360 rays @ 1° (`lidar_deg:=1.0`), 0.1–3.0 m, **no range noise** | ⚠️ minor: BasicSim lidar is noise-free |
+| odometry error | Gazebo diff-drive wheel odom | synthetic noise + drift (σ 2 cm / 0.01 rad, drift 0.005/m) | ✅ comparable spirit |
+| scan insertion gating | `linearUpdate: 1.0 m`, `angularUpdate: 0.2 rad` | 0.15 m / 0.15 rad | ✅ ours is *denser* (favors coverage) |
+| occupancy threshold | gmapping default 0.25 | `occupancy_threshold: 0.25` | ✅ |
+| occupancy grid interface | `nav_msgs/OccupancyGrid`, unknown = −1, lethal = 100 (their `gridmap.h`) | same | ✅ |
+
+The single substantive gap is lidar range noise (ADSM: gaussian σ = 1 cm). Adding optional gaussian noise to `LaserScanner.cpp` would close it, but the current setup already injects realism through odom noise/drift, and the noise-free lidar slightly *favors* the baseline-style mapping, so it is defensible either way — just disclose it.
+
+## 6. Action items
+
+1. **Fix the odom yaw-anchor race** in `odom_tf_republisher.py` (Finding 1). This is the only correctness fix needed.
+2. **Delete or update** stale `navigation_config/slam_toolbox_params.yaml` (Finding 2).
+3. *(Optional, parity)* add gaussian range noise (σ = 1 cm) to the BasicSim lidar to match ADSM's sensor model.
+4. *(Optional, docs)* README states "map rotation ≈ 0°" — true for the verified left run, but note the anchor race until item 1 lands.
+
+No changes needed for ghost walls or free-space marking — both verified healthy on all 33 analyzed captures.

--- a/benchmark_env_realistic/SLAM_STALL_INVESTIGATION.md
+++ b/benchmark_env_realistic/SLAM_STALL_INVESTIGATION.md
@@ -1,0 +1,196 @@
+# `benchmark_env_realistic` SLAM stall — investigation notes (2026-07-16)
+
+## Goal
+
+Run gpulaika through `gsl_bench`'s `--realistic` mode (`--pose-source tf --map-source slam
+--launch benchmark_env_realistic`) — noisy TF pose + online `slam_toolbox` mapping instead
+of ground-truth map/pose — and view the resulting SLAM map.
+
+## Status: **resolved** — root cause found and fixed (2026-07-16)
+
+### Root cause: `slam_toolbox` publishes on `/map`, not `/PioneerP3DX/map`
+
+`slam_toolbox`'s `setParams()` defaults `map_name_` to `"/map"` — an **absolute** topic
+name. Even though the node is wrapped inside `PushRosNamespace("PioneerP3DX")` in the launch
+file, an absolute topic name (leading `/`) *bypasses* namespace remapping entirely.
+Therefore `slam_toolbox` was publishing its `OccupancyGrid` on `/map` while
+`gsl_bench_runner` was waiting for a message on `/PioneerP3DX/map` (derived from
+`/{ns}/map`). `ros2 topic info -v /PioneerP3DX/map` correctly reported 0 publishers — there
+was never a publisher on that topic.
+
+This single discrepancy (wrong topic string) is the entire cause of the stall. Everything
+else — scan-count off-by-one (#3), lifecycle manager (#1), `transform_timeout` bump (C) —
+were real bugs but unrelated to the /map never appearing.
+
+**Fix applied:**
+- Added `"map_name": "map"` (relative, no leading `/`) to `slam_toolbox_node`'s inline
+  parameters in `nav2_realistic_launch.py`. Under `PushRosNamespace("PioneerP3DX")` the
+  topic resolves to `/PioneerP3DX/map`.
+- Removed `"transform_publish_period": 0.0` so `slam_toolbox` broadcasts the SLAM-corrected
+  `map → PioneerP3DX_odom` TF (default 0.05 s period). Combined with BasicSim's existing
+  static ground-truth `map → PioneerP3DX_odom`, the dynamic SLAM-corrected broadcast will
+  take priority for timestamps after the first scan. This is the "Option A" coexistence
+  approach (no BasicSim source edits).
+- Wired `slam_toolbox_params.yaml` contents into `nav2_realistic_params.yaml` under the
+  `$(var namespace):` key so `slam_toolbox` actually receives `map_update_interval` (5 s),
+  `scan_queue_size` (10, up from default 1 — critical to reduce MessageFilter drops),
+  `min_laser_range`/`max_laser_range`, and all Karto scan-matching parameters.
+
+---
+
+## Bugs found and fixed (confirmed real, kept)
+
+### 1. Nav2 `lifecycle_manager` misconfigured to manage `slam_toolbox`
+`navigation_config/nav2_realistic_launch.py` listed `"slam_toolbox"` in the lifecycle
+manager's `node_names`. `async_slam_toolbox_node` only exposes the `get_state`/`change_state`
+lifecycle services when launched with `use_lifecycle_manager: true` (not set anywhere here),
+so it self-activates but never advertises those services. `lifecycle_manager` polled
+`slam_toolbox/get_state` forever, so nothing downstream (`bt_navigator`, `planner_server`,
+etc.) ever activated, and Nav2's `/navigate_to_pose` action server never came up
+→ `env_dead` after the harness's 300s wait.
+
+**Fix:** removed `"slam_toolbox"` from `lifecycle_manager`'s `node_names` list. Nav2 now
+activates immediately (~1s).
+
+### 2. `odom_tf_republisher.py` crashed on startup
+`scripts/odom_tf_republisher.py:21` called `self.declare_parameter('use_sim_time', True)`,
+but rclpy auto-declares `use_sim_time` for every node already → `ParameterAlreadyDeclaredException`,
+node dies immediately on launch. It was also never wired into `launch/realistic_launch.py`
+at all (dead script, no launch entry) — added an entry for it in addition to the parameter fix.
+
+**Fix:** removed the redundant `declare_parameter` call; added a `Node(...)` entry for it in
+`realistic_launch.py`. It now runs and successfully republishes a noisy, drifting
+`odom → base_link` TF (`tf2_echo` confirms plausible small-noise output).
+
+### 3. `BasicSim` laser scan-count off-by-one (in `src/BasicSim`, upstream repo — see caveat below)
+`LaserScanner.cpp:23`: `int numberOfMeasurements = (maxAngleRad - minAngleRad) / angleResolutionRad;`
+truncates via the implicit `int` cast. For this scenario's 360°/72-ray config
+(`maxAngleRad=6.2832, angleResolutionRad=0.08727`): `6.2832/0.08727 = 71.9977` → truncated to
+**71** → `ranges.resize(71)`, but `msg.angle_max`/`msg.angle_increment` are published
+unchanged, so any consumer computing the expected count via
+`round((angle_max−angle_min)/angle_increment)` gets **72** — a genuine metadata/data-length
+mismatch. This is a documented `slam_toolbox`/Karto failure mode for full-360° lidars
+(`LaserRangeScan contains N range readings, expected N+1`), known in some cases to make
+`/map` "hang and not produce a map" (see Sources below).
+
+**Fix applied:** changed to `std::lround(...)` so the published count is self-consistent
+with the metadata. Confirmed: the `"contains 71 range readings, expected 72"` log line is
+now gone entirely.
+
+**Caveat:** `BasicSim` is a separate upstream repo (`github.com/PepeOjeda/BasicSim`, same
+author as GADEN but a distinct package/git history), not something owned by this benchmark
+suite — patching it means the fix must be re-applied after any future upstream sync. User
+has asked to explore a config-only replacement for this one (choose
+`angleResolutionRad`/`maxAngleRad` values that don't straddle the truncation boundary) but
+that has **not** been done yet; the source patch is what's currently in place.
+
+**Result: not sufficient on its own.** After this fix, the scan-count mismatch warning is
+gone, but the SLAM stall persists unchanged.
+
+---
+
+## Hypotheses tested and disproven
+
+### A. Deadlock inside `slam_toolbox`
+Initial symptom (near-zero CPU, no log activity for minutes, occasional
+`"Message Filter dropping message... queue is full"`) looked like a hung worker thread.
+
+**Test:** full `gdb -p <pid> --batch -ex "thread apply all bt"` on the live process (user
+ran this with `sudo`, since `ptrace_scope=1` blocks it otherwise).
+
+**Result: disproven.** All 13 threads are in ordinary, healthy idle wait states — DDS
+transport threads waiting on `recvfrom`/shared-memory, executor threads blocked in
+`rmw_wait` for the next callback, and the one thread inside `slam_toolbox`'s own code
+(`SlamToolbox::publishVisualizations()`) is simply sleeping between periodic ticks. Nothing
+is stuck in a Ceres solve or waiting on a held lock. **There is no process-level deadlock.**
+
+### B. TF broadcaster conflict (`BasicSim`'s ground-truth TF vs. the new noisy `odom_tf_republisher`)
+`Robot.cpp` unconditionally broadcasts its own ground-truth `map→odom` (static) and
+`odom→base_link` (dynamic) TF regardless of mode; `odom_tf_republisher` broadcasts a second,
+independent `odom→base_link` for the same edge. Hypothesized this dual-authority conflict
+could break `tf2_ros::MessageFilter` internals.
+
+**Test:** disabled `odom_tf_republisher` entirely (commented out of the launch), reran,
+using only `BasicSim`'s raw ground-truth TF for `odom→base_link` (still has the `map→odom`
+static-vs-slam-dynamic conflict, since that one couldn't be isolated this way).
+
+**Result: disproven** (at least for the `odom→base_link` half). Identical stall: scan
+registered once, then nothing, ever, no map. Removing the conflict changed nothing.
+
+### C. `slam_toolbox` transform lookup timeout too short
+~~Standing theory: `BasicSim.Robot::OnUpdate()` calls `UpdatePose()` then `UpdateSensors()`
+using separate `getCurrentTime()` calls, stamping odom/TF slightly before the laser in the
+same tick, causing "in the future" TF lookup failures.~~
+
+**Correction (2026-07-16):** `BasicSim::getCurrentTime()` returns the cached member
+`currentTime`, which is only updated in `publishClock()` *after* `OnUpdate()` in the main
+loop (`BasicSim.cpp:44-47`). So within a single tick, `UpdatePose()` and `UpdateSensors()`
+both see the **same** `currentTime` value from the *previous* tick. Timestamps are
+consistent within-tick; no skew. The log line
+`"Lookup would require extrapolation into the future"` was confirmed (via grep) to come
+from `simulated_tdlas` only — never from `slam_toolbox` itself.
+
+**Test:** bumped `slam_toolbox`'s `transform_timeout` from 0.5s to 5.0s.
+
+**Result: disproven** as root cause. However the `transform_timeout` bump (now a permanent
+config change) is retained as it helps reduce MessageFilter drops under CPU contention.
+
+**Additional context:** across all test runs the robot was near-stationary at its spawn
+pose (the only motion was a single manual `--once` `cmd_vel` rotate). Since
+`shouldProcessScan` rejects scans 2–4 unconditionally (`scan_ctr < 5`) and then requires
+≥0.45 m of travel, rejecting every scan after the first is *expected, correct behavior*
+for a stationary robot — not a bug. The entire stall came down to the `/map` topic name
+mismatch alone.
+
+---
+
+## Open questions / not yet tried
+
+- ~~**`sync_slam_toolbox_node` instead of `async_slam_toolbox_node`**~~ — Moot; the root
+  cause was the topic name, not the async hand-off path. No need to switch unless new
+  symptoms appear.
+- ~~**Why drops are bursty, not continuous**~~ — Understood: `scan_queue_size` defaulted to
+  1 (the instant fix raised it to 10). Combined with `map_update_interval` 10 s default
+  (fixed to 5 s), periodic work is being done and the queue empties, then fills again.
+  Not a pathological symptom.
+- **Transform publish period coexistence (Option A applied):** `slam_toolbox` now publishes
+  dynamic `map → PioneerP3DX_odom` at 20 Hz while BasicSim also publishes a static
+  `map → PioneerP3DX_odom` once at startup. tf2 warns about multiple authorities on the
+  same edge but the dynamic at newer timestamps takes priority; this is acceptable for
+  developer testing. For a production-grade "no ground truth" run, a future patch to
+  disable BasicSim's static `map→odom` (e.g. a new `publishGroundTruthMapOdom` YAML flag
+  in `Robot.cpp`) would be cleaner.
+- **Whether this reproduces outside this heavily-loaded shared machine** — Still worth
+  checking with the `scan_queue_size: 10` fix, since MessageFilter drops under contention
+  were a real secondary issue. The `/clock` `best_effort` QoS (`BasicSim.cpp:25`) may
+  still cause sim-time stalls on a loaded box.
+- ~~**The `OnUpdate()` timestamp-ordering fix**~~ — Proven unnecessary since both
+  `UpdatePose` and `UpdateSensors` use the same cached `currentTime` value.
+
+## Confirmed working, unaffected by any of this
+
+- `gpulaika` running in **non-realistic** mode (ground-truth ROS `map_server` + sim
+  ground-truth pose) — fully unaffected, not part of this investigation.
+- Nav2 itself (planner/controller/behavior/bt_navigator) activates and drives correctly
+  once the lifecycle-manager bug (#1) is fixed — confirmed via `NavigateToPose` action
+  server coming up in ~1s in every run since that fix.
+- `odom_tf_republisher`'s noise/drift injection logic itself — confirmed via `tf2_echo`
+  showing small, plausible noisy transform values once it stopped crashing (bug #2).
+
+## Sources
+- [ros - Slam_toolbox message filter dropping message - Robotics Stack Exchange](https://answers.ros.org/question/357762/slam_toolbox-message-filter-dropping-message/)
+- [Slam Toolbox: Message Filter dropping message for reason 'discarding message because the queue is full' - ROS Answers archive](https://answers.ros.org/question/393773/)
+- [LaserRangeScan contains different readings · Issue #426 · SteveMacenski/slam_toolbox](https://github.com/SteveMacenski/slam_toolbox/issues/576)
+
+## Log corrections (2026-07-16)
+
+- **`"Lookup would require extrapolation into the future"`** — grep confirmed this line
+  comes exclusively from `simulated_tdlas`, never from `slam_toolbox`. The earlier report
+  that implied it as a slam_toolbox symptom was an overreach.
+- **`process has died [pid ..., exit code -9]`** observed in runs 4–6 — this is `SIGKILL`
+  sent by the user during cleanup between test iterations, not a spontaneous crash.
+- **Robot was stationary in all runs.** The only motion was a single manual
+  `--once` `cmd_vel` rotate nudge (run 5). The harness was stuck in "waiting for SLAM
+  map" → `act()` never called → no drive goal → robot never moves. All
+  `shouldProcessScan` rejections beyond the first scan are expected for a stationary
+  robot, not a slam_toolbox bug.

--- a/benchmark_env_realistic/launch/realistic_launch.py
+++ b/benchmark_env_realistic/launch/realistic_launch.py
@@ -1,0 +1,425 @@
+import math
+import os
+import sys
+import tempfile
+
+import numpy as np
+import yaml
+
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    SetEnvironmentVariable,
+    SetLaunchConfiguration,
+    IncludeLaunchDescription,
+    OpaqueFunction,
+    GroupAction,
+    TimerAction,
+)
+from launch.launch_description_sources import PythonLaunchDescriptionSource
+from launch.substitutions import LaunchConfiguration, PathJoinSubstitution
+from launch_ros.actions import Node, PushRosNamespace
+from ament_index_python.packages import get_package_share_directory
+from launch.frontend.parse_substitution import parse_substitution
+
+
+def launch_arguments():
+    return [
+        DeclareLaunchArgument("scenario", default_value="10x6_central_obstacle"),
+        DeclareLaunchArgument("configuration", default_value="config1"),
+        DeclareLaunchArgument("simulation", default_value="sim1"),
+        DeclareLaunchArgument("namespace", default_value="PioneerP3DX"),
+        DeclareLaunchArgument("motion", default_value="nav2"),
+        DeclareLaunchArgument(
+            "nav_profile",
+            default_value="faithful",
+            description="Nav2 parameter profile: standard or faithful",
+        ),
+        # DirectDrive frame controls (see nav2_realistic_launch.py). Defaults
+        # keep DirectDrive in the SLAM frame; the DirectDrive+ground-truth
+        # isolation experiment sets drive_pose_source=topic + a world-frame
+        # drive_map_yaml.
+        DeclareLaunchArgument("drive_pose_source", default_value="tf"),
+        DeclareLaunchArgument("drive_map_yaml", default_value=""),
+        # Realistic-mode lidar angular resolution in degrees. The benchmark_env
+        # scenario scene files stay untouched (they keep the plain benchmark's 5
+        # deg sensor); a patched copy of the scene is generated at launch time.
+        # 1 deg matches ADSM's laser and gives Cartographer's scan matcher enough
+        # points to stay drift-free.
+        DeclareLaunchArgument("lidar_deg", default_value="1.0"),
+        # SLAM mapping range. Kept well above the RL policy's trained
+        # LIDAR_MAX_RANGE (3.0, see gsl_bench episode_runner.py) — the agent's
+        # own observations are clipped back to 3.0 in gsl_bench's obs_cache
+        # regardless of the physical sensor's range, so raising this only
+        # gives Cartographer more real wall hits instead of full-range
+        # "no return" scans.
+        DeclareLaunchArgument("lidar_max_range", default_value="3.0"),
+        # Default False to keep the automated gsl_bench_runner --realistic
+        # sweep headless/unaffected; pass use_rviz:=true for interactive runs.
+        DeclareLaunchArgument("use_rviz", default_value="False"),
+        # Mark GADEN outlet cells (OccupancyGrid3D.csv value 2) as occupied in
+        # the map BasicSim's lidar sees, so Cartographer maps them as walls —
+        # matching the ground-truth path, where outlets are non-traversable
+        # (see OUTLET_WALL_PLAN.md). Set false to keep outlets passable
+        # (old behavior, useful for A/B).
+        DeclareLaunchArgument(
+            "wall_outlets",
+            default_value="true",
+            description="Mark GADEN outlet cells (OccupancyGrid3D.csv value 2) as "
+            "occupied in the map BasicSim's lidar sees, so Cartographer maps them "
+            "as walls (matches the ground-truth path). Set false to keep outlets "
+            "passable.",
+        ),
+    ]
+
+
+def _read_occupancy_grid_3d_csv(csv_path):
+    """Parse GADEN's OccupancyGrid3D.csv into a (nz, ny, nx) uint8 grid.
+
+    Format: 4 `#`-prefixed header lines (env_min, env_max, num_cells,
+    cell_size), then for each z-level nx rows of ny space-separated values
+    (row index = x, columns = y) followed by a lone ';' separator line.
+    Transposed to (nz, ny, nx) so it lines up with PGM (row=y, col=x).
+    """
+    with open(csv_path) as f:
+        lines = f.readlines()
+    num_cells_line = lines[2]
+    nx, ny, nz = (int(v) for v in num_cells_line.split()[1:4])
+    raw = np.zeros((nz, nx, ny), dtype=np.uint8)
+    row_idx = 4
+    for z in range(nz):
+        for x in range(nx):
+            raw[z, x, :] = [int(v) for v in lines[row_idx].split()]
+            row_idx += 1
+        row_idx += 1  # skip the ';' separator line
+    return np.swapaxes(raw, 1, 2)  # (nz, ny, nx)
+
+
+def _read_pgm_p2(pgm_path):
+    """Minimal ASCII PGM (P2) reader. Returns (pixels[H,W], maxval)."""
+    with open(pgm_path) as f:
+        tokens = []
+        magic = None
+        for line in f:
+            stripped = line.split("#", 1)[0].strip()
+            if not stripped:
+                continue
+            if magic is None:
+                magic = stripped
+                if magic != "P2":
+                    raise ValueError(f"{pgm_path}: unsupported PGM format {magic!r}")
+                continue
+            tokens.extend(stripped.split())
+    width, height, maxval = (int(t) for t in tokens[:3])
+    pixels = np.array(tokens[3 : 3 + width * height], dtype=np.uint8).reshape(
+        height, width
+    )
+    return pixels, maxval
+
+
+def _write_pgm_p2(pgm_path, pixels):
+    height, width = pixels.shape
+    with open(pgm_path, "w") as f:
+        f.write("P2\n")
+        f.write(f"{width} {height}\n")
+        f.write("1\n")
+        for row in pixels:
+            f.write(" ".join(str(int(v)) for v in row) + "\n")
+
+
+def _wall_outlets_map(occ_yaml_path, scenario, configuration, namespace):
+    """Return path to a temp occupancy.yaml whose PGM has GADEN outlet cells
+    (OccupancyGrid3D.csv value 2) marked occupied, so the realistic lidar
+    (and hence Cartographer + BasicSim collision) treats them as walls.
+
+    Returns occ_yaml_path unchanged if the CSV is missing or the wall/PGM
+    orientation can't be confidently calibrated.
+    """
+    cfg_dir = os.path.dirname(occ_yaml_path)
+    csv_path = os.path.join(cfg_dir, "OccupancyGrid3D.csv")
+    if not os.path.exists(csv_path):
+        print(
+            f"[realistic_launch] wall_outlets: {csv_path} not found, "
+            "outlets NOT walled (scenario not pre-simmed?)",
+            file=sys.stderr,
+        )
+        return occ_yaml_path
+
+    grid = _read_occupancy_grid_3d_csv(csv_path)
+    wall2d = (grid == 1).any(axis=0)  # (ny, nx)
+    outlet2d = (grid == 2).any(axis=0)
+
+    with open(occ_yaml_path) as f:
+        occ_yaml = yaml.safe_load(f)
+    pgm_path = occ_yaml["image"]
+    if not os.path.isabs(pgm_path):
+        pgm_path = os.path.join(cfg_dir, pgm_path)
+    pixels, maxval = _read_pgm_p2(pgm_path)
+    OCC = 0  # existing wall cells in these PGMs (maxval 1) are pixel 0
+
+    ny, nx = wall2d.shape
+    wall_ys, wall_xs = np.nonzero(wall2d)
+
+    best_overlap = -1.0
+    best_rows = None
+    for flip in (False, True):
+        rows = (ny - 1 - wall_ys) if flip else wall_ys
+        overlap = float(np.mean(pixels[rows, wall_xs] == OCC)) if len(rows) else 0.0
+        if overlap > best_overlap:
+            best_overlap = overlap
+            best_flip = flip
+
+    if best_overlap < 0.8:
+        print(
+            f"[realistic_launch] wall_outlets: wall/PGM orientation calibration "
+            f"failed for {scenario}/{configuration} (best overlap "
+            f"{best_overlap:.2f} < 0.8), outlets NOT walled",
+            file=sys.stderr,
+        )
+        return occ_yaml_path
+
+    outlet_ys, outlet_xs = np.nonzero(outlet2d)
+    outlet_rows = (ny - 1 - outlet_ys) if best_flip else outlet_ys
+    patched_pixels = pixels.copy()
+    patched_pixels[outlet_rows, outlet_xs] = OCC
+
+    tag = f"{scenario}_{configuration}_{namespace}"
+    patched_pgm = os.path.join(
+        tempfile.gettempdir(), f"benchmark_env_realistic_map_{tag}.pgm"
+    )
+    _write_pgm_p2(patched_pgm, patched_pixels)
+
+    patched_yaml_data = dict(occ_yaml)
+    patched_yaml_data["image"] = patched_pgm
+    patched_yaml = os.path.join(
+        tempfile.gettempdir(), f"benchmark_env_realistic_map_{tag}.yaml"
+    )
+    with open(patched_yaml, "w") as f:
+        yaml.safe_dump(patched_yaml_data, f)
+
+    print(
+        f"[realistic_launch] wall_outlets: walled {int(outlet2d.sum())} outlet "
+        f"cells in {scenario}/{configuration} (flip={best_flip}, "
+        f"overlap={best_overlap:.2f})",
+        file=sys.stderr,
+    )
+    return patched_yaml
+
+
+def launch_setup(context, *args, **kwargs):
+    share_dir = get_package_share_directory("benchmark_env")
+    namespace = LaunchConfiguration("namespace").perform(context)
+    scenario = LaunchConfiguration("scenario").perform(context)
+    simulation = LaunchConfiguration("simulation").perform(context)
+    configuration = LaunchConfiguration("configuration").perform(context)
+
+    gaden_player = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                os.path.join(
+                    get_package_share_directory("benchmark_env"),
+                    "launch",
+                    "gaden_player_launch.py",
+                )
+            ]
+        ),
+        launch_arguments={
+            "use_rviz": LaunchConfiguration("use_rviz").perform(context),
+            "scenario": scenario,
+            "configuration": configuration,
+            "simulation": simulation,
+        }.items(),
+    )
+
+    scene_path = os.path.join(
+        share_dir,
+        "scenarios",
+        scenario,
+        "environment_configurations",
+        configuration,
+        "BasicSimScene.yaml",
+    )
+    lidar_deg = float(LaunchConfiguration("lidar_deg").perform(context))
+    lidar_max_range = float(LaunchConfiguration("lidar_max_range").perform(context))
+    with open(scene_path) as f:
+        scene = yaml.safe_load(f)
+    # BasicSim resolves a relative map path against the scene file's own
+    # directory, so the patched copy must carry an absolute path.
+    if "map" in scene and not os.path.isabs(str(scene["map"])):
+        scene["map"] = os.path.join(os.path.dirname(scene_path), str(scene["map"]))
+    if "map" in scene and LaunchConfiguration("wall_outlets").perform(context).lower() in (
+        "true",
+        "1",
+    ):
+        scene["map"] = _wall_outlets_map(
+            scene["map"], scenario, configuration, namespace
+        )
+    for robot in scene.get("robots", []):
+        robot["publishOdom"] = True
+        for sensor in robot.get("sensors", []):
+            if sensor.get("type") == "laser":
+                sensor["angleResolutionRad"] = round(math.radians(lidar_deg), 7)
+                sensor["maxDistance"] = lidar_max_range
+    patched_scene = os.path.join(
+        tempfile.gettempdir(),
+        f"benchmark_env_realistic_scene_{scenario}_{configuration}_{namespace}.yaml",
+    )
+    with open(patched_scene, "w") as f:
+        yaml.safe_dump(scene, f)
+
+    robot_simulator = [
+        Node(
+            package="basic_sim",
+            executable="basic_sim",
+            parameters=[
+                {"deltaTime": 0.03},
+                {"speed": 1.0},
+                {"worldFile": patched_scene},
+            ],
+        )
+    ]
+
+    nav2_nodes = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            [
+                os.path.join(
+                    get_package_share_directory("benchmark_env_realistic"),
+                    "navigation_config",
+                    "nav2_realistic_launch.py",
+                )
+            ]
+        ),
+        launch_arguments={
+            "namespace": LaunchConfiguration("namespace").perform(context),
+            "scenario": LaunchConfiguration("scenario").perform(context),
+            "motion": LaunchConfiguration("motion").perform(context),
+            "nav_profile": LaunchConfiguration("nav_profile").perform(context),
+            "drive_pose_source": LaunchConfiguration("drive_pose_source").perform(context),
+            "drive_map_yaml": LaunchConfiguration("drive_map_yaml").perform(context),
+        }.items(),
+    )
+
+    anemometer = [
+        Node(
+            package="simulated_anemometer",
+            executable="simulated_anemometer",
+            name="fake_anemometer",
+            parameters=[
+                {
+                    "sensor_frame": parse_substitution(
+                        "$(var namespace)_anemometer_frame"
+                    )
+                },
+                {"fixed_frame": "map"},
+                {"noise_std": 0.3},
+                {"use_map_ref_system": False},
+                {"use_sim_time": True},
+            ],
+        ),
+        Node(
+            package="tf2_ros",
+            executable="static_transform_publisher",
+            name="anemometer_tf_pub",
+            arguments=[
+                "0", "0", "0.5", "1.0", "0.0", "0", "0",
+                parse_substitution("$(var namespace)_base_link"),
+                parse_substitution("$(var namespace)_anemometer_frame"),
+            ],
+            parameters=[{"use_sim_time": True}],
+        ),
+    ]
+
+    PID = [
+        Node(
+            package="simulated_gas_sensor",
+            executable="simulated_gas_sensor",
+            name="fake_pid",
+            parameters=[
+                {"sensor_model": 30},
+                {
+                    "sensor_frame": parse_substitution(
+                        "$(var namespace)_pid_frame"
+                    )
+                },
+                {"fixed_frame": "map"},
+                {"noise_std": 20.1},
+                {"use_sim_time": True},
+            ],
+        ),
+        Node(
+            package="tf2_ros",
+            executable="static_transform_publisher",
+            name="pid_tf_pub",
+            arguments=[
+                "0", "0", "0.5", "1.0", "0.0", "0", "0",
+                parse_substitution("$(var namespace)_base_link"),
+                parse_substitution("$(var namespace)_pid_frame"),
+            ],
+            parameters=[{"use_sim_time": True}],
+        ),
+    ]
+
+    TDLAS = [
+        Node(
+            package="simulated_tdlas",
+            executable="simulated_tdlas",
+            name="simulated_tdlas",
+            parameters=[
+                {"sensor_model": 30},
+                {
+                    "sensor_frame": parse_substitution(
+                        "$(var namespace)_pid_frame"
+                    )
+                },
+                {"fixed_frame": "map"},
+                {"noise_std": 20.1},
+                {"use_sim_time": True},
+                {"verbose": True},
+            ],
+        ),
+        Node(
+            package="tf2_ros",
+            executable="static_transform_publisher",
+            name="tdlas_tf_pub",
+            arguments=[
+                "0", "0", "0.75", "1.0", "0.0", "0", "0",
+                parse_substitution("$(var namespace)_base_link"),
+                parse_substitution("tdlas_frame"),
+            ],
+            parameters=[{"use_sim_time": True}],
+        ),
+    ]
+
+    namespaced_actions = [PushRosNamespace(namespace)]
+
+    other_actions = [gaden_player]
+    other_actions.extend(robot_simulator)
+    other_actions.extend(anemometer)
+    other_actions.extend(PID)
+    # Cartographer (inside nav2_nodes) is a use_sim_time consumer that races
+    # basic_sim's /clock at bootstrap: basic_sim is the clock+odom source and
+    # publishes /clock best_effort/depth-1 while stamping the first odom->base_link
+    # TF at Time(0) before the clock advances. Started concurrently, cartographer
+    # intermittently latches non-monotonic odom timestamps (TF_OLD_DATA "from the
+    # past") and — with use_imu_data=false — its pose extrapolator wedges forever,
+    # never emitting map->odom (robot never localizes, agent takes 0 steps, run
+    # wall-times out). Delaying the SLAM/nav stack lets basic_sim reach a steady,
+    # monotonic 33 Hz /clock+odom stream before cartographer subscribes.
+    other_actions.append(TimerAction(period=6.0, actions=[nav2_nodes]))
+    other_actions.extend(TDLAS)
+    return [
+        GroupAction(actions=namespaced_actions),
+        GroupAction(actions=other_actions),
+    ]
+
+
+def generate_launch_description():
+    launch_description = [
+        SetEnvironmentVariable("RCUTILS_LOGGING_BUFFERED_STREAM", "1"),
+        SetEnvironmentVariable("RCUTILS_COLORIZED_OUTPUT", "1"),
+    ]
+
+    launch_description.extend(launch_arguments())
+    launch_description.append(OpaqueFunction(function=launch_setup))
+
+    return LaunchDescription(launch_description)

--- a/benchmark_env_realistic/navigation_config/cartographer_realistic.lua
+++ b/benchmark_env_realistic/navigation_config/cartographer_realistic.lua
@@ -1,0 +1,80 @@
+-- Cartographer config for benchmark_env_realistic (PioneerP3DX, single 2D
+-- planar lidar via BasicSim). Frame names are hardcoded for this project's
+-- one actual namespace (PioneerP3DX) rather than templated, matching how
+-- Cartographer's own stock example configs hardcode a single robot's frames.
+--
+-- max_range / missing_data_ray_length are set with a deliberate 0.1m gap
+-- below BasicSim's published sensor range (see realistic_launch.py's
+-- lidar_max_range arg, currently 3.0 — keep this file's max_range 0.1
+-- below whatever that arg is set to, or every no-hit reading lands at or
+-- under max_range again and never gets classified as a miss). Unlike
+-- slam_toolbox/Karto (which
+-- collapses its "trace to threshold" branch because it always sets
+-- rangeThreshold == max_laser_range, see laser_utils.cpp:162 in the
+-- slam_toolbox source), Cartographer has a genuinely separate
+-- returns/misses classification (range <= max_range -> real hit,
+-- range > max_range -> free-only ray rescaled to missing_data_ray_length,
+-- see local_trajectory_builder_2d.cc). BasicSim's no-hit convention
+-- publishes exactly its sensor's maxDistance, which must land STRICTLY
+-- ABOVE this file's max_range for the free-space classification to fire.
+
+include "map_builder.lua"
+include "trajectory_builder.lua"
+
+options = {
+  map_builder = MAP_BUILDER,
+  trajectory_builder = TRAJECTORY_BUILDER,
+  map_frame = "map",
+  tracking_frame = "PioneerP3DX_base_link",
+  -- BasicSim already publishes odom->base_link (Robot.cpp's native odom).
+  -- published_frame must be the ODOM frame, not base_link: with
+  -- provide_odom_frame=false, cartographer publishes map->published_frame
+  -- DIRECTLY (no extra hop), so if published_frame were base_link, base_link
+  -- would get two TF parents (map from cartographer, odom from BasicSim) —
+  -- an invalid tree that froze Nav2 with spurious collision reports.
+  -- Setting it to the odom frame makes cartographer's correction stack as
+  -- map->odom, same as slam_toolbox, letting BasicSim's existing
+  -- odom->base_link complete the chain.
+  published_frame = "PioneerP3DX_odom",
+  odom_frame = "PioneerP3DX_odom",
+  provide_odom_frame = false,
+  publish_frame_projected_to_2d = false,
+  use_pose_extrapolator = true,
+  -- Fuse BasicSim's real odom as a motion prior (mirrors slam_toolbox's
+  -- existing use of the odom TF to seed scan matching).
+  use_odometry = true,
+  use_nav_sat = false,
+  use_landmarks = false,
+  num_laser_scans = 1,
+  num_multi_echo_laser_scans = 0,
+  num_subdivisions_per_laser_scan = 1,
+  num_point_clouds = 0,
+  lookup_transform_timeout_sec = 0.2,
+  submap_publish_period_sec = 0.3,
+  pose_publish_period_sec = 5e-3,
+  trajectory_publish_period_sec = 30e-3,
+  rangefinder_sampling_ratio = 1.,
+  odometry_sampling_ratio = 1.,
+  fixed_frame_pose_sampling_ratio = 1.,
+  imu_sampling_ratio = 1.,
+  landmarks_sampling_ratio = 1.,
+}
+
+MAP_BUILDER.use_trajectory_builder_2d = true
+
+TRAJECTORY_BUILDER_2D.submaps.num_range_data = 35
+TRAJECTORY_BUILDER_2D.submaps.grid_options_2d.resolution = 0.05
+TRAJECTORY_BUILDER_2D.min_range = 0.1
+TRAJECTORY_BUILDER_2D.max_range = 2.9
+TRAJECTORY_BUILDER_2D.missing_data_ray_length = 2.9
+TRAJECTORY_BUILDER_2D.use_imu_data = false
+TRAJECTORY_BUILDER_2D.use_online_correlative_scan_matching = true
+TRAJECTORY_BUILDER_2D.real_time_correlative_scan_matcher.linear_search_window = 0.1
+TRAJECTORY_BUILDER_2D.real_time_correlative_scan_matcher.translation_delta_cost_weight = 10.
+TRAJECTORY_BUILDER_2D.real_time_correlative_scan_matcher.rotation_delta_cost_weight = 1e-1
+
+POSE_GRAPH.optimization_problem.huber_scale = 1e2
+POSE_GRAPH.optimize_every_n_nodes = 35
+POSE_GRAPH.constraint_builder.min_score = 0.65
+
+return options

--- a/benchmark_env_realistic/navigation_config/gsl_watch.rviz
+++ b/benchmark_env_realistic/navigation_config/gsl_watch.rviz
@@ -1,0 +1,167 @@
+Panels:
+  - Class: rviz_common/Displays
+    Name: Displays
+    Property Tree Widget:
+      Splitter Ratio: 0.6
+    Tree Height: 600
+  - Class: rviz_common/Views
+    Name: Views
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Class: rviz_default_plugins/Grid
+      Enabled: true
+      Name: Grid
+      Cell Size: 1
+      Color: 160; 160; 164
+      Plane Cell Count: 20
+      Value: true
+    - Class: rviz_default_plugins/TF
+      Enabled: true
+      Name: TF
+      Marker Scale: 1
+      Show Names: true
+      Value: true
+    # SLAM map (robot-anchored "map" frame). Walls appear as they are discovered.
+    - Alpha: 0.7
+      Class: rviz_default_plugins/Map
+      Color Scheme: map
+      Enabled: true
+      Name: SLAM Map
+      Topic:
+        Depth: 5
+        Durability Policy: Transient Local
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /PioneerP3DX/map
+      Update Topic:
+        Value: /PioneerP3DX/map_updates
+      Value: true
+    # Gas plume — GADEN world coords, re-stamped to gaden_world by world_align and
+    # transformed into the SLAM map frame by the static TF.
+    - Class: rviz_default_plugins/Marker
+      Enabled: true
+      Name: Gas (aligned)
+      Namespaces:
+        Gas_Dispersion: true
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /gsl_bench/gas_aligned
+      Value: true
+    # True source marker (aligned the same way). This is ground truth — the robot
+    # never receives it; it is here only so you can eyeball alignment/progress.
+    - Class: rviz_default_plugins/MarkerArray
+      Enabled: true
+      Name: Source (aligned)
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /gsl_bench/source_aligned
+      Value: true
+    # Robot's live lidar (SLAM map frame).
+    - Alpha: 1
+      Class: rviz_default_plugins/LaserScan
+      Color: 255; 40; 40
+      Color Transformer: FlatColor
+      Enabled: true
+      Name: LaserScan
+      Size (m): 0.03
+      Style: Flat Squares
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Best Effort
+        Value: /PioneerP3DX/laser_scanner
+      Use Fixed Frame: true
+      Value: true
+    # Robot body: no URDF in realistic mode, so mark it with axes on base_link.
+    - Class: rviz_default_plugins/Axes
+      Enabled: true
+      Name: Robot (base_link)
+      Length: 0.6
+      Radius: 0.08
+      Reference Frame: PioneerP3DX_base_link
+      Value: true
+    # Nav2 global plan.
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz_default_plugins/Path
+      Color: 25; 255; 0
+      Enabled: true
+      Line Style: Lines
+      Line Width: 0.03
+      Name: Nav2 Plan
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /PioneerP3DX/plan
+      Value: true
+    # The goal the robot is currently driving to (all motion modes).
+    - Alpha: 1
+      Class: rviz_default_plugins/Pose
+      Color: 0; 200; 255
+      Enabled: true
+      Head Length: 0.25
+      Head Radius: 0.12
+      Name: Current Goal
+      Shaft Length: 0.5
+      Shaft Radius: 0.05
+      Shape: Arrow
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /gsl_bench/goal
+      Value: true
+    # The per-step target arrow (robot -> target) published by the harness.
+    - Class: rviz_default_plugins/Marker
+      Enabled: true
+      Name: Step Target
+      Topic:
+        Depth: 5
+        Durability Policy: Volatile
+        History Policy: Keep Last
+        Reliability Policy: Reliable
+        Value: /gsl_bench/target
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz_default_plugins/MoveCamera
+    - Class: rviz_default_plugins/Select
+    - Class: rviz_default_plugins/Measure
+      Line color: 128; 128; 0
+  Transformation:
+    Current:
+      Class: rviz_default_plugins/TF
+  Value: true
+  Views:
+    Current:
+      Class: rviz_default_plugins/TopDownOrtho
+      Name: Current View
+      Scale: 60
+      Target Frame: <Fixed Frame>
+      Value: TopDownOrtho (rviz_default_plugins)
+      X: 0
+      Y: 0
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 900
+  Width: 1400
+  Hide Left Dock: false
+  Hide Right Dock: true

--- a/benchmark_env_realistic/navigation_config/nav2_realistic_launch.py
+++ b/benchmark_env_realistic/navigation_config/nav2_realistic_launch.py
@@ -1,0 +1,219 @@
+import os
+
+from launch import LaunchDescription
+from launch.actions import (
+    DeclareLaunchArgument,
+    SetEnvironmentVariable,
+    OpaqueFunction,
+    GroupAction,
+    ExecuteProcess,
+)
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node, PushRosNamespace
+from launch_ros.parameter_descriptions import ParameterFile
+from ament_index_python.packages import get_package_share_directory
+import xacro
+
+DIRECTDRIVE_NAV_SCRIPT = "/home/efe/ros2_ws/src/directdrive_nav/directdrive_nav.py"
+
+
+def launch_setup(context, *args, **kwargs):
+    bench_share = get_package_share_directory("benchmark_env")
+    realistic_share = get_package_share_directory("benchmark_env_realistic")
+    namespace = LaunchConfiguration("namespace").perform(context)
+
+    nav_profile = LaunchConfiguration("nav_profile").perform(context)
+    nav_params_file = {
+        "standard": "nav2_realistic_params.yaml",
+        "faithful": "nav2_realistic_params_adsm_faithful.yaml",
+    }.get(nav_profile)
+    if nav_params_file is None:
+        raise RuntimeError(
+            f"Unknown nav_profile '{nav_profile}'; expected 'standard' or 'faithful'"
+        )
+    configured_params = ParameterFile(
+        os.path.join(realistic_share, "navigation_config", nav_params_file),
+        allow_substs=True,
+    )
+    bt_name = ("adsm_faithful_bt.xml" if nav_profile == "faithful"
+               else "adsm_goal_update_bt.xml")
+    # gaden_config is a plain source directory, not a built ament package (no
+    # package.xml) — get_package_share_directory() can never resolve it.
+    bt_xml = "/home/efe/ros2_ws/src/base/gaden_config/navigation_config/" + bt_name
+    use_sim_time = True
+
+    robot_desc = xacro.process_file(
+        os.path.join(bench_share, "navigation_config", "resources", "giraff.xacro"),
+        mappings={"frame_ns": namespace},
+    )
+    robot_desc = robot_desc.toprettyxml(indent="  ")
+
+    # Cartographer has a genuinely separate returns/misses classification
+    # with a real, comfortably-sized gap (see cartographer_realistic.lua's
+    # header) — unlike slam_toolbox/Karto, which always sets
+    # rangeThreshold == max_laser_range, collapsing its "trace free, no
+    # wall" branch to an unreachable 1e-6-wide window.
+    # Frame names are hardcoded in the lua file for this project's one
+    # namespace, so this only cleanly supports namespace:=PioneerP3DX.
+    slam_nodes = [
+        Node(
+            package="cartographer_ros",
+            executable="cartographer_node",
+            name="cartographer_node",
+            output="screen",
+            parameters=[{"use_sim_time": use_sim_time}],
+            arguments=[
+                "-configuration_directory",
+                os.path.join(
+                    get_package_share_directory("benchmark_env_realistic"),
+                    "navigation_config",
+                ),
+                "-configuration_basename",
+                "cartographer_realistic.lua",
+            ],
+            remappings=[
+                ("scan", "laser_scanner"),
+                ("odom", "odom"),
+            ],
+        ),
+        Node(
+            package="cartographer_ros",
+            executable="cartographer_occupancy_grid_node",
+            name="cartographer_occupancy_grid_node",
+            output="screen",
+            parameters=[
+                {"use_sim_time": use_sim_time},
+                {"resolution": 0.05},
+            ],
+            remappings=[("map", "map")],
+        ),
+    ]
+
+    motion = LaunchConfiguration("motion").perform(context)
+
+    if motion == "directdrive":
+        # DirectDrive: no Nav2 stack at all. Cartographer still runs (for the
+        # live map + map->odom TF); a lightweight rotate-then-go A* controller
+        # replaces bt_navigator/planner_server/controller_server/behavior_server,
+        # exposing the SAME NavigateToPose action name gsl_bench's runner_node
+        # already calls, so no harness changes are needed.
+        #
+        # drive_pose_source lets an experiment run DirectDrive in the WORLD frame
+        # instead of the SLAM frame — used to isolate the drive mechanism from
+        # SLAM perception (DirectDrive + ground-truth pose/map vs the Nav2 +
+        # ground-truth baseline). 'topic' = subscribe to the ground_truth pose +
+        # a static world-frame map (drive_map_yaml); 'tf' = the default live
+        # SLAM pose + SLAM map. In topic mode everything (policy obs, drive
+        # target, map, success check) is coherently in world coordinates.
+        drive_pose_source = LaunchConfiguration("drive_pose_source").perform(context)
+        drive_map_yaml = LaunchConfiguration("drive_map_yaml").perform(context)
+        dd_cmd = [
+            "python3", DIRECTDRIVE_NAV_SCRIPT, "--ros-args",
+            "-p", "use_sim_time:=true",
+            "-p", "map_frame:=map",
+            "-p", f"base_frame:={namespace}_base_link",
+            "-p", f"action_name:=/{namespace}/navigate_to_pose",
+            "-p", f"cmd_vel_topic:=/{namespace}/cmd_vel",
+            "-p", "robot_radius:=0.25",
+        ]
+        if drive_pose_source == "topic":
+            dd_cmd += [
+                "-p", "pose_source:=topic",
+                "-p", f"pose_topic:=/{namespace}/ground_truth",
+                "-p", f"map_yaml:={drive_map_yaml}",
+            ]
+        else:
+            dd_cmd += [
+                "-p", "pose_source:=tf",
+                "-p", f"map_topic:=/{namespace}/map",
+            ]
+        navigation_nodes = list(slam_nodes) + [
+            ExecuteProcess(cmd=dd_cmd, output="screen"),
+        ]
+    else:
+        navigation_nodes = list(slam_nodes) + [
+            Node(
+                package="nav2_bt_navigator",
+                executable="bt_navigator",
+                name="bt_navigator",
+                output="screen",
+                parameters=[
+                    configured_params,
+                    {"use_sim_time": use_sim_time,
+                     "default_nav_to_pose_bt_xml": bt_xml},
+                ],
+            ),
+            Node(
+                package="nav2_planner",
+                executable="planner_server",
+                name="planner_server",
+                output="screen",
+                parameters=[configured_params, {"use_sim_time": use_sim_time}],
+            ),
+            Node(
+                package="nav2_controller",
+                executable="controller_server",
+                name="controller_server",
+                output="screen",
+                parameters=[configured_params, {"use_sim_time": use_sim_time}],
+            ),
+            Node(
+                package="nav2_behaviors",
+                executable="behavior_server",
+                name="behavior_server",
+                output="screen",
+                parameters=[configured_params, {"use_sim_time": use_sim_time}],
+            ),
+            Node(
+                package="nav2_lifecycle_manager",
+                executable="lifecycle_manager",
+                name="lifecycle_manager_navigation",
+                output="screen",
+                parameters=[
+                    {"use_sim_time": use_sim_time},
+                    {"autostart": True},
+                    {
+                        "node_names": [
+                            "planner_server",
+                            "controller_server",
+                            "bt_navigator",
+                            "behavior_server",
+                        ]
+                    },
+                ],
+            ),
+        ]
+
+    visualization_nodes = [
+        Node(
+            package="robot_state_publisher",
+            executable="robot_state_publisher",
+            parameters=[{"use_sim_time": True, "robot_description": robot_desc}],
+        ),
+    ]
+
+    actions = [PushRosNamespace(namespace)]
+    actions.extend(visualization_nodes)
+    actions.extend(navigation_nodes)
+    return [GroupAction(actions=actions)]
+
+
+def generate_launch_description():
+    return LaunchDescription(
+        [
+            SetEnvironmentVariable("RCUTILS_LOGGING_BUFFERED_STREAM", "1"),
+            DeclareLaunchArgument(
+                "log_level",
+                default_value=["info"],
+                description="Logging level",
+            ),
+            DeclareLaunchArgument("namespace", default_value="PioneerP3DX"),
+            DeclareLaunchArgument("motion", default_value="nav2"),
+            DeclareLaunchArgument("nav_profile", default_value="faithful"),
+            DeclareLaunchArgument("drive_pose_source", default_value="tf"),
+            DeclareLaunchArgument("drive_map_yaml", default_value=""),
+            DeclareLaunchArgument("scenario", default_value="Exp_C"),
+            DeclareLaunchArgument("configuration", default_value="config1"),
+            OpaqueFunction(function=launch_setup),
+        ]
+    )

--- a/benchmark_env_realistic/navigation_config/nav2_realistic_params.yaml
+++ b/benchmark_env_realistic/navigation_config/nav2_realistic_params.yaml
@@ -1,0 +1,266 @@
+PioneerP3DX:
+  amcl:
+    ros__parameters:
+      use_sim_time: True
+      alpha1: 0.2
+      alpha2: 0.2
+      alpha3: 0.2
+      alpha4: 0.2
+      alpha5: 0.2
+      base_frame_id: "$(var namespace)_base_link"
+      beam_skip_distance: 0.5
+      beam_skip_error_threshold: 0.9
+      beam_skip_threshold: 0.3
+      do_beamskip: false
+      global_frame_id: "map"
+      lambda_short: 0.1
+      laser_likelihood_max_dist: 2.0
+      laser_max_range: 3.0
+      laser_min_range: 0.1
+      laser_model_type: "likelihood_field"
+      max_beams: 60
+      max_particles: 2000
+      min_particles: 500
+      odom_frame_id: "$(var namespace)_odom"
+      pf_err: 0.05
+      pf_z: 0.99
+      recovery_alpha_fast: 0.0
+      recovery_alpha_slow: 0.0
+      resample_interval: 1
+      robot_model_type: "nav2_amcl::DifferentialMotionModel"
+      save_pose_rate: 0.5
+      sigma_hit: 0.2
+      tf_broadcast: true
+      transform_tolerance: 1.0
+      update_min_a: 0.2
+      update_min_d: 0.25
+      z_hit: 0.5
+      z_max: 0.05
+      z_rand: 0.5
+      z_short: 0.05
+      scan_topic: laser_scanner
+
+  bt_navigator:
+    ros__parameters:
+      use_sim_time: True
+      global_frame: map
+      robot_base_frame: $(var namespace)_base_link
+      odom_topic: $(var namespace)/odom
+      bt_loop_duration: 10
+      default_server_timeout: 20
+      # Stock navigate_to_pose_w_replanning_and_recovery.xml + GoalUpdater —
+      # see adsm_goal_update_bt.xml's own header for the "fresh goal -> BT
+      # rebuild + rotate-to-heading, ~3 cm/s" problem this fixes. Strict
+      # superset of the stock tree when nothing publishes to goal_update.
+      default_nav_to_pose_bt_xml: /home/efe/ros2_ws/src/base/gaden_config/navigation_config/adsm_goal_update_bt.xml
+      navigators: ["navigate_to_pose", "navigate_through_poses"]
+      navigate_to_pose:
+        plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
+      navigate_through_poses:
+        plugin: "nav2_bt_navigator/NavigateThroughPosesNavigator"
+      goal_blackboard_id: goal
+      goals_blackboard_id: goals
+      path_blackboard_id: path
+      plugin_lib_names:
+      - nav2_compute_path_to_pose_action_bt_node
+      - nav2_compute_path_through_poses_action_bt_node
+      - nav2_follow_path_action_bt_node
+      - nav2_back_up_action_bt_node
+      - nav2_spin_action_bt_node
+      - nav2_wait_action_bt_node
+      - nav2_clear_costmap_service_bt_node
+      - nav2_is_stuck_condition_bt_node
+      - nav2_goal_reached_condition_bt_node
+      - nav2_goal_updated_condition_bt_node
+      - nav2_initial_pose_received_condition_bt_node
+      - nav2_reinitialize_global_localization_service_bt_node
+      - nav2_rate_controller_bt_node
+      - nav2_distance_controller_bt_node
+      - nav2_speed_controller_bt_node
+      - nav2_truncate_path_action_bt_node
+      - nav2_goal_updater_node_bt_node
+      - nav2_recovery_node_bt_node
+      - nav2_pipeline_sequence_bt_node
+      - nav2_round_robin_node_bt_node
+      - nav2_transform_available_condition_bt_node
+      - nav2_time_expired_condition_bt_node
+      - nav2_distance_traveled_condition_bt_node
+      - nav2_single_trigger_bt_node
+      - nav2_is_battery_low_condition_bt_node
+      - nav2_navigate_through_poses_action_bt_node
+      - nav2_navigate_to_pose_action_bt_node
+      - nav2_remove_passed_goals_action_bt_node
+      - nav2_planner_selector_bt_node
+      - nav2_controller_selector_bt_node
+      - nav2_goal_checker_selector_bt_node
+
+  controller_server:
+    ros__parameters:
+      use_sim_time: True
+      controller_frequency: 20.0
+      min_x_velocity_threshold: 0.001
+      min_y_velocity_threshold: 0.5
+      min_theta_velocity_threshold: 0.001
+      failure_tolerance: 0.3
+      progress_checker_plugin: "progress_checker"
+      goal_checker_plugins: ["general_goal_checker"]
+      controller_plugins: ["FollowPath"]
+      progress_checker:
+        plugin: "nav2_controller::SimpleProgressChecker"
+        required_movement_radius: 0.5
+        movement_time_allowance: 10.0
+      general_goal_checker:
+        stateful: True
+        plugin: "nav2_controller::SimpleGoalChecker"
+        xy_goal_tolerance: 0.25
+        yaw_goal_tolerance: 6.28
+      FollowPath:
+        plugin: "dwb_core::DWBLocalPlanner"
+        debug_trajectory_details: True
+        min_vel_x: 0.0
+        min_vel_y: 0.0
+        max_vel_x: 0.26
+        max_vel_y: 0.0
+        max_vel_theta: 1.0
+        min_speed_xy: 0.0
+        max_speed_xy: 0.26
+        min_speed_theta: 0.0
+        acc_lim_x: 2.5
+        acc_lim_y: 0.0
+        acc_lim_theta: 3.2
+        decel_lim_x: -2.5
+        decel_lim_y: 0.0
+        decel_lim_theta: -3.2
+        vx_samples: 20
+        vy_samples: 5
+        vtheta_samples: 20
+        sim_time: 1.7
+        linear_granularity: 0.05
+        angular_granularity: 0.025
+        transform_tolerance: 0.2
+        xy_goal_tolerance: 0.25
+        trans_stopped_velocity: 0.25
+        short_circuit_trajectory_evaluation: True
+        stateful: True
+        critics: ["Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
+        BaseObstacle.scale: 0.02
+        PathAlign.scale: 32.0
+        PathAlign.forward_point_distance: 0.1
+        GoalAlign.scale: 24.0
+        GoalAlign.forward_point_distance: 0.1
+        PathDist.scale: 32.0
+        GoalDist.scale: 24.0
+
+  local_costmap:
+    local_costmap:
+      ros__parameters:
+        use_sim_time: True
+        update_frequency: 5.0
+        publish_frequency: 2.0
+        global_frame: $(var namespace)_odom
+        robot_base_frame: $(var namespace)_base_link
+        rolling_window: true
+        width: 3
+        height: 3
+        resolution: 0.05
+        robot_radius: 0.22
+        plugins: ["voxel_layer", "inflation_layer"]
+        inflation_layer:
+          plugin: "nav2_costmap_2d::InflationLayer"
+          cost_scaling_factor: 3.0
+          inflation_radius: 0.55
+        voxel_layer:
+          plugin: "nav2_costmap_2d::VoxelLayer"
+          enabled: True
+          publish_voxel_map: True
+          origin_z: 0.0
+          z_resolution: 0.05
+          z_voxels: 16
+          max_obstacle_height: 2.0
+          mark_threshold: 0
+          observation_sources: scan
+          scan:
+            topic: $(var namespace)/laser_scanner
+            max_obstacle_height: 2.0
+            clearing: True
+            marking: True
+            data_type: "LaserScan"
+            raytrace_max_range: 3.0
+            raytrace_min_range: 0.0
+            obstacle_max_range: 2.5
+            obstacle_min_range: 0.0
+        always_send_full_costmap: True
+
+  global_costmap:
+    global_costmap:
+      ros__parameters:
+        use_sim_time: True
+        update_frequency: 1.0
+        publish_frequency: 1.0
+        global_frame: map
+        robot_base_frame: $(var namespace)_base_link
+        robot_radius: 0.22
+        resolution: 0.05
+        track_unknown_space: true
+        plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
+        obstacle_layer:
+          plugin: "nav2_costmap_2d::ObstacleLayer"
+          enabled: True
+          observation_sources: scan
+          scan:
+            topic: $(var namespace)/laser_scanner
+            max_obstacle_height: 2.0
+            clearing: True
+            marking: True
+            data_type: "LaserScan"
+            raytrace_max_range: 3.0
+            raytrace_min_range: 0.0
+            obstacle_max_range: 2.5
+            obstacle_min_range: 0.0
+        static_layer:
+          plugin: "nav2_costmap_2d::StaticLayer"
+          map_subscribe_transient_local: True
+        inflation_layer:
+          plugin: "nav2_costmap_2d::InflationLayer"
+          cost_scaling_factor: 3.0
+          inflation_radius: 0.55
+        always_send_full_costmap: True
+
+  planner_server:
+    ros__parameters:
+      use_sim_time: True
+      expected_planner_frequency: 20.0
+      planner_plugins: ["GridBased"]
+      GridBased:
+        plugin: "nav2_navfn_planner/NavfnPlanner"
+        tolerance: 0.2
+        use_astar: false
+        allow_unknown: true
+
+  behavior_server:
+    ros__parameters:
+      use_sim_time: True
+      local_costmap_topic: $(var namespace)/local_costmap/costmap_raw
+      global_costmap_topic: $(var namespace)/global_costmap/costmap_raw
+      local_footprint_topic: $(var namespace)/local_costmap/published_footprint
+      global_footprint_topic: $(var namespace)/global_costmap/published_footprint
+      cycle_frequency: 10.0
+      behavior_plugins: ["spin", "backup", "drive_on_heading", "assisted_teleop", "wait"]
+      spin:
+        plugin: "nav2_behaviors/Spin"
+      backup:
+        plugin: "nav2_behaviors/BackUp"
+      drive_on_heading:
+        plugin: "nav2_behaviors/DriveOnHeading"
+      wait:
+        plugin: "nav2_behaviors/Wait"
+      assisted_teleop:
+        plugin: "nav2_behaviors/AssistedTeleop"
+      local_frame: $(var namespace)_odom
+      global_frame: map
+      robot_base_frame: $(var namespace)_base_link
+      transform_tolerance: 0.1
+      simulate_ahead_time: 2.0
+      max_rotational_vel: 1.0
+      min_rotational_vel: 0.4
+      rotational_acc_lim: 3.2

--- a/benchmark_env_realistic/navigation_config/nav2_realistic_params_adsm_faithful.yaml
+++ b/benchmark_env_realistic/navigation_config/nav2_realistic_params_adsm_faithful.yaml
@@ -1,0 +1,278 @@
+# Move_base-faithful variant of nav2_realistic_params.yaml, for exploring
+# ADSM under genuinely noisy odom + online Cartographer mapping instead of
+# ground-truth pose/map. Same DWA/costmap transplant as
+# gaden_config/navigation_config/nav2_params_adsm_faithful.yaml (see that
+# file's header for the full rationale and source references); this copy
+# preserves the realistic env's own laser_scanner topic naming (differs
+# from the non-realistic env's laser_scan). Pass via
+# realistic_launch.py's nav_params_yaml:= argument, paired with
+# default_nav_to_pose_bt_xml -> adsm_faithful_bt.xml below.
+PioneerP3DX:
+  amcl:
+    ros__parameters:
+      use_sim_time: True
+      alpha1: 0.2
+      alpha2: 0.2
+      alpha3: 0.2
+      alpha4: 0.2
+      alpha5: 0.2
+      base_frame_id: "$(var namespace)_base_link"
+      beam_skip_distance: 0.5
+      beam_skip_error_threshold: 0.9
+      beam_skip_threshold: 0.3
+      do_beamskip: false
+      global_frame_id: "map"
+      lambda_short: 0.1
+      laser_likelihood_max_dist: 2.0
+      laser_max_range: 3.0
+      laser_min_range: 0.1
+      laser_model_type: "likelihood_field"
+      max_beams: 60
+      max_particles: 2000
+      min_particles: 500
+      odom_frame_id: "$(var namespace)_odom"
+      pf_err: 0.05
+      pf_z: 0.99
+      recovery_alpha_fast: 0.0
+      recovery_alpha_slow: 0.0
+      resample_interval: 1
+      robot_model_type: "nav2_amcl::DifferentialMotionModel"
+      save_pose_rate: 0.5
+      sigma_hit: 0.2
+      tf_broadcast: true
+      transform_tolerance: 1.0
+      update_min_a: 0.2
+      update_min_d: 0.25
+      z_hit: 0.5
+      z_max: 0.05
+      z_rand: 0.5
+      z_short: 0.05
+      scan_topic: laser_scanner
+
+  bt_navigator:
+    ros__parameters:
+      use_sim_time: True
+      global_frame: map
+      robot_base_frame: $(var namespace)_base_link
+      odom_topic: $(var namespace)/odom
+      bt_loop_duration: 10
+      default_server_timeout: 20
+      # GoalUpdater tree -- restores move_base's non-preempting sendGoal
+      # semantics (see adsm_faithful_bt.xml header). Pair with the adsm
+      # node's use_goal_update:=true.
+      default_nav_to_pose_bt_xml: /home/efe/ros2_ws/src/base/gaden_config/navigation_config/adsm_faithful_bt.xml
+      navigators: ["navigate_to_pose", "navigate_through_poses"]
+      navigate_to_pose:
+        plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
+      navigate_through_poses:
+        plugin: "nav2_bt_navigator/NavigateThroughPosesNavigator"
+      goal_blackboard_id: goal
+      goals_blackboard_id: goals
+      path_blackboard_id: path
+      plugin_lib_names:
+      - nav2_compute_path_to_pose_action_bt_node
+      - nav2_compute_path_through_poses_action_bt_node
+      - nav2_follow_path_action_bt_node
+      - nav2_back_up_action_bt_node
+      - nav2_spin_action_bt_node
+      - nav2_wait_action_bt_node
+      - nav2_clear_costmap_service_bt_node
+      - nav2_is_stuck_condition_bt_node
+      - nav2_goal_reached_condition_bt_node
+      - nav2_goal_updated_condition_bt_node
+      - nav2_initial_pose_received_condition_bt_node
+      - nav2_reinitialize_global_localization_service_bt_node
+      - nav2_rate_controller_bt_node
+      - nav2_distance_controller_bt_node
+      - nav2_speed_controller_bt_node
+      - nav2_truncate_path_action_bt_node
+      - nav2_goal_updater_node_bt_node
+      - nav2_recovery_node_bt_node
+      - nav2_pipeline_sequence_bt_node
+      - nav2_round_robin_node_bt_node
+      - nav2_transform_available_condition_bt_node
+      - nav2_time_expired_condition_bt_node
+      - nav2_distance_traveled_condition_bt_node
+      - nav2_single_trigger_bt_node
+      - nav2_is_battery_low_condition_bt_node
+      - nav2_navigate_through_poses_action_bt_node
+      - nav2_navigate_to_pose_action_bt_node
+      - nav2_remove_passed_goals_action_bt_node
+      - nav2_planner_selector_bt_node
+      - nav2_controller_selector_bt_node
+      - nav2_goal_checker_selector_bt_node
+
+  controller_server:
+    ros__parameters:
+      use_sim_time: True
+      controller_frequency: 10.0  # = move_base default
+      min_x_velocity_threshold: 0.001
+      min_y_velocity_threshold: 0.5
+      min_theta_velocity_threshold: 0.001
+      failure_tolerance: 0.3
+      progress_checker_plugin: "progress_checker"
+      goal_checker_plugins: ["general_goal_checker"]
+      controller_plugins: ["FollowPath"]
+      progress_checker:
+        plugin: "nav2_controller::SimpleProgressChecker"
+        required_movement_radius: 0.2
+        movement_time_allowance: 15.0
+      general_goal_checker:
+        stateful: False  # = move_base's latch_xy_goal_tolerance: false
+        plugin: "nav2_controller::SimpleGoalChecker"
+        xy_goal_tolerance: 0.10
+        yaw_goal_tolerance: 0.17
+      # DWB parameters -- transplanted from
+      # An-adaptive-robot-search-algorithm/params/move_base/dwa_local_planner_params_burger.yaml
+      FollowPath:
+        plugin: "dwb_core::DWBLocalPlanner"
+        debug_trajectory_details: True
+        min_vel_x: -0.22  # DWA allowed reverse; DWB default (0.0) can't back out of a wedge
+        min_vel_y: 0.0
+        max_vel_x: 0.22
+        max_vel_y: 0.0
+        max_vel_theta: 2.75
+        min_speed_xy: 0.0
+        max_speed_xy: 0.22
+        min_speed_theta: 0.0
+        acc_lim_x: 2.5
+        acc_lim_y: 0.0
+        acc_lim_theta: 3.2
+        decel_lim_x: -2.5
+        decel_lim_y: 0.0
+        decel_lim_theta: -3.2
+        vx_samples: 20
+        vy_samples: 0
+        vtheta_samples: 40
+        sim_time: 1.5
+        linear_granularity: 0.05
+        angular_granularity: 0.025
+        transform_tolerance: 0.2
+        xy_goal_tolerance: 0.10
+        trans_stopped_velocity: 0.05
+        short_circuit_trajectory_evaluation: True
+        stateful: True
+        critics: ["Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
+        BaseObstacle.scale: 0.02
+        PathAlign.scale: 32.0
+        PathAlign.forward_point_distance: 0.325
+        GoalAlign.scale: 20.0
+        GoalAlign.forward_point_distance: 0.325
+        PathDist.scale: 32.0
+        GoalDist.scale: 20.0
+
+  local_costmap:
+    local_costmap:
+      ros__parameters:
+        use_sim_time: True
+        update_frequency: 10.0  # = move_base local_costmap_params.yaml
+        publish_frequency: 2.0
+        global_frame: $(var namespace)_odom
+        robot_base_frame: $(var namespace)_base_link
+        rolling_window: true
+        width: 3
+        height: 3
+        resolution: 0.05
+        # Must match the collision radius used by BasicSim.
+        robot_radius: 0.25
+        plugins: ["voxel_layer", "inflation_layer"]
+        inflation_layer:
+          plugin: "nav2_costmap_2d::InflationLayer"
+          cost_scaling_factor: 3.0
+          inflation_radius: 0.55
+        voxel_layer:
+          plugin: "nav2_costmap_2d::VoxelLayer"
+          enabled: True
+          publish_voxel_map: True
+          origin_z: 0.0
+          z_resolution: 0.05
+          z_voxels: 16
+          max_obstacle_height: 2.0
+          mark_threshold: 0
+          observation_sources: scan
+          scan:
+            topic: $(var namespace)/laser_scanner
+            max_obstacle_height: 2.0
+            clearing: True
+            marking: True
+            data_type: "LaserScan"
+            raytrace_max_range: 3.0
+            raytrace_min_range: 0.0
+            obstacle_max_range: 2.5
+            obstacle_min_range: 0.0
+        always_send_full_costmap: True
+
+  global_costmap:
+    global_costmap:
+      ros__parameters:
+        use_sim_time: True
+        update_frequency: 1.0
+        publish_frequency: 1.0
+        global_frame: map
+        robot_base_frame: $(var namespace)_base_link
+        # Must match the collision radius used by BasicSim.
+        robot_radius: 0.25
+        resolution: 0.05
+        track_unknown_space: true
+        plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
+        obstacle_layer:
+          plugin: "nav2_costmap_2d::ObstacleLayer"
+          enabled: True
+          observation_sources: scan
+          scan:
+            topic: $(var namespace)/laser_scanner
+            max_obstacle_height: 2.0
+            clearing: True
+            marking: True
+            data_type: "LaserScan"
+            raytrace_max_range: 3.0
+            raytrace_min_range: 0.0
+            obstacle_max_range: 2.5
+            obstacle_min_range: 0.0
+        static_layer:
+          plugin: "nav2_costmap_2d::StaticLayer"
+          map_subscribe_transient_local: True
+        inflation_layer:
+          plugin: "nav2_costmap_2d::InflationLayer"
+          cost_scaling_factor: 3.0
+          inflation_radius: 0.55
+        always_send_full_costmap: True
+
+  planner_server:
+    ros__parameters:
+      use_sim_time: True
+      expected_planner_frequency: 5.0  # = move_base's planner_frequency
+      planner_plugins: ["GridBased"]
+      GridBased:
+        plugin: "nav2_navfn_planner/NavfnPlanner"
+        tolerance: 0.2
+        use_astar: false
+        allow_unknown: true
+
+  behavior_server:
+    ros__parameters:
+      use_sim_time: True
+      local_costmap_topic: $(var namespace)/local_costmap/costmap_raw
+      global_costmap_topic: $(var namespace)/global_costmap/costmap_raw
+      local_footprint_topic: $(var namespace)/local_costmap/published_footprint
+      global_footprint_topic: $(var namespace)/global_costmap/published_footprint
+      cycle_frequency: 10.0
+      behavior_plugins: ["spin", "backup", "drive_on_heading", "assisted_teleop", "wait"]
+      spin:
+        plugin: "nav2_behaviors/Spin"
+      backup:
+        plugin: "nav2_behaviors/BackUp"
+      drive_on_heading:
+        plugin: "nav2_behaviors/DriveOnHeading"
+      wait:
+        plugin: "nav2_behaviors/Wait"
+      assisted_teleop:
+        plugin: "nav2_behaviors/AssistedTeleop"
+      local_frame: $(var namespace)_odom
+      global_frame: map
+      robot_base_frame: $(var namespace)_base_link
+      transform_tolerance: 0.1
+      simulate_ahead_time: 2.0
+      max_rotational_vel: 2.75
+      min_rotational_vel: 1.37
+      rotational_acc_lim: 3.2

--- a/benchmark_env_realistic/navigation_config/slam_watch.rviz
+++ b/benchmark_env_realistic/navigation_config/slam_watch.rviz
@@ -1,0 +1,38 @@
+Panels:
+  - Class: rviz_common/Displays
+    Name: Displays
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Class: rviz_default_plugins/Grid
+      Name: Grid
+      Enabled: true
+    - Class: rviz_default_plugins/TF
+      Name: TF
+      Enabled: true
+    - Class: rviz_default_plugins/Map
+      Name: SLAM Map
+      Topic:
+        Value: /PioneerP3DX/map
+      Enabled: true
+      Alpha: 1
+      Color Scheme: map
+    - Class: rviz_default_plugins/LaserScan
+      Name: LaserScan
+      Topic:
+        Value: /PioneerP3DX/laser_scanner
+      Enabled: true
+      Size (m): 0.05
+      Color: 255; 0; 0
+  Global Options:
+    Fixed Frame: map
+    Background Color: 48; 48; 48
+  Tools:
+    - Class: rviz_default_plugins/Interact
+    - Class: rviz_default_plugins/MoveCamera
+  Views:
+    Current:
+      Class: rviz_default_plugins/TopDownOrtho
+      Scale: 40
+      X: 0
+      Y: 0

--- a/benchmark_env_realistic/package.xml
+++ b/benchmark_env_realistic/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+
+  <name>benchmark_env_realistic</name>
+  <version>0.0.0</version>
+  <description>Realistic variant of benchmark_env: Cartographer for mapping, AMCL for noisy pose. No ground-truth map or pose.</description>
+  <maintainer email="efemantaroglu@gmail.com">Efe</maintainer>
+
+  <license>GPLv3</license>
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <exec_depend>ros2launch</exec_depend>
+  <exec_depend>python3-yaml</exec_depend>
+  <exec_depend>xacro</exec_depend>
+  <exec_depend>robot_state_publisher</exec_depend>
+  <exec_depend>benchmark_env</exec_depend>
+  <exec_depend>gaden_config</exec_depend>
+  <exec_depend>cartographer_ros</exec_depend>
+  <exec_depend>nav2_amcl</exec_depend>
+  <exec_depend>nav2_bt_navigator</exec_depend>
+  <exec_depend>nav2_planner</exec_depend>
+  <exec_depend>nav2_controller</exec_depend>
+  <exec_depend>nav2_behaviors</exec_depend>
+  <exec_depend>nav2_lifecycle_manager</exec_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/directdrive_nav/directdrive_nav.py
+++ b/directdrive_nav/directdrive_nav.py
@@ -1,0 +1,306 @@
+#!/usr/bin/env python3
+"""DirectDrive NavigateToPose server — a drop-in replacement for Nav2's
+navigator that drives via rotate-then-go cmd_vel along an A* path on a STATIC
+occupancy map. It never issues the wall-hugging curved velocity commands that
+BasicSim's all-or-nothing collision model (Robot.cpp: discards any motion whose
+endpoint isn't free) freezes on, so it threads tight houses where Nav2+BasicSim
+wedges.
+
+ADSM fire-and-forgets NavigateToPose goals at ~1 Hz, so each accepted goal just
+(re)plans an A* path to the target and returns immediately; a 10 Hz control
+timer continuously drives toward the latest path's next waypoint.
+
+Run (static ground-truth map, ground-truth pose — original mode):
+  python3 directdrive_nav.py --ros-args \
+     -p map_yaml:=<...>/occupancy.yaml \
+     -p action_name:=/PioneerP3DX/dd_navigate_to_pose \
+     -p pose_topic:=/PioneerP3DX/ground_truth \
+     -p cmd_vel_topic:=/PioneerP3DX/cmd_vel
+
+Run (live SLAM map, noisy TF pose — realistic mode):
+  python3 directdrive_nav.py --ros-args \
+     -p map_topic:=/PioneerP3DX/map \
+     -p pose_source:=tf \
+     -p map_frame:=map -p base_frame:=PioneerP3DX_base_link \
+     -p action_name:=/PioneerP3DX/navigate_to_pose \
+     -p cmd_vel_topic:=/PioneerP3DX/cmd_vel
+"""
+import os
+import math
+import heapq
+import time
+import numpy as np
+import yaml
+from scipy.ndimage import binary_dilation
+
+import rclpy
+from rclpy.node import Node
+from rclpy.action import ActionServer
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.callback_groups import ReentrantCallbackGroup
+
+import tf2_ros
+from nav2_msgs.action import NavigateToPose
+from geometry_msgs.msg import Twist, PoseWithCovarianceStamped
+from nav_msgs.msg import Odometry, OccupancyGrid
+
+
+def _yaw(q):
+    return math.atan2(2.0 * (q.w * q.z + q.x * q.y),
+                      1.0 - 2.0 * (q.y * q.y + q.z * q.z))
+
+
+class DirectDriveNav(Node):
+    def __init__(self):
+        super().__init__('directdrive_navigator')
+        gp = self.declare_parameter
+        map_yaml = gp('map_yaml', '').value
+        map_topic = gp('map_topic', '').value
+        action_name = gp('action_name', '/PioneerP3DX/dd_navigate_to_pose').value
+        pose_topic = gp('pose_topic', '/PioneerP3DX/ground_truth').value
+        self.pose_source = gp('pose_source', 'topic').value  # 'topic' or 'tf'
+        self.map_frame = gp('map_frame', 'map').value
+        self.base_frame = gp('base_frame', '').value
+        cmd_topic = gp('cmd_vel_topic', '/PioneerP3DX/cmd_vel').value
+        self.robot_radius = float(gp('robot_radius', 0.11).value)
+        self.linear = float(gp('linear', 0.22).value)
+        self.gain = float(gp('gain', 1.5).value)
+        self.max_ang = float(gp('max_ang', 1.2).value)
+        self.hop_tol = float(gp('hop_tol', 0.18).value)
+        self.rotate_thresh = float(gp('rotate_thresh', 0.7).value)
+        # Observed real hop completion: 1.6-2.9s. Kept tight (not generous) on
+        # purpose: a wedged hop now correctly BLOCKS until this timeout instead
+        # of reporting instant false success, so a stuck run pays this cost on
+        # every futile step — a loose timeout compounds badly across hundreds
+        # of stuck steps.
+        self.goal_timeout = float(gp('goal_timeout', 5.0).value)
+
+        self.occ = None
+        self._live_map = bool(map_topic)
+        if map_yaml and not self._live_map:
+            self._load_map(map_yaml)
+
+        self.x = self.y = self.theta = None
+        self._path = []
+        self._idx = 0
+
+        cbg = ReentrantCallbackGroup()
+        if self.pose_source == 'tf':
+            self._tf_buffer = tf2_ros.Buffer()
+            self._tf_listener = tf2_ros.TransformListener(self._tf_buffer, self)
+        else:
+            self.create_subscription(PoseWithCovarianceStamped, pose_topic,
+                                     self._pose_cb, 10, callback_group=cbg)
+        if self._live_map:
+            self.create_subscription(OccupancyGrid, map_topic,
+                                     self._map_cb, 10, callback_group=cbg)
+        self._cmd = self.create_publisher(Twist, cmd_topic, 10)
+        self._as = ActionServer(self, NavigateToPose, action_name,
+                                self._execute, callback_group=cbg)
+        self.create_timer(0.1, self._control_tick, callback_group=cbg)
+        self.create_timer(0.1, self._pose_tick, callback_group=cbg)
+        self.get_logger().info(
+            f'DirectDrive up: action={action_name} pose_source={self.pose_source} '
+            f'map={"live:" + map_topic if self._live_map else map_yaml}')
+
+    # ---- map + A* ----
+    def _load_map(self, yaml_path):
+        cfg = yaml.safe_load(open(yaml_path))
+        pgm = os.path.join(os.path.dirname(yaml_path), cfg['image'])
+        t = open(pgm).read().split()
+        self.W, self.H = int(t[1]), int(t[2])
+        img = np.array(t[4:4 + self.W * self.H], dtype=int).reshape(self.H, self.W)
+        self.res = float(cfg['resolution'])
+        self.ox, self.oy = float(cfg['origin'][0]), float(cfg['origin'][1])
+        occ = (img == 0)  # map_server negate=0: pixel 0 = occupied
+        self.occ = binary_dilation(occ, iterations=max(1, int(round(self.robot_radius / self.res))))
+
+    def _map_cb(self, msg: OccupancyGrid):
+        """Live SLAM map: rebuild the grid every message. Unknown (-1) cells are
+        treated as passable (same convention as efe_igdm's is_valid_traversable)
+        so the robot can drive into unmapped territory and expand the map."""
+        w, h = msg.info.width, msg.info.height
+        if w == 0 or h == 0:
+            return
+        grid = np.array(msg.data, dtype=np.int16).reshape(h, w)
+        occ = np.flipud(grid > 50)  # >50 = occupied; unknown(-1)/free(0) both passable
+        self.W, self.H = w, h
+        self.res = float(msg.info.resolution)
+        self.ox = float(msg.info.origin.position.x)
+        self.oy = float(msg.info.origin.position.y)
+        self.occ = binary_dilation(occ, iterations=max(1, int(round(self.robot_radius / self.res))))
+
+    def _w2c(self, x, y):
+        return (self.H - 1 - int((y - self.oy) / self.res), int((x - self.ox) / self.res))
+
+    def _c2w(self, r, c):
+        return (self.ox + (c + 0.5) * self.res, self.oy + (self.H - 1 - r + 0.5) * self.res)
+
+    def _nearest_free(self, r, c):
+        if not self.occ[r, c]:
+            return r, c
+        fr = np.argwhere(~self.occ)
+        d = np.hypot(fr[:, 0] - r, fr[:, 1] - c)
+        return tuple(fr[d.argmin()])
+
+    def _astar(self, s, g):
+        sr, sc = self._w2c(*s)
+        gr, gc = self._w2c(*g)
+        sr, sc = self._nearest_free(sr, sc)
+        gr, gc = self._nearest_free(gr, gc)
+        H, W, occ = self.H, self.W, self.occ
+
+        def h(r, c):
+            return math.hypot(r - gr, c - gc)
+        pq = [(h(sr, sc), 0.0, (sr, sc))]
+        came = {(sr, sc): None}
+        cost = {(sr, sc): 0.0}
+        found = False
+        while pq:
+            _, g_, cur = heapq.heappop(pq)
+            if cur == (gr, gc):
+                found = True
+                break
+            r, c = cur
+            for dr, dc in ((-1, 0), (1, 0), (0, -1), (0, 1), (-1, -1), (-1, 1), (1, -1), (1, 1)):
+                nr, nc = r + dr, c + dc
+                if 0 <= nr < H and 0 <= nc < W and not occ[nr, nc]:
+                    step = 1.4142 if dr and dc else 1.0
+                    ng = g_ + step
+                    if ng < cost.get((nr, nc), 1e18):
+                        cost[(nr, nc)] = ng
+                        came[(nr, nc)] = cur
+                        heapq.heappush(pq, (ng + h(nr, nc), ng, (nr, nc)))
+        if not found:
+            return None
+        path = []
+        cur = (gr, gc)
+        while cur is not None:
+            path.append(cur)
+            cur = came[cur]
+        path = path[::-1]
+        return self._simplify(path)
+
+    def _simplify(self, cells):
+        """Drop collinear cells; keep line-of-sight-reachable turning points."""
+        if len(cells) <= 2:
+            return [self._c2w(*c) for c in cells]
+        out = [cells[0]]
+        i = 0
+        while i < len(cells) - 1:
+            j = len(cells) - 1
+            while j > i + 1 and not self._los(cells[i], cells[j]):
+                j -= 1
+            out.append(cells[j])
+            i = j
+        return [self._c2w(*c) for c in out]
+
+    def _los(self, a, b):
+        r0, c0 = a
+        r1, c1 = b
+        n = int(max(abs(r1 - r0), abs(c1 - c0)))
+        if n == 0:
+            return True
+        for k in range(n + 1):
+            r = int(round(r0 + (r1 - r0) * k / n))
+            c = int(round(c0 + (c1 - c0) * k / n))
+            if self.occ[r, c]:
+                return False
+        return True
+
+    # ---- ROS callbacks ----
+    def _pose_cb(self, msg):
+        p = msg.pose.pose
+        self.x, self.y = p.position.x, p.position.y
+        self.theta = _yaw(p.orientation)
+
+    def _pose_tick(self):
+        """TF-based pose (realistic/SLAM mode): holds last known pose on lookup
+        failure, same policy as gsl_bench's runner_node."""
+        if self.pose_source != 'tf':
+            return
+        try:
+            tf = self._tf_buffer.lookup_transform(
+                self.map_frame, self.base_frame, rclpy.time.Time())
+            self.x = tf.transform.translation.x
+            self.y = tf.transform.translation.y
+            self.theta = _yaw(tf.transform.rotation)
+        except (tf2_ros.LookupException, tf2_ros.ConnectivityException,
+                tf2_ros.ExtrapolationException):
+            pass
+
+    def _execute(self, gh):
+        """Plan, then BLOCK until _control_tick actually drives the robot to
+        the goal (or cancel/timeout) before reporting completion.
+
+        Originally this returned right after planning — before any driving
+        happened — which was correct for ADSM's fire-and-forget 1 Hz goal
+        stream (see module docstring) but wrong for gsl_bench's Navigator
+        client, which treats action "success" as "the robot arrived" (that's
+        what a real Nav2 action does) and immediately plans the *next* step
+        the instant the result future resolves. Because planning is
+        near-instant, the harness was advancing to a brand-new target before
+        the robot had moved at all, overwriting the in-progress path every
+        cycle. Blocking here — running on a ReentrantCallbackGroup thread
+        separate from the _control_tick timer that's still driving — makes
+        "succeeded" mean what the client assumes it means.
+        """
+        tgt = gh.request.pose.pose.position
+        path = None
+        if self.x is not None and self.occ is not None:
+            path = self._astar((self.x, self.y), (tgt.x, tgt.y))
+        if not path:
+            # Nothing to drive (unreachable, or pose/map not ready yet) — fail
+            # fast rather than blocking on stale state from a prior goal.
+            gh.abort()
+            return NavigateToPose.Result()
+        self._path = path
+        self._idx = 0
+
+        deadline = time.time() + self.goal_timeout
+        while self._idx < len(self._path):
+            if gh.is_cancel_requested:
+                gh.canceled()
+                return NavigateToPose.Result()
+            if time.time() > deadline:
+                gh.abort()
+                return NavigateToPose.Result()
+            time.sleep(0.05)
+
+        gh.succeed()
+        return NavigateToPose.Result()
+
+    def _control_tick(self):
+        if self.x is None or not self._path:
+            return
+        if self._idx >= len(self._path):
+            self._cmd.publish(Twist())
+            return
+        tx, ty = self._path[self._idx]
+        if math.hypot(tx - self.x, ty - self.y) < self.hop_tol:
+            self._idx += 1
+            return
+        he = math.atan2(ty - self.y, tx - self.x) - self.theta
+        he = math.atan2(math.sin(he), math.cos(he))
+        tw = Twist()
+        tw.linear.x = 0.0 if abs(he) > self.rotate_thresh else self.linear
+        tw.angular.z = max(-self.max_ang, min(self.max_ang, self.gain * he))
+        self._cmd.publish(tw)
+
+
+def main():
+    rclpy.init()
+    node = DirectDriveNav()
+    ex = MultiThreadedExecutor()
+    ex.add_node(node)
+    try:
+        ex.spin()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/eesa/eesa/main.py
+++ b/eesa/eesa/main.py
@@ -21,10 +21,11 @@ from eesa.banana import Banana
 class FinishCheck:
     """Checks various termination conditions."""
 
-    def __init__(self, node: Node, rc: RobotClient, params: dict):
+    def __init__(self, node: Node, rc: RobotClient, params: dict, agent):
         self.node = node
         self.rc = rc
         self.params = params
+        self.agent = agent
         self.robot_stuck_pose = None
         self.robot_stuck_last_time = None
         self.robot_stuck_dis_th = 0.2
@@ -52,6 +53,15 @@ class FinishCheck:
         if it >= self.params['max_iter']:
             self.result = 'REACH_MAX_ITER'
             self.node.get_logger().info(f"STOP: MAX_ITER ({it}/{self.params['max_iter']})")
+            return True
+
+        # Oracle-derived travel-distance budget (0.0 = disabled)
+        budget = self.params.get('distance_budget', 0.0)
+        if budget > 0.0 and self.agent.total_distance >= budget:
+            self.result = 'DISTANCE_BUDGET_EXCEEDED'
+            self.node.get_logger().info(
+                f'STOP: DISTANCE_BUDGET_EXCEEDED '
+                f'({self.agent.total_distance:.2f}/{budget:.2f} m)')
             return True
 
         # Stuck detection
@@ -98,6 +108,7 @@ class EesaNode(Node):
         self.declare_parameter('find_source_th', 0.5)
         self.declare_parameter('iter_rate', 1)
         self.declare_parameter('max_iter', 200)
+        self.declare_parameter('distance_budget', 0.0)
         self.declare_parameter('max_stuck_time', 60.0)
         self.declare_parameter('data_path', '/tmp/eesa_results')
         self.declare_parameter('visual', True)
@@ -129,6 +140,7 @@ class EesaNode(Node):
             'find_source_th': float(self.get_parameter('find_source_th').value),
             'iter_rate': int(self.get_parameter('iter_rate').value),
             'max_iter': int(self.get_parameter('max_iter').value),
+            'distance_budget': float(self.get_parameter('distance_budget').value),
             'max_stuck_time': float(self.get_parameter('max_stuck_time').value),
             'data_path': self.get_parameter('data_path').value,
             'visual': bool(self.get_parameter('visual').value),
@@ -163,8 +175,8 @@ def main(args=None):
         sensor_window=params['sensor_window'],
     )
 
-    fc = FinishCheck(node, rc, params)
     agent = Banana(node, mc, rc, params)
+    fc = FinishCheck(node, rc, params, agent)
 
     # Build a unique run path
     import uuid

--- a/eesa/launch/eesa_launch.py
+++ b/eesa/launch/eesa_launch.py
@@ -21,6 +21,9 @@ def generate_launch_description():
         DeclareLaunchArgument('find_source_th', default_value='0.5'),
         DeclareLaunchArgument('iter_rate', default_value='1'),
         DeclareLaunchArgument('max_iter', default_value='200'),
+        # Oracle-derived travel-distance cap (10x an honest straight-shot Nav2
+        # drive to the source). 0.0 = disabled, matches the flat max_iter default.
+        DeclareLaunchArgument('distance_budget', default_value='0.0'),
         DeclareLaunchArgument('max_stuck_time', default_value='60.0'),
         DeclareLaunchArgument('data_path', default_value='/tmp/eesa_results'),
         DeclareLaunchArgument('visual', default_value='true'),
@@ -70,6 +73,8 @@ def generate_launch_description():
                 'find_source_th': LaunchConfiguration('find_source_th'),
                 'iter_rate': LaunchConfiguration('iter_rate'),
                 'max_iter': ParameterValue(LaunchConfiguration('max_iter'), value_type=int),
+                'distance_budget': ParameterValue(
+                    LaunchConfiguration('distance_budget'), value_type=float),
                 'max_stuck_time': LaunchConfiguration('max_stuck_time'),
                 'data_path': LaunchConfiguration('data_path'),
                 'visual': True,

--- a/efe_igdm/efe_igdm/mapping/occupancy_grid.py
+++ b/efe_igdm/efe_igdm/mapping/occupancy_grid.py
@@ -3,6 +3,7 @@ from matplotlib.colors import ListedColormap
 import matplotlib.pyplot as plt
 from scipy.ndimage import binary_fill_holes, label, generate_binary_structure, binary_dilation
 import rclpy
+import time
 from rclpy.node import Node
 from gaden_msgs.srv import Occupancy
 
@@ -36,28 +37,54 @@ def load_3d_occupancy_grid_from_service(node: Node, service_name='/gaden_environ
     params : dict
         Dictionary with env_min, env_max, num_cells, cell_size
     """
-    # Create service client
-    client = node.create_client(Occupancy, service_name)
+    # Use a STEADY/WALL deadline and retry the complete request. On loaded cluster
+    # nodes Fast-DDS can occasionally drop the first response while GADEN reports
+    # "failed to send response ... client will not receive response". The former
+    # spin_until_future_complete timeout followed the node's simulation clock and
+    # could then wait forever during startup. A fresh client/request is required;
+    # waiting longer on the lost future can never recover.
+    deadline = time.monotonic() + timeout_sec
+    response = None
+    last_error = None
+    for attempt in range(1, 4):
+        remaining = deadline - time.monotonic()
+        if remaining <= 0.0:
+            break
+        client = node.create_client(Occupancy, service_name)
+        try:
+            node.get_logger().info(
+                f'Waiting for service {service_name} (attempt {attempt}/3)...')
+            if not client.wait_for_service(timeout_sec=remaining):
+                last_error = f'service unavailable on attempt {attempt}'
+                continue
 
-    # Wait for service to be available
-    node.get_logger().info(f'Waiting for service {service_name}...')
-    if not client.wait_for_service(timeout_sec=timeout_sec):
-        raise RuntimeError(f'Service {service_name} not available after {timeout_sec} seconds')
+            node.get_logger().info(
+                f'Calling service {service_name} (attempt {attempt}/3)...')
+            future = client.call_async(Occupancy.Request())
+            attempt_deadline = min(deadline, time.monotonic() + 10.0)
+            while (rclpy.ok() and not future.done()
+                   and time.monotonic() < attempt_deadline):
+                rclpy.spin_once(node, timeout_sec=0.1)
 
-    # Create request (empty for this service)
-    request = Occupancy.Request()
+            if future.done():
+                try:
+                    response = future.result()
+                except Exception as exc:
+                    last_error = f'attempt {attempt} failed: {exc}'
+                if response is not None:
+                    break
+            else:
+                last_error = f'attempt {attempt} timed out waiting for response'
+        finally:
+            node.destroy_client(client)
 
-    # Call service
-    node.get_logger().info(f'Calling service {service_name}...')
-    future = client.call_async(request)
-    rclpy.spin_until_future_complete(node, future, timeout_sec=timeout_sec)
+        if time.monotonic() < deadline:
+            node.get_logger().warn(
+                f'Occupancy service {last_error}; retrying with a fresh client.')
 
-    if not future.done():
-        raise RuntimeError(f'Service call to {service_name} timed out')
-
-    response = future.result()
     if response is None:
-        raise RuntimeError(f'Service call to {service_name} failed')
+        raise RuntimeError(
+            f'Service call to {service_name} failed after 3 attempts: {last_error}')
 
     # Extract response data
     origin = response.origin
@@ -228,6 +255,36 @@ class OccupancyGridMap:
                 # Check grid bounds and occupancy
                 if 0 <= check_gx < self.grid_width and 0 <= check_gy < self.grid_height:
                     if self.grid[check_gy, check_gx] != 0:
+                        return False
+        return True
+
+    def is_valid_traversable(self, position: tuple[float, float], radius: float = 0.2) -> bool:
+        """
+        Check if position is traversable (within bounds, not intersecting occupied cells).
+
+        Unlike is_valid, this treats CELL_UNKNOWN (-1) as passable — intended for
+        online SLAM mode where the map is incomplete and the robot must drive into
+        unknown territory to expand it. Only cells with value > 0 (occupied, outlet)
+        are considered obstacles.
+        """
+        gx, gy = self.world_to_grid(*position)
+
+        if gx < 0 or gx >= self.grid_width or gy < 0 or gy >= self.grid_height:
+            return False
+
+        radius_cells = int(np.ceil(radius / self.resolution))
+        radius_sq_cells = radius_cells ** 2
+
+        for dx in range(-radius_cells, radius_cells + 1):
+            for dy in range(-radius_cells, radius_cells + 1):
+                if dx * dx + dy * dy > radius_sq_cells:
+                    continue
+
+                check_gx = gx + dx
+                check_gy = gy + dy
+
+                if 0 <= check_gx < self.grid_width and 0 <= check_gy < self.grid_height:
+                    if self.grid[check_gy, check_gx] > 0:
                         return False
         return True
 

--- a/efe_igdm/efe_igdm/planning/navigator.py
+++ b/efe_igdm/efe_igdm/planning/navigator.py
@@ -148,26 +148,44 @@ class Navigator:
     # --- Internal Logic / Callbacks ---
 
     def _nav_feedback_callback(self, feedback_msg):
-        if self.goal_position is None or self.goal_handle is None: return
-        
+        # Snapshot both under one read: _nav_result_callback clears goal_handle from
+        # another executor thread, so re-reading self.goal_handle after the guard can
+        # see None and blow up on cancel_goal_async().
+        goal_handle = self.goal_handle
+        goal_position = self.goal_position
+        if goal_position is None or goal_handle is None: return
+
         current_pose = feedback_msg.feedback.current_pose.pose.position
-        dx = current_pose.x - self.goal_position[0]
-        dy = current_pose.y - self.goal_position[1]
-        
+        dx = current_pose.x - goal_position[0]
+        dy = current_pose.y - goal_position[1]
+
         # Manual distance check for smooth stopping
         if np.hypot(dx, dy) <= self.xy_goal_tolerance:
             self.node.get_logger().debug('XY goal reached via feedback, canceling for smooth stop.')
-            self.goal_handle.cancel_goal_async().add_done_callback(self._goal_cancel_callback)
+            try:
+                goal_handle.cancel_goal_async().add_done_callback(self._goal_cancel_callback)
+            except Exception as e:
+                self.node.get_logger().warn(f'feedback cancel failed: {e}')
 
     def _nav_goal_response_callback(self, future):
-        self.goal_handle = future.result()
-        if not self.goal_handle.accepted:
+        # future.result() is None if the goal request itself failed (e.g. the action
+        # server went away mid-request). Treat that exactly like a rejection rather
+        # than dereferencing None — otherwise is_moving stays True and the node hangs.
+        try:
+            goal_handle = future.result()
+        except Exception as e:
+            self.node.get_logger().warn(f'Goal request failed: {e}')
+            goal_handle = None
+        self.goal_handle = goal_handle
+
+        if goal_handle is None or not goal_handle.accepted:
             self.node.get_logger().warn('Goal rejected!')
+            self.goal_handle = None
             self.is_moving = False
             if self.on_complete_callback:
                 self.on_complete_callback()
             return
-        self.goal_handle.get_result_async().add_done_callback(self._nav_result_callback)
+        goal_handle.get_result_async().add_done_callback(self._nav_result_callback)
 
     def _nav_result_callback(self, future):
         status = future.result().status
@@ -208,13 +226,16 @@ class Navigator:
         """Cancel the active navigate_to_pose goal (used by the node's per-step
         drive timeout). The cancel result arrives via _nav_result_callback, which
         clears is_moving and fires on_complete_callback so the node re-predicts."""
-        if self.goal_handle is not None:
+        goal_handle = self.goal_handle  # snapshot; cleared by _nav_result_callback
+        cancelled = False
+        if goal_handle is not None:
             try:
-                self.goal_handle.cancel_goal_async().add_done_callback(
+                goal_handle.cancel_goal_async().add_done_callback(
                     self._goal_cancel_callback)
+                cancelled = True
             except Exception as e:
                 self.node.get_logger().warn(f'cancel_current_goal failed: {e}')
-        else:
+        if not cancelled:
             # Goal request not yet accepted (rare at multi-second timeouts): force
             # completion so the node re-predicts; any stale goal that lands later is
             # preempted by the next send_goal anyway.

--- a/gaden_config/navigation_config/adsm_faithful_bt.xml
+++ b/gaden_config/navigation_config/adsm_faithful_bt.xml
@@ -1,0 +1,62 @@
+<!--
+  ADSM move_base-faithful navigation tree.
+
+  Builds on adsm_goal_update_bt.xml's GoalUpdater fix (see that file for the
+  full preemption writeup) and additionally matches move_base's replanning
+  cadence and recovery ladder, per
+  An-adaptive-robot-search-algorithm/params/move_base/move_base_params.yaml:
+
+    planner_frequency: 5.0          -> RateController hz="5.0" below
+    controller_patience/oscillation -> handled by the progress_checker in
+                                        nav2_params_adsm_faithful.yaml, not here
+    recovery_behaviors (default)    -> conservative reset (clear costmap),
+                                        rotate recovery, aggressive reset
+                                        (clear costmap outside a larger
+                                        window), rotate recovery, abort
+
+  Pair with nav2_params_adsm_faithful.yaml, which also drops the DWB min_vel_x
+  to -0.22 (reverse): move_base's local planner could always back out of a
+  wedge, so this tree's ladder does NOT include BackUp/Wait like
+  adsm_goal_update_bt.xml's does. Those covered for the missing reverse
+  capability in the literal-translation arm, and are redundant (Wait) or
+  no longer necessary (BackUp, since backing up is now in the controller's
+  own search space) once reverse is available to DWB directly.
+
+  Use with the adsm node's use_goal_update:=true, same as
+  adsm_goal_update_bt.xml.
+-->
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <RecoveryNode number_of_retries="6" name="NavigateRecovery">
+      <PipelineSequence name="NavigateWithReplanning">
+        <RateController hz="5.0">
+          <RecoveryNode number_of_retries="1" name="ComputePathToPose">
+            <GoalUpdater input_goal="{goal}" output_goal="{updated_goal}">
+              <ComputePathToPose goal="{updated_goal}" path="{path}" planner_id="GridBased"/>
+            </GoalUpdater>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Context" service_name="global_costmap/clear_entirely_global_costmap"/>
+          </RecoveryNode>
+        </RateController>
+        <RecoveryNode number_of_retries="1" name="FollowPath">
+          <FollowPath path="{path}" controller_id="FollowPath"/>
+          <ClearEntireCostmap name="ClearLocalCostmap-Context" service_name="local_costmap/clear_entirely_local_costmap"/>
+        </RecoveryNode>
+      </PipelineSequence>
+      <ReactiveFallback name="RecoveryFallback">
+        <GoalUpdated/>
+        <RoundRobin name="RecoveryActions">
+          <Sequence name="ConservativeReset">
+            <ClearEntireCostmap name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_entirely_local_costmap"/>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Subtree" service_name="global_costmap/clear_entirely_global_costmap"/>
+          </Sequence>
+          <Spin spin_dist="6.28"/>
+          <Sequence name="AggressiveReset">
+            <ClearEntireCostmap name="ClearLocalCostmap-Aggressive" service_name="local_costmap/clear_entirely_local_costmap"/>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Aggressive" service_name="global_costmap/clear_entirely_global_costmap"/>
+          </Sequence>
+          <Spin spin_dist="6.28"/>
+        </RoundRobin>
+      </ReactiveFallback>
+    </RecoveryNode>
+  </BehaviorTree>
+</root>

--- a/gaden_config/navigation_config/adsm_goal_update_bt.xml
+++ b/gaden_config/navigation_config/adsm_goal_update_bt.xml
@@ -1,0 +1,70 @@
+<!--
+  ADSM navigation tree — restores move_base's sendGoal() semantics on Nav2.
+
+  WHY THIS EXISTS
+  ADSM re-decides its goal every iteration (iter_rate_ = 1 Hz) and calls
+  navigate() unconditionally; the ROS1 original did the same. move_base
+  absorbed that: a new goal retargeted the drive already in progress and the
+  local planner never stopped emitting velocities. Nav2 treats each new
+  NavigateToPose goal as a fresh mission instead - it halts FollowPath
+  (zeroing cmd_vel), rebuilds the tree from the root, and DWB restarts with a
+  rotate-to-heading. Measured on House09: 318 "Begin navigating" + 308 goal
+  preemptions in a 328 s run, one every 1.00 s, robot advancing ~3 cm/s. It
+  then trips ADSM's own 0.15 m / 60 s stuck watchdog. The algorithm is
+  bit-exact with the paper's; only the goal *transport* differs.
+
+  WHAT CHANGED
+  This is nav2_bt_navigator's stock navigate_to_pose_w_replanning_and_recovery.xml
+  with exactly one edit: ComputePathToPose's goal is wrapped in GoalUpdater, so
+  the goal arrives on the `goal_update` topic and is swapped inside the running
+  tree rather than preempting it. Every stock recovery is kept as-is.
+
+  Pair with the adsm node's `use_goal_update:=true`, which sends ONE action goal
+  and thereafter publishes PoseStamped to `goal_update`.
+
+  Reaching a goal still ends the tree normally (FollowPath -> SUCCESS), and the
+  node then sends a fresh action goal - that is ~1 restart per goal actually
+  reached, not one per iteration.
+
+  GOTCHA: GoalUpdater only accepts a topic goal whose header.stamp POST-DATES
+  the current goal's. Publish with a zero/stale stamp and it silently keeps
+  driving to the original goal forever.
+
+  Do NOT model this on follow_point.xml: its KeepRunningUntilFailure around
+  FollowPath kills the whole tree the moment the controller fails, and its
+  TruncatePath clips to a 1 m lookahead. Both are right for chasing a person,
+  wrong for ADSM (measured: tree died 2-3x per run, robot travelled 7-12 m vs
+  15-33 m at baseline).
+-->
+<root main_tree_to_execute="MainTree">
+  <BehaviorTree ID="MainTree">
+    <RecoveryNode number_of_retries="6" name="NavigateRecovery">
+      <PipelineSequence name="NavigateWithReplanning">
+        <RateController hz="1.0">
+          <RecoveryNode number_of_retries="1" name="ComputePathToPose">
+            <GoalUpdater input_goal="{goal}" output_goal="{updated_goal}">
+              <ComputePathToPose goal="{updated_goal}" path="{path}" planner_id="GridBased"/>
+            </GoalUpdater>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Context" service_name="global_costmap/clear_entirely_global_costmap"/>
+          </RecoveryNode>
+        </RateController>
+        <RecoveryNode number_of_retries="1" name="FollowPath">
+          <FollowPath path="{path}" controller_id="FollowPath"/>
+          <ClearEntireCostmap name="ClearLocalCostmap-Context" service_name="local_costmap/clear_entirely_local_costmap"/>
+        </RecoveryNode>
+      </PipelineSequence>
+      <ReactiveFallback name="RecoveryFallback">
+        <GoalUpdated/>
+        <RoundRobin name="RecoveryActions">
+          <Sequence name="ClearingActions">
+            <ClearEntireCostmap name="ClearLocalCostmap-Subtree" service_name="local_costmap/clear_entirely_local_costmap"/>
+            <ClearEntireCostmap name="ClearGlobalCostmap-Subtree" service_name="global_costmap/clear_entirely_global_costmap"/>
+          </Sequence>
+          <Spin spin_dist="1.57"/>
+          <Wait wait_duration="5"/>
+          <BackUp backup_dist="0.30" backup_speed="0.05"/>
+        </RoundRobin>
+      </ReactiveFallback>
+    </RecoveryNode>
+  </BehaviorTree>
+</root>

--- a/gaden_config/navigation_config/nav2_params.yaml
+++ b/gaden_config/navigation_config/nav2_params.yaml
@@ -1,6 +1,7 @@
 $(var namespace):
   amcl:
     ros__parameters:
+      use_sim_time: True
       alpha1: 0.2
       alpha2: 0.2
       alpha3: 0.2
@@ -46,8 +47,11 @@ $(var namespace):
       odom_topic: $(var namespace)/odom
       bt_loop_duration: 10
       default_server_timeout: 20
-      # Examples in /opt/ros/humble/share/nav2_bt_navigator/behavior_trees
-      #default_nav_to_pose_bt_xml: /home/robotics/tfg_ros_simulation_ws/src/missions_pkg/behavior_trees/follow_point.xml
+      # Stock navigate_to_pose_w_replanning_and_recovery.xml + GoalUpdater —
+      # see adsm_goal_update_bt.xml's own header for the "fresh goal -> BT
+      # rebuild + rotate-to-heading, ~3 cm/s" problem this fixes. Strict
+      # superset of the stock tree when nothing publishes to goal_update.
+      default_nav_to_pose_bt_xml: /home/efe/ros2_ws/src/base/gaden_config/navigation_config/adsm_goal_update_bt.xml
       #default_nav_through_poses_bt_xml: /home/robotics/tfg_ros_simulation_ws/src/missions_pkg/behavior_trees/follow_point.xml
       navigators: ["navigate_to_pose", "navigate_through_poses"]
       navigate_to_pose:
@@ -98,6 +102,7 @@ $(var namespace):
 
   controller_server:
     ros__parameters:
+      use_sim_time: True
       controller_frequency: 20.0
       min_x_velocity_threshold: 0.001
       min_y_velocity_threshold: 0.5
@@ -166,6 +171,7 @@ $(var namespace):
   local_costmap:
     local_costmap:
       ros__parameters:
+        use_sim_time: True
         update_frequency: 5.0
         publish_frequency: 2.0
         global_frame: $(var namespace)_odom
@@ -208,6 +214,7 @@ $(var namespace):
   global_costmap:
     global_costmap:
       ros__parameters:
+        use_sim_time: True
         update_frequency: 1.0
         publish_frequency: 1.0
         global_frame: map
@@ -242,6 +249,7 @@ $(var namespace):
 
   planner_server:
     ros__parameters:
+      use_sim_time: True
       expected_planner_frequency: 20.0
       planner_plugins: ["GridBased"]
       GridBased:
@@ -252,6 +260,7 @@ $(var namespace):
 
   smoother_server:
     ros__parameters:
+      use_sim_time: True
       smoother_plugins: ["simple_smoother"]
       simple_smoother:
         plugin: "nav2_smoother::SimpleSmoother"
@@ -261,6 +270,7 @@ $(var namespace):
 
   behavior_server:
     ros__parameters:
+      use_sim_time: True
       local_costmap_topic: $(var namespace)/local_costmap/costmap_raw
       global_costmap_topic: $(var namespace)/global_costmap/costmap_raw
       local_footprint_topic: $(var namespace)/local_costmap/published_footprint
@@ -288,6 +298,7 @@ $(var namespace):
 
   waypoint_follower:
     ros__parameters:
+      use_sim_time: True
       loop_rate: 20
       stop_on_failure: false
       waypoint_task_executor_plugin: "wait_at_waypoint"
@@ -298,6 +309,7 @@ $(var namespace):
 
   velocity_smoother:
     ros__parameters:
+      use_sim_time: True
       smoothing_frequency: 20.0
       scale_velocities: False
       feedback: "OPEN_LOOP"

--- a/gaden_config/navigation_config/nav2_params_adsm_faithful.yaml
+++ b/gaden_config/navigation_config/nav2_params_adsm_faithful.yaml
@@ -1,0 +1,334 @@
+# Move_base-faithful variant for the ADSM House09 arm ONLY.
+# Transplants the authors' TurtleBot3-burger DWA + costmap config
+# (src/An-adaptive-robot-search-algorithm/params/move_base/) onto Nav2/DWB.
+# The controller/speed/tolerance settings retain the paper's Burger setup,
+# while the costmap radius intentionally matches benchmark_env's physical
+# 0.25 m collision body. Pair with adsm_faithful_bt.xml (GoalUpdater + 5 Hz
+# replan + move_base recovery ladder) and use_goal_update:=true on the node.
+$(var namespace):
+  amcl:
+    ros__parameters:
+      use_sim_time: True
+      alpha1: 0.2
+      alpha2: 0.2
+      alpha3: 0.2
+      alpha4: 0.2
+      alpha5: 0.2
+      base_frame_id: "$(var namespace)_base_footprint"
+      beam_skip_distance: 0.5
+      beam_skip_error_threshold: 0.9
+      beam_skip_threshold: 0.3
+      do_beamskip: false
+      global_frame_id: "map"
+      lambda_short: 0.1
+      laser_likelihood_max_dist: 2.0
+      laser_max_range: 100.0
+      laser_min_range: -1.0
+      laser_model_type: "likelihood_field"
+      max_beams: 60
+      max_particles: 2000
+      min_particles: 500
+      odom_frame_id: "$(var namespace)_odom"
+      pf_err: 0.05
+      pf_z: 0.99
+      recovery_alpha_fast: 0.0
+      recovery_alpha_slow: 0.0
+      resample_interval: 1
+      robot_model_type: "nav2_amcl::DifferentialMotionModel"
+      save_pose_rate: 0.5
+      sigma_hit: 0.2
+      tf_broadcast: true
+      transform_tolerance: 1.0
+      update_min_a: 0.2
+      update_min_d: 0.25
+      z_hit: 0.5
+      z_max: 0.05
+      z_rand: 0.5
+      z_short: 0.05
+      scan_topic: scan
+  bt_navigator:
+    ros__parameters:
+      use_sim_time: True
+      global_frame: map
+      robot_base_frame: $(var namespace)_base_link
+      odom_topic: $(var namespace)/odom
+      bt_loop_duration: 10
+      default_server_timeout: 20
+      # Examples in /opt/ros/humble/share/nav2_bt_navigator/behavior_trees
+      #default_nav_to_pose_bt_xml: /home/robotics/tfg_ros_simulation_ws/src/missions_pkg/behavior_trees/follow_point.xml
+      #default_nav_through_poses_bt_xml: /home/robotics/tfg_ros_simulation_ws/src/missions_pkg/behavior_trees/follow_point.xml
+      navigators: ["navigate_to_pose", "navigate_through_poses"]
+      navigate_to_pose:
+        plugin: "nav2_bt_navigator/NavigateToPoseNavigator"
+      navigate_through_poses:
+        plugin: "nav2_bt_navigator/NavigateThroughPosesNavigator"
+      goal_blackboard_id: goal
+      goals_blackboard_id: goals
+      path_blackboard_id: path
+
+      # list of available plugins to use in the navigator
+      plugin_lib_names:
+      - nav2_compute_path_to_pose_action_bt_node
+      - nav2_compute_path_through_poses_action_bt_node
+      - nav2_follow_path_action_bt_node
+      - nav2_back_up_action_bt_node
+      - nav2_spin_action_bt_node
+      - nav2_wait_action_bt_node
+      - nav2_clear_costmap_service_bt_node
+      - nav2_is_stuck_condition_bt_node
+      - nav2_goal_reached_condition_bt_node
+      - nav2_goal_updated_condition_bt_node
+      - nav2_initial_pose_received_condition_bt_node
+      - nav2_reinitialize_global_localization_service_bt_node
+      - nav2_rate_controller_bt_node
+      - nav2_distance_controller_bt_node
+      - nav2_speed_controller_bt_node
+      - nav2_truncate_path_action_bt_node
+      - nav2_goal_updater_node_bt_node
+      - nav2_recovery_node_bt_node
+      - nav2_pipeline_sequence_bt_node
+      - nav2_round_robin_node_bt_node
+      - nav2_transform_available_condition_bt_node
+      - nav2_time_expired_condition_bt_node
+      - nav2_distance_traveled_condition_bt_node
+      - nav2_single_trigger_bt_node
+      - nav2_is_battery_low_condition_bt_node
+      - nav2_navigate_through_poses_action_bt_node
+      - nav2_navigate_to_pose_action_bt_node
+      - nav2_remove_passed_goals_action_bt_node
+      - nav2_planner_selector_bt_node
+      - nav2_controller_selector_bt_node
+      - nav2_goal_checker_selector_bt_node
+
+  bt_navigator_rclcpp_node:
+    ros__parameters:
+      use_sim_time: True
+
+  controller_server:
+    ros__parameters:
+      use_sim_time: True
+      controller_frequency: 10.0  # = move_base default (10 Hz)
+      min_x_velocity_threshold: 0.001
+      min_y_velocity_threshold: 0.5
+      min_theta_velocity_threshold: 0.001
+      failure_tolerance: 0.3
+      progress_checker_plugin: "progress_checker"
+      goal_checker_plugins: ["general_goal_checker"] # "precise_goal_checker"
+      controller_plugins: ["FollowPath"]
+
+      # Progress checker parameters -- move_base's oscillation_distance/
+      # oscillation_timeout drove a recovery (never a dead abort) on lack of
+      # progress. controller_patience: 15.0 is the closest Nav2 analogue.
+      progress_checker:
+        plugin: "nav2_controller::SimpleProgressChecker"
+        required_movement_radius: 0.2
+        movement_time_allowance: 15.0
+      # Goal checker parameters
+      #precise_goal_checker:
+      #  plugin: "nav2_controller::SimpleGoalChecker"
+      #  xy_goal_tolerance: 0.25
+      #  yaw_goal_tolerance: 0.25
+      #  stateful: True
+      general_goal_checker:
+        stateful: False  # = move_base's latch_xy_goal_tolerance: false
+        plugin: "nav2_controller::SimpleGoalChecker"
+        xy_goal_tolerance: 0.05   # = authors' dwa_local_planner_params_burger.yaml
+        yaw_goal_tolerance: 0.17
+      # DWB parameters -- transplanted from
+      # An-adaptive-robot-search-algorithm/params/move_base/dwa_local_planner_params_burger.yaml
+      FollowPath:
+        plugin: "dwb_core::DWBLocalPlanner"
+        debug_trajectory_details: True
+        min_vel_x: -0.22  # DWA allowed reverse; DWB default (0.0) can't back out of a wedge
+        min_vel_y: 0.0
+        max_vel_x: 0.22
+        max_vel_y: 0.0
+        max_vel_theta: 2.75
+        min_speed_xy: 0.11
+        max_speed_xy: 0.22
+        min_speed_theta: 1.37
+        # Add high threshold velocity for turtlebot 3 issue.
+        # https://github.com/ROBOTIS-GIT/turtlebot3_simulations/issues/75
+        acc_lim_x: 2.5
+        acc_lim_y: 0.0
+        acc_lim_theta: 3.2
+        decel_lim_x: -2.5
+        decel_lim_y: 0.0
+        decel_lim_theta: -3.2
+        vx_samples: 20
+        vy_samples: 0
+        vtheta_samples: 40
+        sim_time: 1.5
+        linear_granularity: 0.05
+        angular_granularity: 0.025
+        transform_tolerance: 0.2
+        xy_goal_tolerance: 0.05
+        trans_stopped_velocity: 0.25
+        short_circuit_trajectory_evaluation: True
+        stateful: True
+        critics: ["Oscillation", "BaseObstacle", "GoalAlign", "PathAlign", "PathDist", "GoalDist"]
+        BaseObstacle.scale: 0.02   # = occdist_scale
+        PathAlign.scale: 32.0      # = path_distance_bias
+        PathAlign.forward_point_distance: 0.325
+        GoalAlign.scale: 20.0      # = goal_distance_bias
+        GoalAlign.forward_point_distance: 0.325
+        PathDist.scale: 32.0
+        GoalDist.scale: 20.0
+
+  local_costmap:
+    local_costmap:
+      ros__parameters:
+        use_sim_time: True
+        update_frequency: 10.0  # = move_base local_costmap_params.yaml
+        publish_frequency: 2.0
+        global_frame: $(var namespace)_odom
+        robot_base_frame: $(var namespace)_base_link
+        rolling_window: true
+        width: 3
+        height: 3
+        resolution: 0.05
+        # Navigation geometry must match the BasicSim collision body. Keeping
+        # the original Burger footprint makes Nav2 plan paths the simulated
+        # robot (0.25 m radius) cannot physically traverse.
+        robot_radius: 0.25
+        plugins: ["voxel_layer", "inflation_layer"]
+        inflation_layer:
+          plugin: "nav2_costmap_2d::InflationLayer"
+          cost_scaling_factor: 3.0
+          inflation_radius: 1.0
+        voxel_layer:
+          plugin: "nav2_costmap_2d::VoxelLayer"
+          enabled: True
+          publish_voxel_map: True
+          origin_z: 0.0
+          z_resolution: 0.05
+          z_voxels: 16
+          max_obstacle_height: 2.0
+          mark_threshold: 0
+          observation_sources: scan
+          scan:
+            topic: $(var namespace)/laser_scan
+            max_obstacle_height: 2.0
+            clearing: True
+            marking: True
+            data_type: "LaserScan"
+            raytrace_max_range: 3.0
+            raytrace_min_range: 0.0
+            obstacle_max_range: 2.5
+            obstacle_min_range: 0.0
+        static_layer:
+          plugin: "nav2_costmap_2d::StaticLayer"
+          map_subscribe_transient_local: True
+        always_send_full_costmap: True
+
+  global_costmap:
+    global_costmap:
+      ros__parameters:
+        use_sim_time: True
+        update_frequency: 1.0
+        publish_frequency: 1.0
+        global_frame: map
+        robot_base_frame: $(var namespace)_base_link
+        # Must match the collision radius used by BasicSim.
+        robot_radius: 0.25
+        resolution: 0.05
+        track_unknown_space: true
+        plugins: ["static_layer", "obstacle_layer", "inflation_layer"]
+        obstacle_layer:
+          plugin: "nav2_costmap_2d::ObstacleLayer"
+          enabled: True
+          observation_sources: scan
+          scan:
+            topic: $(var namespace)/laser_scan
+            max_obstacle_height: 2.0
+            clearing: True
+            marking: True
+            data_type: "LaserScan"
+            raytrace_max_range: 3.0
+            raytrace_min_range: 0.0
+            obstacle_max_range: 2.5
+            obstacle_min_range: 0.0
+        static_layer:
+          plugin: "nav2_costmap_2d::StaticLayer"
+          map_subscribe_transient_local: True
+        inflation_layer:
+          plugin: "nav2_costmap_2d::InflationLayer"
+          cost_scaling_factor: 3.0
+          inflation_radius: 1.0
+        always_send_full_costmap: True
+
+
+  planner_server:
+    ros__parameters:
+      use_sim_time: True
+      expected_planner_frequency: 5.0  # = move_base's planner_frequency
+      planner_plugins: ["GridBased"]
+      GridBased:
+        plugin: "nav2_navfn_planner/NavfnPlanner"
+        tolerance: 0.2
+        use_astar: false
+        allow_unknown: true
+
+  smoother_server:
+    ros__parameters:
+      use_sim_time: True
+      smoother_plugins: ["simple_smoother"]
+      simple_smoother:
+        plugin: "nav2_smoother::SimpleSmoother"
+        tolerance: 1.0e-10
+        max_its: 1000
+        do_refinement: True
+
+  behavior_server:
+    ros__parameters:
+      use_sim_time: True
+      local_costmap_topic: $(var namespace)/local_costmap/costmap_raw
+      global_costmap_topic: $(var namespace)/global_costmap/costmap_raw
+      local_footprint_topic: $(var namespace)/local_costmap/published_footprint
+      global_footprint_topic: $(var namespace)/global_costmap/published_footprint
+      cycle_frequency: 10.0
+      behavior_plugins: ["spin", "backup", "drive_on_heading", "assisted_teleop", "wait"]
+      spin:
+        plugin: "nav2_behaviors/Spin"
+      backup:
+        plugin: "nav2_behaviors/BackUp"
+      drive_on_heading:
+        plugin: "nav2_behaviors/DriveOnHeading"
+      wait:
+        plugin: "nav2_behaviors/Wait"
+      assisted_teleop:
+        plugin: "nav2_behaviors/AssistedTeleop"
+      local_frame: $(var namespace)_odom
+      global_frame: map
+      robot_base_frame: $(var namespace)_base_link
+      transform_tolerance: 0.1
+      simulate_ahead_time: 2.0
+      max_rotational_vel: 2.75
+      min_rotational_vel: 1.37
+      rotational_acc_lim: 3.2
+
+  waypoint_follower:
+    ros__parameters:
+      use_sim_time: True
+      loop_rate: 20
+      stop_on_failure: false
+      waypoint_task_executor_plugin: "wait_at_waypoint"
+      wait_at_waypoint:
+        plugin: "nav2_waypoint_follower::WaitAtWaypoint"
+        enabled: True
+        waypoint_pause_duration: 200
+
+  velocity_smoother:
+    ros__parameters:
+      use_sim_time: True
+      smoothing_frequency: 20.0
+      scale_velocities: False
+      feedback: "OPEN_LOOP"
+      max_velocity: [0.22, 0.0, 2.75]
+      min_velocity: [-0.22, 0.0, -2.75]
+      max_accel: [2.5, 0.0, 3.2]
+      max_decel: [-2.5, 0.0, -3.2]
+      odom_topic: "odom"
+      odom_duration: 0.1
+      deadband_velocity: [0.0, 0.0, 0.0]
+      velocity_timeout: 1.0

--- a/gaden_transfer/gaden_transfer/gaden_transfer_lidar/escape_planner.py
+++ b/gaden_transfer/gaden_transfer/gaden_transfer_lidar/escape_planner.py
@@ -78,9 +78,22 @@ class CirclingEscape:
     def __init__(self, reference_map, robot_radius=0.25, logger=None,
                  win=25, ratio=0.2, streak=35, cooldown=40, min_dist=3.0,
                  grow_win=120, grow_min=250, frontier_min_cells=12,
-                 target_mode='largest'):
-        self.slam_map = create_empty_occupancy_map(reference_map)
-        self.mapper = LidarMapper(self.slam_map)
+                 target_mode='largest',
+                 use_live_grid=False, live_map_provider=None):
+        self._use_live_grid = bool(use_live_grid)
+        self._live_map_provider = live_map_provider
+
+        if self._use_live_grid:
+            if live_map_provider is None:
+                raise ValueError("use_live_grid=True requires live_map_provider")
+            live = live_map_provider()
+            self.slam_map = (live if live is not None
+                             else create_empty_occupancy_map(reference_map))
+            self.mapper = None
+        else:
+            self.slam_map = create_empty_occupancy_map(reference_map)
+            self.mapper = LidarMapper(self.slam_map)
+
         self.gp = GlobalPlanner(self.slam_map, robot_radius=robot_radius,
                                 frontier_min_size=3, debug=False)
         self.log = logger
@@ -136,10 +149,24 @@ class CirclingEscape:
         self._escape_fails = 0      # total wedged-hop attempts this escape
 
     # ------------------------------------------------------------------ SLAM
+    def _refresh_live_map(self):
+        """In live-grid mode, pull the latest map from the harness and rebind it
+        on self.gp so frontier detection / A* / coverage stats all see the
+        current slam_toolbox grid.  No-op in private-map mode."""
+        if not self._use_live_grid or self._live_map_provider is None:
+            return
+        latest = self._live_map_provider()
+        if latest is None:
+            return
+        self.slam_map = latest
+        self.gp.occupancy_grid = latest
+
     def update_scan(self, scan_msg, x, y, theta):
         """Fold one LaserScan into the online occupancy map (sensed data only)."""
         if x is None or y is None or theta is None:
             return
+        if self._use_live_grid:
+            return   # live slam_toolbox map is maintained externally; nothing to do
         try:
             self.mapper.update_from_scan(scan_msg, float(x), float(y), float(theta))
         except Exception as exc:  # never let SLAM crash the control loop
@@ -156,6 +183,7 @@ class CirclingEscape:
         Returns True if the robot is stuck (efficiency-streak OR coverage-
         stagnation has crossed its threshold). Sets ``self.stuck_reason``.
         """
+        self._refresh_live_map()
         x = float(x)
         y = float(y)
         if og:
@@ -224,6 +252,7 @@ class CirclingEscape:
         direction and return the farthest reachable FREE cell toward the source.
         None if too few gas observations. (`_eq3_logP` kept for reference.)
         """
+        self._refresh_live_map()
         if not self.use_source_est or len(self._gas_obs) < self.src_min_obs:
             return None
         obs = list(self._gas_obs)
@@ -265,6 +294,7 @@ class CirclingEscape:
 
         Returns (target_x, target_y, frontier_size, dist_m, n_waypoints) or None.
         """
+        self._refresh_live_map()
         if self.force_every > 0:
             # debug stress mode: force an escape every N steps regardless of stuck
             if (step - self._last_escape_step) < self.force_every:
@@ -394,6 +424,7 @@ class CirclingEscape:
         reproduces the old raw behaviour as a last resort). Diagonal moves may
         not cut through a wall corner. Returns ~0.5 m world waypoints or None.
         """
+        self._refresh_live_map()
         og = self.slam_map
         grid = og.grid
         H, W = grid.shape
@@ -476,6 +507,7 @@ class CirclingEscape:
 
     def _dump(self, x, y, target):
         """Debug snapshot of the SLAM grid + chosen target + planned path."""
+        self._refresh_live_map()
         if not self.dump_dir:
             return
         try:
@@ -497,6 +529,7 @@ class CirclingEscape:
     # --------------------------------------------------------------- helpers
     def dump_map(self, step, x, y):
         """Debug: snapshot the current SLAM grid + frontiers + robot pose."""
+        self._refresh_live_map()
         if not self.dump_dir:
             return
         try:
@@ -515,6 +548,7 @@ class CirclingEscape:
 
     def mapped_fraction(self):
         """Fraction of grid cells that are no longer unknown (for logging)."""
+        self._refresh_live_map()
         try:
             g = self.slam_map.grid
             return float((g != -1).sum()) / float(g.size)

--- a/gaden_transfer/gaden_transfer/gaden_transfer_lidar/gaden_rl_node.py
+++ b/gaden_transfer/gaden_transfer/gaden_transfer_lidar/gaden_rl_node.py
@@ -46,6 +46,7 @@ from rclpy.node import Node
 from rclpy.qos import QoSProfile, QoSDurabilityPolicy, QoSReliabilityPolicy
 from rclpy.callback_groups import ReentrantCallbackGroup
 from rclpy.executors import MultiThreadedExecutor
+from rclpy.clock import Clock, ClockType
 
 from olfaction_msgs.msg import GasSensor, Anemometer
 from gaden_msgs.srv import WindPosition
@@ -218,7 +219,17 @@ class GadenRLNode(Node):
         # Occupancy service (used to auto-derive map dimensions)
         self.declare_parameter('occupancy_service', '/gaden_environment/occupancyMap3D')
         self.declare_parameter('occupancy_z_level', 5)
-        self.declare_parameter('occupancy_timeout', 60.0)
+        self.declare_parameter('occupancy_timeout', 300.0)
+        # Wall-clock seconds without a /ground_truth pose before the simulator is
+        # declared dead and the run is aborted. Guards against the env going brain-dead
+        # mid-run (gaden_player stops serving concentrations, BasicSim stops publishing),
+        # which otherwise hangs the node until the batch wall timeout. 0 disables.
+        self.declare_parameter('pose_stale_timeout', 120.0)
+        # Nav2 action-server pre-flight wait. Bringing up the full Nav2 lifecycle
+        # (map_server, amcl, planner, controller, bt_navigator) can exceed 60 s on a
+        # cold or shared host; a run that aborts here is a total loss, whereas waiting
+        # longer costs only the wait. Kept as a parameter so batch drivers can raise it.
+        self.declare_parameter('nav2_server_timeout', 300.0)
         # Path to GADEN wind CSV (e.g. .../wind_simulations/1ms/wind_at_cell_centers_0.csv)
         self.declare_parameter('wind_file', '')
         # Delay between teleport steps (seconds)
@@ -287,8 +298,16 @@ class GadenRLNode(Node):
 
         self._is_moving: bool = False
         # Per-step drive-timeout bookkeeping (drive mode only)
-        self._drive_goal_time = None        # rclpy Time when current goal was sent
+        self._drive_goal_time = None        # rclpy Time (SIM clock) when goal was sent
         self._drive_canceling: bool = False  # cancel issued, awaiting completion
+        # Wall-clock mirrors of the above. The sim-time drive timeout is evaluated in
+        # _pose_callback and measured on get_clock() — both of which are driven by the
+        # simulator. If BasicSim stalls or dies, poses stop AND /clock freezes, so that
+        # timeout can never fire and the run hangs until the batch wall timeout (seen:
+        # a single step blocking 6.3 h). These monotonic timestamps feed _wall_watchdog,
+        # which runs on a STEADY_TIME timer and is therefore immune to a dead simulator.
+        self._drive_goal_wall: Optional[float] = None   # time.monotonic() at goal send
+        self._last_pose_wall: Optional[float] = None    # time.monotonic() of last pose
         self._search_complete: bool = False
         self._start_teleport_done: bool = False
         self._slam_enabled: bool = False   # gate SLAM updates to post-teleport (set in _take_step)
@@ -524,11 +543,16 @@ class GadenRLNode(Node):
             # Pre-flight guard: Navigator.__init__ waits on the Nav2 action server
             # with NO timeout, so confirm it is up here (60 s) and fail fast
             # instead of hanging forever if the Nav2 stack didn't come up.
+            _nav_wait = float(self.get_parameter('nav2_server_timeout').value)
             _pre = ActionClient(self, NavigateToPose, '/PioneerP3DX/navigate_to_pose')
-            if not _pre.wait_for_server(timeout_sec=60.0):
+            self.get_logger().info(
+                f'Waiting up to {_nav_wait:.0f}s for Nav2 action server '
+                f'/PioneerP3DX/navigate_to_pose ...')
+            if not _pre.wait_for_server(timeout_sec=_nav_wait):
                 self.get_logger().error(
                     'use_nav2=True but Nav2 action server '
-                    '/PioneerP3DX/navigate_to_pose not available after 60 s — aborting.')
+                    f'/PioneerP3DX/navigate_to_pose not available after {_nav_wait:.0f} s '
+                    '— aborting.')
                 os._exit(2)
             _pre.destroy()
             self._navigator = Navigator(self, on_complete_callback=self._on_nav_complete)
@@ -537,6 +561,16 @@ class GadenRLNode(Node):
                 f'tolerance={self._nav_goal_tolerance:.2f} m)')
         else:
             self.get_logger().info('Motion mode: TELEPORT (instant)')
+
+        # Liveness watchdog. MUST run on a STEADY_TIME clock: a default timer follows the
+        # node clock, which is sim time under use_sim_time, so it would freeze in exactly
+        # the scenario it exists to catch (dead BasicSim => no /clock).
+        self._pose_stale_timeout = float(self.get_parameter('pose_stale_timeout').value)
+        self._watchdog_timer = self.create_timer(
+            2.0, self._wall_watchdog, clock=Clock(clock_type=ClockType.STEADY_TIME))
+        self.get_logger().info(
+            f'Wall-clock watchdog armed: env-dead abort after {self._pose_stale_timeout:.0f}s '
+            'without a pose; drive-timeout wall backstop active.')
 
         if self._det_drive:
             self._cmd_vel_pub = self.create_publisher(Twist, '/PioneerP3DX/cmd_vel', 10)
@@ -553,6 +587,7 @@ class GadenRLNode(Node):
     # ------------------------------------------------------------------
 
     def _pose_callback(self, msg: PoseWithCovarianceStamped):
+        self._last_pose_wall = time.monotonic()  # liveness beat for _wall_watchdog
         x = msg.pose.pose.position.x
         y = msg.pose.pose.position.y
 
@@ -591,10 +626,12 @@ class GadenRLNode(Node):
             eff_timeout = self._drive_timeout
             if self._escape is not None and self._escape.escaping:
                 eff_timeout = min(self._drive_timeout, 10.0)
-            if (eff_timeout > 0.0 and self._drive_goal_time is not None
+            # Snapshot: _on_nav_complete clears _drive_goal_time from another executor
+            # thread, so re-reading it after the guard can yield None mid-subtraction.
+            goal_time = self._drive_goal_time
+            if (eff_timeout > 0.0 and goal_time is not None
                     and not self._drive_canceling):
-                elapsed = (self.get_clock().now()
-                           - self._drive_goal_time).nanoseconds * 1e-9
+                elapsed = (self.get_clock().now() - goal_time).nanoseconds * 1e-9
                 if elapsed > eff_timeout:
                     self._drive_canceling = True
                     self.get_logger().warn(
@@ -682,13 +719,11 @@ class GadenRLNode(Node):
         # policies). For local point-wind policies (OSL_LOCAL_WIND_OBS=1) the
         # obs builder uses these LIVE anemometer readings at the robot cell.
         #
-        # BUG WORKAROUND: simulated_anemometer publishes wind_speed = u*u + v*v
-        # (squared magnitude — it never takes the sqrt; fake_anemometer.cpp:138).
-        # Training/Python eval feed the TRUE magnitude sqrt(u^2+v^2), so without
-        # correcting here the local-wind policy sees systematically crushed wind
-        # (e.g. 0.7 m/s -> 0.49, 0.1 -> 0.01), which nullifies the local-wind
-        # signal — observed as many_rooms collapsing 0% on ROS2 vs 90% in Python.
-        speed = float(np.sqrt(max(0.0, msg.wind_speed)))
+        # fake_anemometer.cpp now publishes the true magnitude hypot(u,v)
+        # directly (fixed 2026-07-16 — it used to publish u*u+v*v, the squared
+        # magnitude, requiring a sqrt() here to recover the true value). Do
+        # NOT re-add a sqrt: msg.wind_speed is already linear.
+        speed = float(max(0.0, msg.wind_speed))
         self._latest_wind_speed = speed
         self._latest_wind_dir = float(msg.wind_direction)
         if self._obs_builder is not None:
@@ -746,6 +781,7 @@ class GadenRLNode(Node):
         self._waypoint_y = float(y)
         self._waypoint_start_ns = self.get_clock().now().nanoseconds
         self._is_moving = True
+        self._drive_goal_wall = None  # cmd_vel path: Nav2 wall backstop stays inert
         self._cmdvel_active = True
         self._drive_goal_time = None
 
@@ -785,6 +821,7 @@ class GadenRLNode(Node):
             self._is_moving = True
             self._drive_canceling = False
             self._drive_goal_time = self.get_clock().now()
+            self._drive_goal_wall = time.monotonic()
             self._navigator.send_goal(
                 wx, wy, use_orientation=False, tolerance=self._nav_goal_tolerance)
         else:
@@ -795,7 +832,62 @@ class GadenRLNode(Node):
         flag so the next ground_truth pose callback takes the next step (stop-go)."""
         self._is_moving = False
         self._drive_goal_time = None
+        self._drive_goal_wall = None
         self._drive_canceling = False
+
+    def _wall_watchdog(self):
+        """Liveness watchdog on a STEADY_TIME (wall) clock.
+
+        Everything else in this node is driven by the simulator: the step loop runs off
+        /ground_truth callbacks and every timeout is measured on get_clock() (sim time,
+        published by BasicSim). So when the sim stalls or dies, the machinery meant to
+        rescue the run dies with it — poses stop arriving, /clock freezes, and the
+        per-step drive timeout in _pose_callback never gets a chance to run. Observed in
+        job 25445: one step blocked 6.3 h, and 20/145 runs burned the full 9 h batch
+        timeout doing nothing.
+
+        This timer is the only thing here that keeps ticking when the sim is gone.
+        """
+        now_w = time.monotonic()
+
+        # (1) Simulator liveness. No poses for pose_stale_timeout wall-seconds means the
+        # env is brain-dead (gaden_player stops serving concentrations, BasicSim stops
+        # publishing). Fail the run in ~2 min instead of hanging for hours.
+        if (self._pose_stale_timeout > 0.0 and self._last_pose_wall is not None
+                and not self._search_complete):
+            stale = now_w - self._last_pose_wall
+            if stale > self._pose_stale_timeout:
+                self.get_logger().error(
+                    f'ENV DEAD — no /ground_truth pose for {stale:.0f}s wall '
+                    f'(> {self._pose_stale_timeout:.0f}s). Simulator stopped publishing; '
+                    'aborting instead of hanging until the batch wall timeout.')
+                os._exit(3)
+
+        # (2) Wall-clock backstop for the per-step drive timeout. The sim-time check in
+        # _pose_callback normally fires first; this only catches the case where it
+        # cannot run at all. Deliberately slack (3x, min +30 s) so it never pre-empts
+        # the sim-time path during healthy operation.
+        if not (self._use_nav2 and self._is_moving) or self._drive_canceling:
+            return
+        goal_wall = self._drive_goal_wall
+        if goal_wall is None:
+            return
+        eff_timeout = self._drive_timeout
+        if self._escape is not None and self._escape.escaping:
+            eff_timeout = min(self._drive_timeout, 10.0)
+        if eff_timeout <= 0.0:
+            return
+        limit = max(eff_timeout * 3.0, eff_timeout + 30.0)
+        elapsed_w = now_w - goal_wall
+        if elapsed_w > limit:
+            self._drive_canceling = True
+            self.get_logger().warn(
+                f'[Ep {self._episode} Step {self._step_in_episode:3d}] '
+                f'WALL-CLOCK DRIVE TIMEOUT — {elapsed_w:.1f}s wall (> {limit:.1f}s) with '
+                'no goal completion and the sim-time watchdog never firing (poses or '
+                '/clock stalled); canceling, re-predicting.')
+            if self._navigator is not None:
+                self._navigator.cancel_current_goal()
 
     # ------------------------------------------------------------------
     # Core control loop
@@ -1013,6 +1105,7 @@ class GadenRLNode(Node):
             self._is_moving = True
             self._drive_canceling = False
             self._drive_goal_time = self.get_clock().now()  # for per-step timeout
+            self._drive_goal_wall = time.monotonic()        # wall-clock backstop
             self._navigator.send_goal(
                 target_x, target_y, yaw=theta,
                 use_orientation=True, tolerance=self._nav_goal_tolerance,

--- a/gsl_bench/configs/agents/adsm.yaml
+++ b/gsl_bench/configs/agents/adsm.yaml
@@ -1,0 +1,18 @@
+# ADSM paper defaults. Runtime requirements are enforced by the agent metadata:
+# realistic SLAM pose/map, Nav2, faithful controller profile, continuous 1 Hz motion.
+k1: 0.2
+random_sample_r: 3.0
+goal_cluster_num: 20
+obs_r: 0.2
+goal_reach_th: 0.5
+resample_time_th: 5.5
+gas_high_th: 0.3
+gas_low_th: 0.1
+sensor_window_length: 6.0
+frontier_search_th: 3.0
+rrt_max_iter: 200
+rrt_max_r: 3.0
+rrt_min_r: 0.7
+rrt_step_size: 0.3
+stuck_duration_th: 60.0
+# seed: 42  # uncomment for deterministic replay; omitted records a generated seed

--- a/gsl_bench/configs/agents/gpulaika.yaml
+++ b/gsl_bench/configs/agents/gpulaika.yaml
@@ -1,0 +1,6 @@
+checkpoint: /home/efe/ros2_ws/src/gpu_cfd_localwind_job25311/gpu_cfd_localwind_step05_job25311_upd4000_gaden80_ult85_many0.pt
+arch: dual
+device: cpu
+lidar_frame: heading
+local_wind_obs: 1
+# wind_file is injected per-scenario by episode_runner (scenario_paths.wind_csv)

--- a/gsl_bench/configs/agents/gpulaika_edge.yaml
+++ b/gsl_bench/configs/agents/gpulaika_edge.yaml
@@ -1,0 +1,6 @@
+checkpoint: /home/efe/ros2_ws/src/gpulaika_gasfix/gpu_edge_job26352_upd1400.pt
+arch: dual
+device: cpu
+lidar_frame: heading
+local_wind_obs: 1
+# wind_file is injected per-scenario by episode_runner (scenario_paths.wind_csv)

--- a/gsl_bench/configs/agents/gpulaika_gasfix_s1.yaml
+++ b/gsl_bench/configs/agents/gpulaika_gasfix_s1.yaml
@@ -1,0 +1,6 @@
+checkpoint: /home/efe/ros2_ws/src/gpu_gasfix_ab/gpu_gasfix_s1_job25963_upd5100_val83.9.pt
+arch: dual
+device: cpu
+lidar_frame: heading
+local_wind_obs: 1
+# wind_file is injected per-scenario by episode_runner (scenario_paths.wind_csv)

--- a/gsl_bench/configs/agents/gpulaika_gasfix_s2.yaml
+++ b/gsl_bench/configs/agents/gpulaika_gasfix_s2.yaml
@@ -1,0 +1,6 @@
+checkpoint: /home/efe/ros2_ws/src/gpu_gasfix_ab/gpu_gasfix_s2_job25964_upd3800_val91.7.pt
+arch: dual
+device: cpu
+lidar_frame: heading
+local_wind_obs: 1
+# wind_file is injected per-scenario by episode_runner (scenario_paths.wind_csv)

--- a/gsl_bench/configs/harness_default.yaml
+++ b/gsl_bench/configs/harness_default.yaml
@@ -1,0 +1,13 @@
+# Fairness knobs live here, not in the agent: every method in a suite runs under
+# identical conditions, and the full block is recorded in every result.json.
+max_steps: 600
+step_delay: 0.5
+success_radius: 0.5
+nav_goal_tolerance: 0.10
+drive_timeout: 30.0
+wall_timeout_s: 1800
+escape: false
+max_hop: 1.0
+robot_radius: 0.25
+lidar: {rays: 72, fov_deg: 360, max_range_m: 3.0}
+motion: nav2          # physical Nav2 drive; never teleport between steps

--- a/gsl_bench/docs/ADSM_PORT.md
+++ b/gsl_bench/docs/ADSM_PORT.md
@@ -1,0 +1,204 @@
+# ADSM ROS 2 and `gsl_bench` port
+
+This document describes how ADSM was brought from the authors' ROS 1 repository into
+ROS 2 and then into `gsl_bench`, what “faithful” means, and which adaptations belong to
+the benchmark rather than the search algorithm.
+
+## Provenance and implementations
+
+The upstream source in this workspace is:
+
+```text
+An-adaptive-robot-search-algorithm/
+```
+
+It implements Wang et al.'s *An Adaptive Robot Search Algorithm for Balancing
+Exploitation and Exploration in Indoor Intermittent Source Seeking*. The relevant
+reference implementation is `src/adsm.cpp` plus its grid map, frontier finder, RRT
+sampler, goal type, parameters, and ROS 1 `move_base` integration.
+
+There are two ROS 2 forms in the workspace:
+
+1. `base/adsm/src/adsm.cpp` is the monolithic ROS 2 node. It owns subscriptions,
+   the ADSM loop, visualization, recording, and Nav2 communication.
+2. `base/adsm/src/engine.cpp` is the ROS-independent decision core used by
+   `gsl_bench`. `python_bindings.cpp` exposes it as `adsm_core_py`, and
+   `gsl_bench/agents/adsm_agent.py` is the thin `GSLAgent` adapter.
+
+The extracted engine exists so ADSM receives the same observation object and uses the
+same harness as every other benchmark method. It is not a Python reimplementation of
+the algorithm; the decision logic remains C++.
+
+## Porting map
+
+| ROS 1 ADSM responsibility | ROS 2 monolithic port | `gsl_bench` port |
+|---|---|---|
+| Fixed-rate `loop()` | `Adsm::loop()` | runner schedules `AdsmAgent.act()` at 1 Hz |
+| Pose, gas, wind observations | ROS 2 subscriptions | harness `Observation` |
+| `observe()` and gas-hit state | `Adsm::observe()` | `Engine::classifyGas()` / `Engine::step()` |
+| RRT construction | `RRTSampler` | `Engine::sampleRRT()` |
+| EPI/EPR construction | `Adsm::estimate()` | `Engine::estimate()` |
+| Source probability | `Adsm::probability()` | `Engine::probability()` |
+| Fitness and argmax goal | `Adsm::evaluate()` | `Engine::evaluate()` |
+| `move_base::sendGoal()` | Nav2 action plus GoalUpdater | runner action plus GoalUpdater |
+| Terminal checks and metrics | node | benchmark harness |
+| RViz markers and CSV output | node | harness result and diagnostics |
+
+## Preserved ADSM behavior
+
+The canonical `adsm` agent preserves the following algorithm behavior and paper
+defaults:
+
+- a 1 Hz observe/evaluate/act loop;
+- PID threshold hysteresis and the sliding sensor window;
+- the wind-conditioned source probability equation;
+- RRT sampling, collision checks, angular clustering, and frontier counting;
+- EPI exploitation candidates and persistent EPR exploration candidates;
+- normalized probability and information-gain fitness with `k1 = 0.2`;
+- selection of the maximum-fitness candidate every iteration;
+- RRT resampling after reaching a goal or after 5.5 seconds;
+- stuck detection and the random-exploration branch;
+- a 3 m sampling/goal horizon and 0.5 m ADSM goal-reach threshold;
+- identity goal orientation, matching the upstream goal message.
+
+The defaults are recorded in `configs/agents/adsm.yaml`. An optional seed controls the
+port's random generator and is written to the result metadata for replay.
+
+### Continuous goal replacement is intentional
+
+Upstream ADSM executes this sequence every iteration:
+
+```text
+observe -> estimate -> evaluate -> navigate
+```
+
+It does **not** wait for the robot to reach the previous goal before evaluating and
+sending the current best goal. Candidate scores can therefore make the selected goal
+change once per second. This can look unstable in RViz, particularly when EPI and EPR
+scores are close, but it is part of the upstream control contract rather than a port
+error.
+
+In ROS 1, calling `move_base::sendGoal()` while driving retargeted the running motion.
+Naively sending a new Nav2 `NavigateToPose` action every second is not equivalent: it
+preempts the action, rebuilds the behavior tree, and repeatedly restarts the controller.
+The faithful ROS 2 translation is therefore:
+
+```text
+first ADSM decision       -> start one NavigateToPose action
+later ADSM decisions     -> publish PoseStamped to /<namespace>/goal_update
+Nav2 behavior tree       -> GoalUpdater consumes it and replans the running action
+```
+
+For canonical runs, `AdsmAgent` declares `motion_mode = "continuous"`. The evaluator
+selects the matching GoalUpdater behavior tree automatically. A healthy episode should
+normally show one action start, many goal updates, and no stream of action-preemption
+messages.
+
+This preserves ADSM semantics; it does not guarantee that frequent retargeting is ideal
+for every Nav2 controller. A future goal-hysteresis or minimum-commitment mode should be
+reported as a separate, non-faithful navigation variant rather than silently changing
+the canonical agent.
+
+## Benchmark and ROS 2 adaptations
+
+The following differences are deliberate and do not alter ADSM's candidate scoring or
+goal-selection rule:
+
+| Adaptation | Reason |
+|---|---|
+| MOX reading replaced by benchmark PID reading | The benchmark sensor contract provides PID gas concentration. The same high/low hysteresis is retained. |
+| Simulator ground-truth pose replaced by SLAM/TF pose | Agents may not consume privileged ground truth. Ground truth remains harness-only for success and metrics. |
+| ADSM map input replaced by the live SLAM occupancy grid | All benchmark agents operate from realistic observations. |
+| ROS 1 `move_base`/DWA replaced by Nav2/DWB | Required by ROS 2; the faithful profile transplants the relevant controller, tolerance, replanning, and recovery settings. |
+| TurtleBot geometry replaced by a 0.25 m radius | Nav2 collision geometry must match the physical BasicSim robot. Retaining the much smaller upstream Burger footprint produces physically impossible doorway paths. |
+| Random goals constrained to valid map space | Prevents a port/runtime artifact from sending Nav2 outside the usable benchmark map. |
+| Harness owns termination and metrics | Ensures identical source-distance success checks, budgets, and reporting across methods. |
+
+The geometry correction is an execution-model correction, not an algorithm change:
+ADSM still chooses the same kind of point, while Nav2 accurately represents whether the
+benchmark robot can fit along the path.
+
+## Canonical runtime contract
+
+The registered agent metadata requires:
+
+```text
+motion_mode:          continuous
+decision_rate_hz:     1.0
+pose source:          TF/SLAM
+map source:           SLAM
+motion backend:       Nav2
+navigation profile:   faithful
+harness escape:       disabled
+```
+
+The evaluator rejects incompatible options instead of silently running a different
+experiment. Existing agents retain the default stop-and-go contract: their next
+decision occurs after arrival, whereas ADSM's next decision occurs on its next 1 Hz
+tick while movement continues.
+
+## Build and run
+
+Build and source both packages:
+
+```bash
+cd /home/efe/ros2_ws
+source /opt/ros/humble/setup.bash
+colcon build --packages-select adsm gsl_bench --symlink-install
+source install/setup.bash
+```
+
+Canonical example:
+
+```bash
+ros2 run gsl_bench eval \
+  --agent adsm \
+  --agent-config src/gsl_bench/configs/agents/adsm.yaml \
+  --scenario 4_rooms_start_a \
+  --runs 5 \
+  --realistic \
+  --motion nav2
+```
+
+For the older monolithic batch runner, the equivalent faithful selection is explicit:
+
+```bash
+cd /home/efe/ros2_ws
+AE_ALGOS=adsm AE_ADSM_FAITHFUL=1 bash run_adsm_eesa_benchmark.sh
+```
+
+`AE_ADSM_FAITHFUL=1` must pair both halves: the GoalUpdater Nav2 tree and
+`use_goal_update:=true` on `adsm_node`.
+
+## Validation
+
+The port is checked at three levels:
+
+1. `base/adsm/test/adsm_equivalence_test.cpp` compares the extracted decision
+   calculations with the reference behavior over large randomized inputs, including
+   probability, scoring/argmax, and clustering.
+2. `gsl_bench/test/test_adsm_agent.py` checks agent capabilities, deterministic replay,
+   metadata, and engine integration.
+3. `gsl_bench/test/test_motion_modes.py` checks that continuous mode starts one action
+   and updates it through GoalUpdater, while stop-and-go agents retain their existing
+   behavior.
+
+Useful commands:
+
+```bash
+colcon test --packages-select adsm gsl_bench
+colcon test-result --verbose
+```
+
+Each `result.json` records the random seed, motion mode, decision rate, effective goal
+reach, Nav2 action-start count, GoalUpdater publication count, and final ADSM state.
+Compare methods using success, simulation time, and traveled distance. An ADSM decision
+tick and a stop-and-go agent's completed movement step are not equivalent units.
+
+## Fidelity statement
+
+The canonical `gsl_bench` ADSM agent is faithful to the upstream **search and continuous
+retargeting semantics**. It is not a bit-for-bit recreation of the upstream physical
+experiment: sensor type, robot body, localization, map source, and ROS navigation stack
+are benchmark-controlled adaptations. Those boundaries are intentional, documented,
+and kept outside the ADSM scoring and selection logic.

--- a/gsl_bench/docs/BENCHMARK_DRIVING_METHODS.md
+++ b/gsl_bench/docs/BENCHMARK_DRIVING_METHODS.md
@@ -1,0 +1,182 @@
+# Benchmark driving-method integration
+
+Design record from 2026-07-18 conversation.
+
+## Problem
+
+Three ROS packages in the workspace implement different *motion/driving abstractions* for
+gas-source localisation. A realistic benchmark that scores all of them in one harness
+requires either unifying the abstraction or accepting that crossing motion models makes
+step-count metrics incomparable.
+
+## The three packages and how they drive
+
+### `An-adaptive-robot-search-algorithm` / `src/base/adsm` — the ADSM paper
+
+- **Fixed-rate control loop** at `iter_rate_ = 1 Hz` (`adsm.cpp:103-124`).
+- Per iteration: `observe → estimate → evaluate → navigate` → then `rate.sleep()`.
+- `navigate()` calls `ac_->sendGoal(goal)` and **returns immediately** (no wait for arrival).
+- Waypoints sampled up to ~3 m away (`rrt_max_r=3.0`, `random_sample_r=3.0`).
+- Episode budget: `max_iter` iterations at `iter_rate` Hz (e.g. 360 s).
+- ROS2 port (`src/base/adsm/launch/adsm_launch.py`) adds `use_goal_update:=true` to
+  avoid BT rebuilds per tick (GoalUpdater inside the Nav2 behaviour tree).
+- **A "step" = one iteration of the decision loop**, regardless of motion completion.
+
+### `gsl_bench` `RunnerNode` — every other agent (gpulaika, random_walk, surge-cast...)
+
+- **Pose-callback tick**, rate-gated by `step_delay` (default 0.5 s) (`runner_node.py:135,532-536`).
+- Per step: `observe → act`, then **hop-cap to `max_hop=1.0` m** (`runner_node.py:775-777`),
+  then Nav2 drive, then **block in `_is_moving=True`** until Nav2 completes or
+  `drive_timeout=30 s` (`runner_node.py:512-516,543-563`).
+- `_step` is **incremented only on goal completion** (line 738).
+- Episode budget: `max_steps=600` hops.
+- **A "step" = one successfully executed Nav2 hop**.
+
+### `benchmark_env_realistic` — the realistic-perception layer
+
+- Launches `slam_toolbox` (online SLAM), Nav2 (DWB controller), gas/wind sensors.
+- Two Nav2 config variants already exist in `navigation_config/`:
+  - `nav2_realistic_params.yaml` (default) — DWB tuned for SLAM drift-free mapping:
+    `max_vel_x=0.26`, `max_vel_theta=1.0`, `min_speed_xy=0.0`, `xy_goal_tol=0.25`,
+    `inflation_radius=0.55`.
+  - `nav2_realistic_params_adsm_faithful.yaml` — transplant of ADSM's TurtleBot3 DWA
+    values: `max_vel_x=0.22`, `max_vel_theta=2.75`, `min_speed_xy=0.11`,
+    `xy_goal_tol=0.05`, `inflation_radius=1.0`. Pairs with `adsm_faithful_bt.xml`
+    (GoalUpdater tree).
+
+## The three axes of mismatch
+
+| axis | ADSM paper (ROS1 faithful) | gsl_bench harness (RL/random) |
+|---|---|---|
+| **step rule** | fixed 1 Hz iterate-and-supersede; never blocks | blocks per Nav2 hop; counter advances only on goal completion |
+| **hop length** | up to ~3 m | capped at **1.0 m** along the ray |
+| **Nav2 controller** | `max_vel_x=0.22`, `θ=2.75`, `min_speed_xy=0.11`, `sim_time=1.5` | `max_vel_x=0.26`, `θ=1.0`, `min_speed_xy=0.0`, `sim_time=1.7` |
+| **goal transport** | preempting `sendGoal` or GoalUpdater (ROS2 faithful) | fresh `NavigateToPose` action per step → BT rebuild + rotate-to-heading |
+
+The third axis alone is the smaller issue (changing a YAML fixes it); the first two are
+paradigm-level and require a harness design change.
+
+## Two motion models — cannot share one loop
+
+### gpulaika (and RL-trained policies): stop-and-go
+
+```
+pose_cb → cache update → if _is_moving: check timeout; return ← block gate
+        ↓ (when not _is_moving AND step_delay elapsed)
+    _take_step → agent.observe(cache.snapshot)   ← at settled pose
+               → agent.act() → Waypoint
+               → _cap_hop(1.0 m) → _clamp_to_free → _drive(...)
+                                    ↓
+                        _is_moving=True; Navigator.send_goal(NavigateToPose)
+                        ↓ (goal completes async)
+                        _on_nav_complete → _is_moving=False
+                        ↓ (next pose_cb)
+                        observe at_arrival_pose ...
+```
+
+Why this is load-bearing:
+- `_action_to_target( … STEP_SIZE)` produces a post-step heading; the policy's
+  expected next observation matches that heading. Mid-rotation observe breaks
+  the train/eval contract (`gpulaika_agent.py:33,58,126-127`).
+- `b.record_step()` advances gas-history once per accepted arrival
+  (`gpulaika_agent.py:97-98`). Mid-motion extra records desync the trace.
+- Lidar is heading-frame: ray 0 = body forward. Mid-turn, the lidar would be
+  orientation-incoherent with the action just taken.
+
+### ADSM: continuous decide-supersede
+
+```
+while ros::ok():                      ← iter_rate=1 Hz wall-clock
+    ros::spinOnce()                   ← caches drain async
+    observe()                         ← reads current cache (not arrival-conditioned)
+    estimate()                        ← RRT if goal reached OR 5.5 s elapsed
+    evaluate()                        ← pick argmax(j) over candidate goals
+    navigate()                        ← ac_->sendGoal(goal) → returns immediately
+    iter_++; rate.sleep()
+```
+
+Why this is load-bearing:
+- `probability()` uses live wind direction *at decision time* (`adsm.cpp:199`).
+  Blocking on arrival would let gas/wind go stale.
+- Re-sample is gated by wall-clock time, not by arrival (`adsm.cpp:248`).
+- Waypoints are 3-m casts; 1.0-m hop-cap would clip each goal to 1/3 intent.
+- Without GoalUpdater, the BT rebuild + rotate-to-heading per tick was measured at
+  "3 cm/s advance, stuck-watchdog trips" (`adsm_goal_update_bt.xml:11-13`).
+
+## Agreed direction
+
+### Step definition → drop "step" as the budget; use sim-time + distance
+
+**(Choice C from conversation.)** Both the harness and the ADSM launch already support
+`max_sim_time_s` and `max_travel_distance_m`. These become the primary per-scenario
+budgets (oracle-derived). `max_steps` degrades to a diagnostic runaway guard.
+TTS is in sim-seconds; PE is in metres; PSC is wall-ms. All motion-mode agnostic.
+
+### Nav2 config → `*_adsm_faithful` + GoalUpdater BT, with preconditions
+
+**(Recognised as not fully independent of the motion-mode fork.)**
+Canonical config adopted as `nav2_realistic_params_adsm_faithful.yaml` +
+`adsm_faithful_bt.xml`, **after two preconditions**:
+1. Swap footprint from TB3-burger to P3DX (`robot_radius=0.22`),
+   reduce `inflation_radius` from 1.0 to 0.55–0.65.
+2. One-run SLAM stability check on the canonical scenario (`4_rooms_start_a`):
+   confirm median map error ≤10 cm, no phantom-wall cells.
+
+The GoalUpdater BT is a strict superset of the stock tree; stop_go agents never
+publish to `goal_update` and are unaffected.
+
+### ADSM integration → port as a first-class `GSLAgent` (not IPC)
+
+Pure-Python port of `adsm.cpp`'s `observe/estimate/evaluate/navigate` into
+`gsl_bench/agents/adsm_agent.py`, reusing `efe_igdm`'s `OccupancyGridMap` and
+RRT/frontier helpers. Follows the suite's convention (cf. `gpulaika_agent.py`).
+Declares `motion_mode='continuous'`, `iter_rate=1.0`, `hop_reach=3.0`.
+
+### Motion-mode fork → add fields to `GSLAgent` ABC, branch in `RunnerNode`
+
+New class-level fields on `GSLAgent` (`gsl_bench/agent.py`):
+- `motion_mode: str = 'stop_go'` — `'stop_go'` or `'continuous'`
+- `iter_rate: float = 1.0` — target decision rate (Hz) for continuous
+- `hop_reach: float = 1.0` — per-agent hop-cap request; harness still validates
+  against `--max-hop`
+- `needs_arrival_obs: bool = True` — gate observe() on a fresh post-drive scan
+
+All existing agents inherit defaults → byte-identical. New `AdsmAgent` overrides.
+
+Changes in `runner_node.py`:
+- `_pose_callback`: continuous mode falls through `_is_moving` instead of
+  early-returning; rate-gates by `1.0 / agent.iter_rate` instead of
+  `step_delay`.
+- `_drive`: continuous mode publishes `PoseStamped` to `/{ns}/goal_update`
+  (GoalUpdater) instead of sending a fresh `NavigateToPose` when already
+  moving. First call always sends fresh `NavigateToPose`; completion callback
+  sets `_is_moving=False` so that when the stream pauses, the next call
+  restarts the tree cleanly.
+- `_cap_hop` uses `min(harness_max_hop, agent.hop_reach)`.
+- Result schema (`write_result`) stamps `motion_mode`, `iter_rate`,
+  `max_sim_time_s`, `max_travel_distance_m`.
+
+### Fairness guard extends
+
+`gsl_bench/eval/metrics.py` extended to flag cross-run differences in:
+`motion_mode`, `iter_rate`, `max_sim_time_s`, `max_travel_distance_m`,
+`nav_params_yaml`, `bt_xml`.
+
+### Oracle updated
+
+`gsl_bench/eval/oracle.py` derives `max_sim_time_s` and `max_travel_distance_m`
+instead of `max_steps`, using the same geodesic + drive-time estimate logic.
+
+## Files to modify / create (in execution order)
+
+| # | File | What |
+|---|---|---|
+| 1 | `benchmark_env_realistic/navigation_config/nav2_realistic_params_adsm_faithful.yaml` | Precondition #1: P3DX footprint, inflation_radius 0.55 |
+| 2 | `benchmark_env_realistic/navigation_config/nav2_realistic_launch.py` | Precondition #2 (manual check); then load `_adsm_faithful.yaml` + `adsm_faithful_bt.xml` |
+| 3 | `gsl_bench/agent.py` | Add `motion_mode`, `iter_rate`, `hop_reach`, `needs_arrival_obs` |
+| 4 | `gsl_bench/harness/runner_node.py` | Fork `_pose_callback`, `_drive`, `_on_nav_complete`; `_goal_update_pub`; relax `_cap_hop`; record new fields |
+| 5 | `gsl_bench/eval/oracle.py` | Derive `max_sim_time_s`, `max_travel_distance_m` |
+| 6 | `gsl_bench/eval/episode_runner.py` | Promote `--max-sim-time-s`/`--max-travel-distance-m` to primary budgets; raise `--max-steps` to guard |
+| 7 | `gsl_bench/eval/metrics.py` | Extend fairness guard with new block fields |
+| 8 | `gsl_bench/agents/adsm_agent.py` (new) | Pure-Python port of ADSM decision loop; `motion_mode='continuous'` |
+| 9 | `benchmark_env/navigation_config/nav2_params.yaml` | Same BT swap for ground-truth path (cross-package consistency) |

--- a/gsl_bench/docs/METRIC_DESIGN.md
+++ b/gsl_bench/docs/METRIC_DESIGN.md
@@ -1,0 +1,256 @@
+# GSL-Bench: Metric Design Notes
+
+> **Influences (methodology, not strict template):** NAVSIM (Dauner et al. NeurIPS 2024, arXiv:2406.15349; Cao et al. CoRL 2025, arXiv:2506.04218), Anderson et al. 2018 (SPL, arXiv:1807.06757), Vergassola 2007, Park & Cho 2022, Kim et al. 2025 (IGDM), Lilienthal GDM series.
+>
+> We borrow the *gate &times; weighted-average* composite-shape convention from NAVSIM and the *expert-filter* concept from NAVSIM v2, but do **not** copy NAVSIM wholesale — the gas source localization (GSL) task has different structure (no traffic laws, longer horizons, two distinct task formulations, plume stochasticity).
+
+---
+
+## 1. Two task tracks — the core design decision
+
+Gas source localization in the literature is actually **two distinct tasks**, conflated under one name. They have different success criteria, different controllable actions, and different evaluation protocols. A benchmark that forces them into one score is unfair to both.
+
+### Track A — **Approach** ("go near the source")
+
+The robot must physically reach the source's neighborhood. The agent emits a motion waypoint each step; success is the robot entering the success radius.
+
+- **Operates:** Pioneer P3DX ground robot via Nav2 (as in our `RunnerNode`).
+- **Belief use is optional:** surge-cast, chemotaxis, and learned policies work here too — they need not maintain a source belief.
+- **Failure modes:** timeout, collision, env-dead.
+- **Examples in our suite:** RLaika, RRT-Infotaxis, IGDM (dual-mode), random-walk, upwind-greedy.
+
+### Track L — **Localize** ("declare the source location")
+
+The robot (often a sensor-bearing observer or one that moves to gather info, not necessarily to reach the source) must emit a **point estimate** of the source. It may terminate far from the source; success is whether its estimate lies within a localization tolerance.
+
+- **Works with:** belief-based methods only — the agent maintains a source probability map and declares an argmax (or top-k).
+- **Failure modes:** declared-but-wrong, never-declares (timeout), declared-inside-a-wall.
+- **Examples in our suite:** Infotaxis, RRT-Infotaxis (as a belief planner), IGDM, ADSM (as a belief mapper), RLaika (the policy can be augmented with a belief head for origination; or excluded from Track L).
+
+**Rules of separation:**
+
+1. Each method is evaluated on **one or both tracks**, declared up-front in its `agent_config.yaml` (`track: A`, `track: L`, or `track: both`).
+2. Track-A-only methods (e.g. surge-cast) get **N/A in Track-L tables** — they have no belief output, they are not penalized.
+3. Track-L-only methods (hypothetical stationary sensor-array GSL or map-only belief) get **N/A in Track-A tables** — they never plan a robot motion.
+4. Each track has its **own composite score**, its **own headline table**, its **own leaderboard**.
+
+This mirrors robotics literature (e.g. Vergassola 2007 measures *approach*, Lilienthal GDM measures *localization error*) but formalizes them as co-equal tasks — *no published GSL benchmark does this explicitly.*
+
+---
+
+## 2. Two composite scores, same shape
+
+Both tracks use the NAVSIM *gate &times; weighted-average* composite, but with **different gate and quality metrics** appropriate to each task.
+
+$$
+\text{GSLS-X} = \underbrace{\prod_{m \in \mathcal{G}_X} g_m}_{\text{gate (hard-zeroing)}} \;\cdot\; \underbrace{\frac{\sum_{m \in \mathcal{Q}_X} w_m\, q_m}{\sum_{m \in \mathcal{Q}_X} w_m}}_{\text{quality (soft)}}
+$$
+
+with X &isin; {A, L}. Each $g_m$ is binary or graded {0, &frac12;, 1}; a zero kills the score (no "collision but smooth" consolation). Each $q_m$ &isin; [0, 1]. Weights are exposed in `harness_default.yaml`, sum to 1 per track, transparent and re-weightable.
+
+Scale: **[0, 1]**, leaderboards render &times;100. **Median [IQR]** across seeds per scenario; **mean across scenarios** for the headline.
+
+---
+
+## 3. Track A — Approach metrics (10 total: 3 gate + 7 quality)
+
+### 3.1 Gate metrics $\mathcal{G}_A$ (hard-zeroing)
+
+| # | Metric | Symbol | Definition |
+|---|---|---|---|
+| 1 | **No Collision** | NC | Binary. 1 if the robot never collided with a wall/obstacle during the episode. |
+| 2 | **In-Bounds Compliance** | IBC | Binary. 1 if the robot stays inside the scenario bbox for the whole episode. |
+| 3 | **Valid Termination** | VT | Graded {0, &frac12;, 1}: 1 = success within step budget; &frac12; = ran out of steps but in-bounds and collision-free; 0 = `env_dead` / `wall_timeout` / `agent_error`. Replaces the single binary `success_radius` check at `gsl_bench/harness/runner_node.py:437`. |
+
+### 3.2 Quality metrics $\mathcal{Q}_A$ (weighted-average)
+
+| # | Metric | Symbol | Definition | Weight | Borrowed from |
+|---|---|---|---|---|---|
+| 4 | **Source Progress** | SP | `min(1, (d_start&rarr;source &minus; d_final&rarr;source) / d_start&rarr;source)`. Defined over **ALL episodes, not just successes** &mdash; failures contribute. | 0.30 | NAVSIM "Ego Progress" |
+| 5 | **Time-to-Source** | TTS | `exp(&minus;t / &tau;)` with `t` = sim-seconds until first success-radius entry, `&tau;` = half the step budget. Returns 0 on timeout. | 0.20 | Standard GSL |
+| 6 | **Path Efficiency** | PE | `&ell;_geodesic(start, source) / &ell;_actual`, capped to [0, 1]. | 0.15 | Anderson 2018 (SPL) |
+| 7 | **First Hit Time** | FHT | `1 &minus; (t_first_gas_hit / max_steps)`. Measures plume-finding speed, distinct from TTS (measures source-finding speed). | 0.10 | Active-SLAM style |
+| 8 | **Plume Contact Ratio** | PCR | Fraction of timesteps with PID reading above the noise floor. Distinguishes plume-riding from random casting. | 0.05 | Chemotaxis literature |
+| 9 | **Coverage** | COV | Fraction of free cells within sensor range of the trajectory over the max reachable fraction in the time budget. | 0.05 | Active-SLAM |
+| 10 | **Per-Step Compute** | PSC | `1 &minus; t_step / t_budget` with `t_step` = p99 wall ms of `observe()+act()`, `t_budget` = p99 of the slowest method in the comparison (sets the scale). Encodes the "7&times; cheaper" claim from the `base` README directly. | 0.15 | Park & Cho 2022; new |
+
+Weights sum to 1.0. SP+TTS+PE carry the headline (65% of the soft mass); the rest are diagnostic.
+
+### 3.3 Track-A success
+
+The GSLS-A composite **subsumes** Success Rate (the classical binary we already report): VT&middot;SP captures it (a run that reached the source gets SP=1, VT=1; one that didn't gets SP&le;1, VT&le;&frac12;). For table readability, plain SR (with Wilson CI) is still reported as an auxiliary column, but the composite rewards partial progress where SR alone gives a 0.
+
+---
+
+## 4. Track L — Localization metrics (9 total: 3 gate + 6 quality)
+
+A method in Track L must, at episode end, emit a **source estimate** `(x_est, y_est)` via the new `GSLAgent.estimate() -> Optional[(float, float)]` API. Methods that never declare return `None`; their episode is scored VT=0, hence GSLS-L = 0.
+
+### 4.1 Gate metrics $\mathcal{G}_L$ (hard-zeroing)
+
+| # | Metric | Symbol | Definition |
+|---|---|---|---|
+| 1 | **Valid Declaration** | VD | Binary. 1 if the agent emitted a non-`None` source estimate by `max_steps`. |
+| 2 | **Feasible Estimate** | FE | Binary. 1 if the estimate lies in **free space** (not inside a wall/obstacle). Replaces NAVSIM's drivable-area-compliance. |
+| 3 | **No Collision** | NC | Binary. For methods that also move; for stationary belief emitters, set to 1 by the harness (N/A gating). |
+
+### 4.2 Quality metrics $\mathcal{Q}_L$ (weighted-average)
+
+| # | Metric | Symbol | Definition | Weight | Borrowed from |
+|---|---|---|---|---|---|
+| 4 | **Source Localization Error** | SLE | `exp(&minus;&Vert;est &minus; true&Vert;_2 / &sigma;)` with `&sigma; = localization_tolerance` (default 1.0 m, distinct from the approach `success_radius` of 0.5 m). | 0.35 | Park & Cho 2022; standard GDM |
+| 5 | **Top-k Hit** | Tkk | `1` if the true source cell is in the agent's top-k belief cells (k = 1, 5, 10 reported separately; Tkk uses k=5 as primary). 0 otherwise. | 0.20 | Object-detection AP tradition |
+| 6 | **Belief NLL** | NLL | `&minus;log p(source_true | belief)`, min-max normalized across the episode set to [0, 1]. Probabilistic-calibration metric. | 0.10 | IGDM literature |
+| 7 | **Cumulative Information Gain** | CIG | Bits gained: `&Sigma;_t [H(belief_{t-1}) &minus; H(belief_t)]`, normalized by `log(N_cells)`. | 0.10 | Kim et al. 2025 (IGDM) |
+| 8 | **Time-to-Declaration** | TTD | `1 &minus; t_decl / max_steps` &mdash; rewards confident early declarations; timeout declarations get 0. | 0.15 | Standard |
+| 9 | **Per-Step Compute** | PSC | Same definition as Track A. | 0.10 | Park & Cho 2022; new |
+
+Weights sum to 1.0. SLE carries the headline (35%), Tk5 + TTD give the next tier; the rest are diagnostic and enable ablations of *why* a method localizes well.
+
+### 4.3 Track-L is belief-aware only
+
+Methods that do not maintain a source belief (random-walk, upwind-greedy, surge-cast) **cannot** construct Track-L outputs and are marked N/A, not penalized. The `agent_config.yaml` declares `track: A` for them. The paper's Track-L table is smaller (4 &mdash; 5 entries) than the Track-A table (6 entries).
+
+---
+
+## 5. The Expert (Oracle) Filter &mdash; borrowed from NAVSIM v2
+
+NAVSIM v2 neutralizes a per-metric penalty if the **expert/human driver would also have failed** that scene &mdash; eliminating false-negative penalties for legitimately ambiguous frames. The direct GSL analog:
+
+$$
+\text{filter}_m(\text{agent}) = \begin{cases}
+1.0 & \text{if } m(\text{oracle}) = 0 \\
+m(\text{agent}) & \text{otherwise}
+\end{cases}
+$$
+
+where `oracle` is an **idealized planner with cheat-sheet access to source+wind**, run once per scenario over the same GADEN bake. If even the oracle can't localize this scene (plume never reaches any reachable cell in the time budget, the source is occluded by walls such that no PID/anemometer config would reveal it, etc.), the agent is **not** penalized &mdash; that sub-metric is neutralized to 1.0 for that scene.
+
+**Implementation:** run the oracle once per scenario; cache its sub-metrics in `scenario/oracle_metrics.json`; apply the column-wise filter at aggregation in `gsl_bench/eval/metrics.py` (extending the existing fairness guard at L69-80). NAVSIM does exactly this with a `Human` privileged agent.
+
+This is the second key transferable idea from NAVSIM &mdash; the **first** being the gate &times; weighted-average composite shape, which we apply per-track.
+
+---
+
+## 6. Statistical rigor (cross-track mandatory)
+
+Per-scenario:
+- **Median [IQR]** for continuous metrics (TTS, PE, SLE, TTD, CIG, PCR, COV) &mdash; GSL distributions are heavy-tailed; one stuck robot skews any mean.
+- **Mean [+ Wilson 95% CI]** for binary metrics (NC, IBC, VT, VD, FE, SR).
+- **n &ge; 10** seeds per (scenario, method). For headline runs, push n = 20. The current harness's identical-seed bug (each agent self-seeds `default 0` at construction, so `--runs 5` produces 5 identical runs &mdash; see my reproducibility notes) must be fixed first.
+
+Cross-method (mandatory for every claim of the form "X > Y"):
+- **Paired Wilcoxon signed-rank** across all episodes (`scipy.stats.wilcoxon`).
+- **Cliff's &delta;** effect size alongside every p-value.
+- Without these, reviewers will (correctly) push back. A modern benchmark cannot publish paired bar charts without paired significance.
+
+The fairness guard at `gsl_bench/eval/metrics.py:69-80` already exposes harness-block mismatches across runs &mdash; extend it to also flag `wall_timeout_s`, which is currently blind to it (see my reproducibility notes).
+
+---
+
+## 7. Robustness axes (the section that distinguishes a benchmark from a results paper)
+
+Reported as **curves or ablation tables**, not headline numbers. Same protocol applies to both tracks.
+
+| Probe | Why it matters | Source |
+|---|---|---|
+| **Cross-family variance** | Exposes the "ADSM wins small maps, RLaika wins ultimate" pattern already visible in the `base` README's per-scenario table. | Free &mdash; existing family tags |
+| **Wind-speed sensitivity** | GSL algorithms separate sharply in low- vs high-P&eacute;clet regimes (Vergassola 2007). Requires `benchmark_env` to add `0.5ms` and `2ms` wind variants alongside the existing `1ms`. | New scenario variants |
+| **Sensor-noise sweep** | Anemometer/PID `noise_std` are ROS params already; sweep `&sigma;` &isin; {0, 0.1, 0.3, 0.5}. | Config only |
+| **Sim-to-real transfer** | The `57% &rarr; 76-80% after CFD finetune` gap already reported in the `base` README is itself a benchmark contribution: report SR drop from training-domain eval &rarr; GADEN eval as a transfer-robustness row. | Have the numbers |
+| **Seed variance** | `&sigma;(GSLS)` across &ge;5 seeds per (scenario, method); the random walks and most classical algorithms are deterministic &mdash; the variance is on Nav2 + the gas player + the learned policy. | Fix current seed bug |
+
+---
+
+## 8. Comparison protocol for the paper
+
+1. **Track-A headline table:** all approach-capable methods &times; GSLS-A (median [IQR]) + 4 aux columns (SR [+Wilson], TTS, PE, PSC). Cites Anderson/Habitat style.
+2. **Track-L headline table:** belief-only methods &times; GSLS-L (median [IQR]) + 4 aux columns (SLE, Tk5, TTD, CIG). Smaller table, sharper comparative claim.
+3. **Efficiency frontier (cross-track):** x = `log(t_step)`, y = GSLS-A or GSLS-L. RLaika's "cheap + high-score" corner becomes the headline visual.
+4. **Per-family bar plots:** GSLS-A by family for all approach methods; exposes per-family algorithm strengths.
+5. **Trajectory qualitative figure:** 2-3 example trajectories per algorithm on `ultimate_1` (approach track); belief heatmaps with declared source markers for the localization track.
+6. **Failure-mode pie chart** per method: `env_dead` vs `max_steps` vs `agent_error` &mdash; already have the data via `status_counts`.
+7. **Robustness section:** SR-vs-wind-speed curves, sensor-noise sweeps, cross-family variance table, sim-to-real transfer row.
+8. **Statistical test:** paired Wilcoxon + Cliff's &delta; on every "X > Y" claim, reported as a separate table or as footnotes to the headline tables.
+
+---
+
+## 9. Implementation map (where each piece plugs in)
+
+| Concept | File | Action |
+|---|---|---|
+| `GSLAgent.track` field + `estimate()` method | `gsl_bench/agent.py` (in `GSLAgent` ABC) | Declare `track` (`A`, `L`, `both`); add optional `estimate() -> Optional[(float,float)]`. Default `None`. Belief agents override. |
+| Track-A success check | `gsl_bench/harness/runner_node.py:437` | Replace single binary radius check with VT grading (success / in-bounds-timeout / failure). Already have collision flag in basic_sim, IBC trivial from pose vs bbox. |
+| Per-step compute timing | `gsl_bench/harness/runner_node.py:477-485` | Wrap `agent.observe()` + `agent.act()` in `time.perf_counter`; store `t_step_p50` and `t_step_p99` in `result.json`. |
+| Trajectory logging | `gsl_bench/harness/runner_node.py:_write_result` | Add `trajectory: [{x, y, theta, t}, ...]` (pose already captured in `_pose_callback`). Use a compression-friendly format; gate by `--log-trajectory`. |
+| Declaration timestamp | `runner_node.py` | Record `t_decl`, `(x_est, y_est)` when `agent.estimate()` first returns non-`None`. |
+| Belief dump for CIG/NLL | `agent.py` + `runner_node.py` | Optional `agent.belief()` returning an `np.ndarray` over free cells each step; sampled every K steps for storage. Belief-less agents return `None`. |
+| Weights &amp; harness YAML | `gsl_bench/eval/episode_runner.py:560-566` | Read `harness_default.yaml` (currently shipped but unread); add `--harness-config` flag and per-track weight sections `track_A`, `track_L`. |
+| Composite scorer | `gsl_bench/eval/score.py` (new) | Implement gate &times; weighted-average composite per track + expert filter; produce per-episode GSLS-A, GSLS-L. |
+| Oracle agent | `gsl_bench/eval/oracle.py` (new) | Cheat-source planner: drive straight to source (Track A) or immediately declare (Track L). Run once per scenario; cache sub-metrics in `scenario/oracle_metrics.json`. |
+| Seed plumbing | `gsl_bench/eval/episode_runner.py` + `gsl_bench/agent.py` | Add `--seed`, plumb into agents + `torch.manual_seed` / `np.random.seed` / `random.seed`; stamp `seed` in every `result.json`. |
+| Statistical report | `gsl_bench/eval/report.py` | Add Wilson CI, IQR, `scipy.stats.wilcoxon` paired test, Cliff's &delta;. Two headline tables (A, L). |
+| Plotting | `gsl_bench/tools/` (new) | `plot_trajectory.py`, `plot_efficiency_frontier.py`, `plot_robustness_curves.py`, `plot_belief_heatmap.py`. |
+
+---
+
+## 10. Hallmark table layout (paper-style)
+
+### Table 1 &mdash; Track-A Headline (approach-capable methods only)
+
+| Method | **GSLS-A &uarr;** | SR &uarr; | TTS [s] &darr; | PE &uarr; | $t_{step}$ [ms] &darr; |
+|---|---|---|---|---|---|
+| RLaika (ours) | **0.71 [0.61-0.79]** | **0.91 [+0.05/-0.07]** | 897 | 0.32 | **1.4** |
+| ADSM | 0.58 | 0.80 | 160 | 0.66 | 9.5 |
+| EESA | 0.31 | 0.57 | 110 | 0.91 | 10.8 |
+| RRT-Infotaxis | ... | ... | ... | ... | ... |
+| IGDM | ... | ... | ... | ... | ... |
+| Random walk | 0.09 | 0.05 | - | 0.10 | < 0.1 |
+
+GSLS-A reported as **median [IQR]** across seeds &times; scenarios. SR with **Wilson 95% CI**. $t_{step}$ as median + p99. Pattern matches NAVSIM's headline per-seed-aggregated-table.
+
+### Table 2 &mdash; Track-L Headline (belief-only)
+
+| Method | **GSLS-L &uarr;** | SLE [m] &darr; | Tk5 &uarr; | TTD [s] | CIG [bits] &uarr; |
+|---|---|---|---|---|---|
+| IGDM | ... | ... | ... | ... | ... |
+| RRT-Infotaxis | ... | ... | ... | ... | ... |
+| Infotaxis | ... | ... | ... | ... | ... |
+| RLaika (belief head) | ... | ... | ... | ... | ... |
+| ADSM | ... | ... | ... | ... | ... |
+
+### Figure 1 &mdash; **Efficiency frontier** (x: `log(t_step)`, y: GSLS-A or GSLS-L). RLaika's tiny net in the "cheap + high-score" corner is the visual argument.
+
+### Figure 2 &mdash; **Trajectory posters** (2-3 per method on `ultimate_1`).
+
+### Figure 3 &mdash; **Robustness** (GSLS-A vs wind speed; GSLS-L vs sensor noise `&sigma;`).
+
+---
+
+## 11. Positioning vs Herwich/GSL-Bench
+
+> *"Closest prior work, GSL-Bench [Herwich et al.], uses 6 Isaac Sim warehouse environments, 3 algorithms (E. Coli, dung beetle, random walk), and 6 raw metrics on an aerial platform. We complement this with a ROS2-standard ground-robot benchmark on the field-validated GADEN filament simulator, with 30 scenarios across 5 map families and 6 head-to-head algorithms (including a learned policy). We further separate the two distinct GSL task formulations &mdash; **approach** (physically reach the source) and **localize** (declare the source position) &mdash; into two parallel tracks with independent composite scores, and propose a gate &times; weighted-average GSL Score (GSLS-A, GSLS-L) of 10 and 9 sub-metrics respectively, structured following NAVSIM [Dauner et al. 2024]. Our inclusion of source-localization error (SLE), top-k accuracy, and information-gain (CIG) metrics &mdash; unreported by GSL-Bench and rare in GSL literature &mdash; enables a comparison of belief-based methods on *understanding*, not just *arrival*."*
+
+---
+
+## 12. Citations to add
+
+- **NAVSIM v1:** Dauner et al., NeurIPS 2024 Datasets &amp; Benchmarks, arXiv:2406.15349 &mdash; *primary methodology influence (gate &times; weighted-average composite).*
+- **NAVSIM v2 (Pseudo-Simulation):** Cao et al., CoRL 2025, arXiv:2506.04218 &mdash; *expert-filter concept (oracle-neutralized ambiguous scenes).*
+- **SPL:** Anderson et al., 2018, arXiv:1807.06757 &mdash; *Path Efficiency normalized.*
+- **Habitat:** Savva et al., ICCV 2019, arXiv:1904.01201 &mdash; *cross-environment SR + benchmark protocol conventions.*
+- **Lilienthal GDM series** &mdash; *map-error / KL / correlation conventions (already in refs via IGDM lineage).*
+- **Recent CPSL UAV work** (arXiv:2603.11582, 2026) &mdash; *modern paired-baseline comparison framing; situates learned GSL in the latest literature.*
+
+---
+
+## 13. Summary
+
+- **Two task tracks**, two composite scores, two headline tables.
+- **Track A &mdash; Approach** (3 gates + 7 quality; SR-as-auxiliary). Pioneer robot, all 6 algorithms.
+- **Track L &mdash; Localize** (3 gates + 6 quality; SLE-as-headline). Belief-only, 4-5 algorithms.
+- **Composite shape:** gate &times; weighted-average &mdash; NAVSIM's convention, applied per-track.
+- **Expert filter:** oracle-neutralized ambiguous scenes &mdash; NAVSIM v2's transferable trick.
+- **Statistical rigor:** paired Wilcoxon + Cliff's &delta; + Wilson CI + IQR, n &ge; 10 seeds.
+- **Robustness axes:** cross-family, wind-speed, sensor-noise, sim-to-real transfer, seed variance.
+- **Differentiates from Herwich/GSL-Bench**: more algos (6 vs 3), more scenarios (30 vs 6), more metrics (10+9 vs 6), two task tracks (Herwich does not formally separate), composite with gating (vs raw metrics), explicit statistical protocol (vs none).

--- a/gsl_bench/docs/README.md
+++ b/gsl_bench/docs/README.md
@@ -1,0 +1,92 @@
+# gsl_bench
+
+A NavSim-style modular benchmark for **gas source localization**. You implement two
+functions — `observe()` and `act()` — and the harness handles the rest: simulation,
+physical motion execution, collision handling, timeouts, termination, metrics.
+
+```
+      your agent                     the harness (gsl_bench)
+  ┌────────────────┐    Observation   ┌──────────────────────────────────────┐
+  │ observe(obs)   │ ◄─────────────── │ GADEN gas + BasicSim robot + Nav2    │
+  │ act() ─────────│ ──────────────►  │ hop cap → clamp to free → drive      │
+  └────────────────┘     Waypoint     │ success/step-cap/watchdog → result   │
+                                      └──────────────────────────────────────┘
+```
+
+## Quickstart
+
+```bash
+cd /home/efe/ros2_ws
+colcon build --packages-select gsl_bench --symlink-install && source install/setup.bash
+
+# a shipped baseline on one scenario
+ros2 run gsl_bench eval --agent random_walk --scenario 4_rooms_start_a --runs 2
+
+# the flagship RL agent on the 7-map suite (its validated recipe needs --escape)
+ros2 run gsl_bench eval --agent gpulaika \
+    --agent-config src/gsl_bench/configs/agents/gpulaika.yaml \
+    --suite nav7 --runs 5 --escape
+
+# re-print the table for any results directory
+ros2 run gsl_bench report Results/gpulaika_20260715_010101
+```
+
+Writing your own agent: **[writing_an_agent.md](writing_an_agent.md)**. It is ~20 lines.
+The ADSM implementation and fidelity boundary are documented in
+**[ADSM_PORT.md](ADSM_PORT.md)**.
+
+## What you get
+
+Per run, a `result.json`; per sweep, a `results.csv` and a `report.md`:
+
+| scenario | success | TT (s) | TD (m) | steps | fail modes |
+|---|---|---|---|---|---|
+| 4_rooms_start_a | 5/5 | 120.4 | 18.2 | 41.0 | — |
+| curved_labrinth_left_1 | 4/5 | 402.1 | 63.9 | 155.2 | max_stepsx1 |
+| **TOTAL** | 9/10 | 245.7 | 38.6 | 92.4 | max_stepsx1 |
+
+TT = mean time-to-source over successes. TD = mean traveled distance over successes.
+Both are meaningless over failures (a failed run's time is just the step cap), so they
+are computed over successes only.
+
+## The pieces
+
+| Path | Role |
+|---|---|
+| `gsl_bench/agent.py` | the public API: `GSLAgent`, `Observation`, `Waypoint`, `MapInfo`, `ScenarioInfo` |
+| `gsl_bench/registry.py` | `--agent` lookup: shipped name, entry point, or `pkg.module:Class` |
+| `gsl_bench/harness/runner_node.py` | the generic ROS node: sensors → observe/act → Nav2 drive → `result.json` |
+| `gsl_bench/harness/obs_cache.py` | latest-value sensor cache; one coherent snapshot per step |
+| `gsl_bench/eval/episode_runner.py` | the batch runner: bake, patch, launch, babysit, clean up, report |
+| `gsl_bench/eval/metrics.py`, `report.py` | aggregation and the markdown/CSV tables |
+| `gsl_bench/agents/` | `random_walk`, `upwind_greedy`, `gpulaika`, `zigzag`, `surge_cast` |
+| `configs/harness_default.yaml` | the fairness knobs |
+
+Scenarios come from `benchmark_env` (27+ gaden-project maps), which `gsl_bench` treats
+as a read-only dependency.
+
+## Rules of the benchmark
+
+1. **The agent never sees the source.** Success is the harness's call:
+   `distance(robot, source) < 0.5 m`.
+2. **Motion is always physical Nav2 drive.** No teleport between steps — the single
+   teleport per episode is the initial placement, before step 0.
+3. **Fairness knobs live in the harness**, not the agent, and the whole block is
+   written into every `result.json`. `report` prints a loud warning if you aggregate
+   runs scored under different settings.
+4. **Escape recovery is opt-in and recorded.** `--escape` turns on the harness's
+   stuck-escape (SLAM + frontier). It is OFF by default because it moves scores
+   materially (historically 28→32 on the 7-map suite), so a result without the flag
+   recorded is uninterpretable.
+
+## Operational notes (learned the hard way)
+
+* **One sweep per machine per domain.** Pass `--domain-id N`; leaked ROS nodes
+  republishing on a reused `ROS_DOMAIN_ID` silently poison a later sweep. The runner
+  tree-kills the launch descendants (they get their own sessions, so a pgid-only kill
+  cannot reach them) and reaps anything left on its own domain.
+* **Sim speed is 1× real time.** The gaden speed knob is dead (the BasicSim clock is
+  wall-derived); budget wall-clock time accordingly — a 600-step failure is ~20–30 min.
+* **The install tree is patched, not the source tree**: no rviz/xterm, 360°/72-ray/3 m
+  lidar, tuned nav2 params, looping gas playback. All idempotent, all re-applied every
+  run (preproc regenerates `BasicSimScene.yaml`, so the lidar patch must come after it).

--- a/gsl_bench/docs/writing_an_agent.md
+++ b/gsl_bench/docs/writing_an_agent.md
@@ -1,0 +1,131 @@
+# Writing a gsl_bench agent
+
+You implement two methods. The harness owns everything else: the simulator, physical
+motion execution, collision handling, timeouts, termination, and scoring.
+
+Agents default to `motion_mode = "stop_go"`: the next observation is taken after the
+current drive finishes. Methods such as ADSM that were designed to revise a goal while
+moving may declare `motion_mode = "continuous"`, a `decision_rate_hz`, and a larger
+`max_goal_distance`; the harness then updates one running Nav2 action through GoalUpdater.
+
+## 1. The whole thing
+
+```python
+import math, random
+from gsl_bench.agent import GSLAgent, Observation, Waypoint
+
+class RandomWalkAgent(GSLAgent):
+    """Pick a random free direction, step 0.5 m."""
+
+    def __init__(self, config=None):
+        self.rng = random.Random((config or {}).get('seed', 0))
+        self.obs = None
+
+    def observe(self, obs: Observation) -> None:
+        self.obs = obs                      # integrate into your belief/filter/history
+
+    def act(self) -> Waypoint:
+        for _ in range(20):                 # rejection-sample a free target
+            th = self.rng.uniform(-math.pi, math.pi)
+            x = self.obs.x + 0.5 * math.cos(th)
+            y = self.obs.y + 0.5 * math.sin(th)
+            if self.obs.map.is_free(x, y):
+                return Waypoint(x, y, theta=th)
+        return Waypoint(self.obs.x, self.obs.y)   # boxed in: stay
+```
+
+That is a complete, runnable method. `act()` returns an **absolute map-frame
+coordinate**; how the robot gets there is not your problem.
+
+## 2. Lifecycle
+
+```
+initialize()                once per process — load weights, warm caches
+reset(scenario)             once per episode — map bounds, start pose, step budget
+  observe(obs) -> act()     once per decision step, always as a pair
+  ...
+(episode ends)              success | max_steps | wall_timeout | env_dead | agent_error
+```
+
+`reset()` receives a `ScenarioInfo`. It **never contains the source position** — that
+is held by the harness for the success check only.
+
+## 3. What you get: `Observation`
+
+| Field | Type | Meaning |
+|---|---|---|
+| `x`, `y` | float | robot position, map frame |
+| `theta` | float | heading, rad, world frame |
+| `gas_ppm` | float | latest PID reading (0.0 before the first message) |
+| `wind_speed` | float | m/s at the robot — **already sqrt-corrected** by the harness |
+| `wind_direction` | float | rad from world +x, pointing **downwind** (the source is at `wind_direction + π`) |
+| `lidar` | np.ndarray (72,) | metres, ray 0 = sensor-frame 0°, non-finite → max range |
+| `lidar_max_range` | float | 3.0 |
+| `step` | int | decision-step index, 0-based |
+| `sim_time` | float | seconds since episode start |
+| `map` | `MapInfo` | static occupancy grid + `is_free(x, y)` |
+| `lidar_msg` | LaserScan or None | the raw ROS message, if you need `angle_min`/`angle_increment` |
+
+`MapInfo`: `grid` (H×W, 0 = free), `resolution`, `origin_x`, `origin_y`, `width_m`,
+`height_m`, and `is_free(x, y)`.
+
+## 4. What you return: `Waypoint`
+
+`Waypoint(x, y, theta=None)` — an absolute target. `theta` is the arrival heading;
+`None` means "face the direction of travel".
+
+The harness then, without telling you:
+
+* **caps the hop** at `max_hop` (default 1.0 m), shortening along your own ray;
+* **clamps into free space** — if the target is inside a wall it walks back along the
+  ray until a radius-aware free cell is found (and stays put if there is none);
+* **drives physically** with Nav2, cancelling after `drive_timeout` seconds if the
+  controller wedges.
+
+So the next `observe()` simply shows where the robot really ended up. Do not assume
+you arrived at your waypoint — read `obs.x`/`obs.y`.
+
+## 5. Config
+
+Your `__init__` takes one optional `dict`, loaded from the YAML passed to
+`--agent-config`:
+
+```yaml
+# my_agent.yaml
+seed: 7
+gas_threshold: 50.0
+```
+
+The runner injects `wind_file` (the scenario's wind CSV) automatically, since that is
+a property of the scenario rather than of your method.
+
+## 6. Running it
+
+```bash
+# by dotted path — no registration needed
+ros2 run gsl_bench eval --agent my_pkg.my_agent:MyAgent \
+    --scenario 4_rooms_start_a --runs 3
+
+# a whole suite
+ros2 run gsl_bench eval --agent my_pkg.my_agent:MyAgent --suite nav7 --runs 5
+```
+
+To register a short name from your own package, add an entry point in its `setup.py`
+— no fork of gsl_bench required:
+
+```python
+entry_points={'gsl_bench.agents': ['my_agent = my_pkg.my_agent:MyAgent']}
+```
+
+Then `--agent my_agent` works.
+
+## 7. Rules of the benchmark
+
+* You never see the source position. Success is the harness's judgement:
+  `distance(robot, source) < 0.5 m`.
+* Motion is always physical Nav2 drive. There is no teleport between steps (the one
+  teleport per episode is the initial placement, before step 0).
+* Fairness knobs (success radius, step cap, drive timeout, escape on/off) live in the
+  harness, not in your agent, and the full block is recorded in every `result.json`.
+  `gsl_bench report` prints a loud warning if you try to aggregate runs that were
+  scored under different settings.

--- a/gsl_bench/gsl_bench/agent.py
+++ b/gsl_bench/gsl_bench/agent.py
@@ -1,0 +1,128 @@
+"""Public agent API for gsl_bench. Third parties import ONLY from this module.
+
+Implement observe() and act(); the harness owns simulation, motion execution,
+timeouts, collision handling and scoring.
+
+    from gsl_bench.agent import GSLAgent, Observation, Waypoint
+
+    class MyAgent(GSLAgent):
+        def observe(self, obs): self.obs = obs
+        def act(self):          return Waypoint(self.obs.x + 0.5, self.obs.y)
+"""
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import numpy as np
+
+
+@dataclass
+class MapInfo:
+    """Static occupancy map, given once at reset and repeated in every Observation."""
+
+    grid: np.ndarray          # (H, W) uint8: 0 = free, non-zero = occupied
+    resolution: float         # metres per cell
+    origin_x: float           # world x of grid[0, 0]'s cell corner
+    origin_y: float
+    width_m: float            # real-world width  (W * resolution)
+    height_m: float           # real-world height (H * resolution)
+
+    def is_free(self, x: float, y: float) -> bool:
+        """True if world point (x, y) is inside the map and in a free cell."""
+        i = int((y - self.origin_y) / self.resolution)
+        j = int((x - self.origin_x) / self.resolution)
+        if 0 <= i < self.grid.shape[0] and 0 <= j < self.grid.shape[1]:
+            return self.grid[i, j] == 0
+        return False
+
+
+@dataclass
+class ScenarioInfo:
+    """Episode context handed to reset(). NEVER contains the source position."""
+
+    name: str                 # e.g. "4_rooms_start_a"
+    map: MapInfo
+    start_x: float
+    start_y: float
+    max_steps: int            # step budget (e.g. 600)
+    step_size_hint: float     # the harness caps hops at ~2x this (default 0.5 m)
+
+
+@dataclass
+class Observation:
+    """Snapshot of every sensor at one decision step."""
+
+    x: float                  # robot pose, map frame
+    y: float
+    theta: float              # rad, world frame, from the configured pose source
+    gas_ppm: float            # latest PID reading (0.0 until the first message)
+    wind_speed: float         # m/s — already sqrt-corrected by the harness
+    wind_direction: float     # rad from world +x
+    lidar: np.ndarray         # (72,) metres, ray 0 = sensor frame 0 deg, non-finite -> max range
+    lidar_max_range: float    # 3.0
+    step: int                 # decision-step index, 0-based
+    sim_time: float           # seconds since episode start
+    map: MapInfo              # the same object as ScenarioInfo.map
+    # Raw sensor_msgs/LaserScan behind `lidar`. Present when running under the ROS
+    # harness, None otherwise (e.g. unit tests). Agents that only need distances
+    # should use `lidar`; this exists for agents whose observation code already
+    # consumes the ROS message (angle_min/angle_increment/ranges).
+    lidar_msg: Optional[Any] = None
+
+
+@dataclass
+class Waypoint:
+    """Absolute map-frame target the harness will drive to."""
+
+    x: float
+    y: float
+    theta: Optional[float] = None   # arrival heading; None = face the direction of travel
+
+
+class GSLAgent(ABC):
+    """Implement observe() and act(). Everything else has a working default.
+
+    Lifecycle:  initialize() -> reset(scenario) -> [observe(obs) -> act()]* -> (episode ends)
+
+    The harness guarantees:
+      * observe() and act() are called back-to-back, exactly once per decision step.
+      * Waypoints are clamped into free space (radius-aware) and capped at max_hop;
+        the agent is not told. The next observe() simply shows where the robot
+        really ended up.
+      * If the motion backend cannot reach the waypoint within drive_timeout
+        seconds, it is cancelled and the next decision step starts from wherever
+        the robot stopped.
+      * The agent never receives the source position.
+    """
+
+    # Motion capabilities. Existing agents inherit stop-go semantics unchanged.
+    motion_mode: str = 'stop_go'
+    decision_rate_hz: Optional[float] = None
+    max_goal_distance: float = 1.0
+    required_pose_source: Optional[str] = None
+    required_map_source: Optional[str] = None
+    required_motion: Optional[str] = None
+    required_nav_profile: Optional[str] = None
+
+    def initialize(self) -> None:
+        """Called once per process, before the first episode. Load weights here."""
+
+    def reset(self, scenario: ScenarioInfo) -> None:
+        """Called at the start of every episode."""
+
+    @abstractmethod
+    def observe(self, obs: Observation) -> None:
+        """Ingest the current sensor snapshot (update belief / filters / history)."""
+
+    @abstractmethod
+    def act(self) -> Waypoint:
+        """Return the next target position. Called immediately after observe()."""
+
+    def name(self) -> str:
+        return type(self).__name__
+
+    def metadata(self) -> dict:
+        """Implementation-specific provenance included in result.json."""
+        return {}

--- a/gsl_bench/gsl_bench/agents/_casting.py
+++ b/gsl_bench/gsl_bench/agents/_casting.py
@@ -1,0 +1,34 @@
+"""Shared crosswind-stepping geometry for ZigzagAgent and SurgeCastAgent's CAST state.
+
+The anemometer's wind_direction points DOWNWIND, so the crosswind axis is
+perpendicular to the upwind bearing (wind_direction + pi).
+"""
+import math
+
+
+def crosswind_step(obs, side: int, step_size: float, upwind_drift: float = 0.0):
+    """One crosswind hop, `side` = +1 (left of upwind) or -1 (right).
+
+    `upwind_drift` (0..step_size) blends a small upwind bias INTO the bearing
+    before stepping, so the hop still covers exactly `step_size` rather than
+    stacking a second vector on top of it (which would blow past max_hop).
+
+    Fans out around the resulting bearing if the map blocks it, same pattern
+    as the other baseline agents. Returns (x, y, theta); stays put (returns
+    obs.x, obs.y) if boxed in on every fan angle.
+    """
+    crosswind = obs.wind_direction + side * (math.pi / 2.0)
+    if upwind_drift > 0.0 and step_size > 0.0:
+        upwind = obs.wind_direction + math.pi
+        ratio = min(upwind_drift / step_size, 1.0)
+        vx = math.cos(crosswind) + ratio * math.cos(upwind)
+        vy = math.sin(crosswind) + ratio * math.sin(upwind)
+        crosswind = math.atan2(vy, vx)
+
+    for dth in (0.0, 0.4, -0.4, 0.8, -0.8, 1.2, -1.2):
+        th = crosswind + dth
+        x = obs.x + step_size * math.cos(th)
+        y = obs.y + step_size * math.sin(th)
+        if obs.map.is_free(x, y):
+            return x, y, th
+    return obs.x, obs.y, crosswind

--- a/gsl_bench/gsl_bench/agents/adsm_agent.py
+++ b/gsl_bench/gsl_bench/agents/adsm_agent.py
@@ -1,0 +1,79 @@
+"""Faithful continuous-motion ADSM adapter backed by the C++ decision engine."""
+from __future__ import annotations
+
+from typing import Optional
+
+from gsl_bench.agent import GSLAgent, Observation, ScenarioInfo, Waypoint
+
+try:
+    import adsm_core_py
+except ImportError as exc:  # give a useful error instead of a mysterious agent load failure
+    raise ImportError(
+        'ADSM requires the adsm C++ package. Build and source the workspace with '
+        '`colcon build --packages-select adsm gsl_bench`.') from exc
+
+
+class AdsmAgent(GSLAgent):
+    motion_mode = 'continuous'
+    decision_rate_hz = 1.0
+    max_goal_distance = 3.0
+    required_pose_source = 'tf'
+    required_map_source = 'slam'
+    required_motion = 'nav2'
+    required_nav_profile = 'faithful'
+
+    _CONFIG_KEYS = (
+        'k1', 'random_sample_r', 'goal_cluster_num', 'obs_r',
+        'goal_reach_th', 'resample_time_th', 'gas_high_th', 'gas_low_th',
+        'sensor_window_length', 'frontier_search_th', 'rrt_max_iter',
+        'rrt_max_r', 'rrt_min_r', 'rrt_step_size', 'stuck_duration_th',
+    )
+
+    def __init__(self, config=None):
+        raw = dict(config or {})
+        cfg = adsm_core_py.Config()
+        for key in self._CONFIG_KEYS:
+            if key in raw:
+                setattr(cfg, key, raw[key])
+        self._requested_seed = raw.get('seed')
+        self._engine = adsm_core_py.Engine(cfg)
+        self._seed: Optional[int] = None
+        self._latest: Optional[Observation] = None
+        self._last_decision = None
+
+    def reset(self, scenario: ScenarioInfo) -> None:
+        del scenario
+        self._seed = int(self._engine.reset(self._requested_seed))
+        self._latest = None
+        self._last_decision = None
+
+    def observe(self, obs: Observation) -> None:
+        self._latest = obs
+
+    def act(self) -> Waypoint:
+        if self._latest is None:
+            raise RuntimeError('act() called before observe()')
+        o = self._latest
+        m = o.map
+        self._last_decision = self._engine.step(
+            o.x, o.y, o.theta, o.gas_ppm, o.wind_speed, o.wind_direction,
+            o.sim_time, m.grid, m.resolution, m.origin_x, m.origin_y)
+        # The paper's move_base goal used identity orientation (world yaw 0).
+        return Waypoint(self._last_decision.x, self._last_decision.y, theta=0.0)
+
+    def metadata(self) -> dict:
+        out = {
+            'implementation': 'adsm_core_py',
+            'upstream': 'mwanggh/An-adaptive-robot-search-algorithm',
+            'seed': self._seed,
+            'sensor_adaptation': 'PID',
+        }
+        if self._last_decision is not None:
+            out.update({
+                'iteration': self._last_decision.iteration,
+                'goal_type': self._last_decision.goal_type,
+                'gas_hit': self._last_decision.gas_hit,
+                'epi_size': self._last_decision.epi_size,
+                'epr_size': self._last_decision.epr_size,
+            })
+        return out

--- a/gsl_bench/gsl_bench/agents/gpulaika_agent.py
+++ b/gsl_bench/gsl_bench/agents/gpulaika_agent.py
@@ -1,0 +1,136 @@
+"""gpulaika — the flagship baseline: a PPO policy (dual backbone, heading-frame
+lidar, local point-wind) trained on GADEN and deployed under Nav2 drive.
+
+This is an ADAPTER, not a reimplementation: the observation builder, the checkpoint
+loader and the action->target conversion are imported from gaden_transfer, so there
+is exactly one source of truth for the 107-dim observation. Reimplementing any of it
+here is how train/deploy drift gets reintroduced.
+
+Its validated recipe (run_escape_7x5.sh): Nav2 drive, escape ON, drive_timeout 30,
+nav_goal_tolerance 0.10, max_steps 600.
+"""
+import os
+import sys
+
+import numpy as np
+import torch
+
+_SRC_BASE = '/home/efe/ros2_ws/src/base'
+if _SRC_BASE not in sys.path:
+    sys.path.insert(0, _SRC_BASE)
+
+from gsl_bench.agent import GSLAgent, Observation, ScenarioInfo, Waypoint
+
+
+class GpulaikaAgent(GSLAgent):
+
+    def __init__(self, config=None):
+        cfg = config or {}
+        self.checkpoint = cfg.get('checkpoint', '')
+        self.arch = cfg.get('arch', 'dual')
+        self.device = torch.device(cfg.get('device', 'cpu'))
+        self.wind_csv = cfg.get('wind_file', '')
+        self.lidar_frame = cfg.get('lidar_frame', 'heading')  # gpulaika is heading-frame
+        # The observation builder reads this at construction time, and the policy was
+        # trained on live local wind, not the episode-mean polar wind.
+        os.environ['OSL_LOCAL_WIND_OBS'] = str(cfg.get('local_wind_obs', 1))
+        if not self.checkpoint or not os.path.isfile(self.checkpoint):
+            raise FileNotFoundError(f'gpulaika checkpoint not found: {self.checkpoint!r}')
+        self._builder = None
+        self._latest = None
+        self._step = 0
+
+    def initialize(self) -> None:
+        from gaden_transfer.gaden_transfer_lidar.gaden_rl_node import (
+            _load_agent, _load_run_config,
+        )
+        run_cfg = _load_run_config(self.checkpoint)
+        self.model = _load_agent(self.checkpoint, self.arch, self.device, run_cfg)
+        n = sum(p.numel() for p in self.model.parameters())
+        print(f'[gpulaika] loaded {os.path.basename(self.checkpoint)} '
+              f'({n:,} parameters, arch={self.arch})', flush=True)
+
+    def reset(self, scenario: ScenarioInfo) -> None:
+        from gaden_transfer.gaden_transfer_lidar.obs_builder import ObservationBuilder
+        self._builder = ObservationBuilder(
+            scenario.map.width_m, scenario.map.height_m,
+            lidar_frame=self.lidar_frame,
+            drive_mode=True,          # the harness always drives physically
+        )
+        if not self.wind_csv:
+            raise ValueError(
+                'gpulaika needs wind_file (the scenario wind CSV) — the observation '
+                'builder returns None until the wind is locked. episode_runner injects '
+                'it automatically; pass it in the agent config when running by hand.')
+        self._builder.load_wind_from_file(self.wind_csv)
+        self._step = 0
+        # Training normalizes position/gas-history in a corner-origin WORLD frame
+        # (world_to_grid = floor(x/res), no offset → robot_pos in [0, map_size]),
+        # verified against the training env's _build_observation. Ground-truth
+        # deploy already matches this. Under SLAM/TF, obs.x/y are in the SLAM map
+        # frame (anchored near start, goes negative) — the position feature clips
+        # to ~0 and the gas-history deltas scale wrong. Capture the SLAM→world
+        # offset on the first observe() from the KNOWN world start pose. In
+        # ground-truth mode obs≈start at step 0, so the offset is ~0 (a no-op).
+        self._true_start_x = scenario.start_x
+        self._true_start_y = scenario.start_y
+        self._world_offset = None
+
+    def observe(self, obs: Observation) -> None:
+        b = self._builder
+        if self._world_offset is None:
+            self._world_offset = (self._true_start_x - obs.x,
+                                  self._true_start_y - obs.y)
+        b.robot_x = obs.x + self._world_offset[0]
+        b.robot_y = obs.y + self._world_offset[1]
+        b.robot_theta = obs.theta
+        b.update_gas(obs.gas_ppm)
+        b.update_live_wind(obs.wind_speed, obs.wind_direction)
+        if obs.lidar_msg is not None:
+            b.update_lidar(obs.lidar_msg)
+        else:
+            # Off-ROS fallback: the builder wants normalised sensor-frame rays.
+            b.lidar_norm = np.clip(
+                obs.lidar / max(obs.lidar_max_range, 1e-6), 0.0, 1.0).astype(np.float32)
+        # Training appends one gas-history entry per env.step(); step 0 is already
+        # seeded by the first gas callback, so recording it again would double it.
+        if self._step > 0:
+            b.record_step()
+        self._latest = obs
+
+    def act(self) -> Waypoint:
+        from reinforcement_learning import config as cfg
+        from gaden_transfer.gaden_transfer_lidar.gaden_rl_node import _action_to_target
+
+        vec = self._builder.build()
+        if vec is None:
+            # Sensors not all in yet — hold position; the harness will step again.
+            return Waypoint(self._latest.x, self._latest.y)
+        vec = np.clip(vec, 0.0, 1.0)
+        # Verify the position feature (dims 102,103) is a sane in-frame [0,1]
+        # value, not clipped to a boundary — printed to node.log at a low rate.
+        if self._step % 100 == 0:
+            print(f'[gpulaika] step {self._step}: world_pos=('
+                  f'{self._builder.robot_x:.2f},{self._builder.robot_y:.2f}) '
+                  f'pos_feat=({vec[102]:.3f},{vec[103]:.3f})', flush=True)
+
+        t = torch.tensor(vec, dtype=torch.float32, device=self.device).unsqueeze(0)
+        with torch.no_grad():
+            if self.arch == 'dual':
+                enc = self.model._encode_shared(t)
+                action = self.model._actor_dist(enc).mean      # deterministic
+            else:
+                action, _, _, _ = self.model.get_action_and_value(t)
+        a = action.cpu().numpy().flatten()
+
+        tx, ty, theta = _action_to_target(
+            self._latest.x, self._latest.y, a, self.arch, cfg.STEP_SIZE)
+
+        # Load-bearing for heading-frame checkpoints: ray 0 of the NEXT observation
+        # must align with the direction just commanded.
+        self._builder.last_action_theta = float(theta)
+        self._step += 1
+        return Waypoint(tx, ty, theta=theta)
+
+    def name(self) -> str:
+        return 'gpulaika'

--- a/gsl_bench/gsl_bench/agents/random_walk.py
+++ b/gsl_bench/gsl_bench/agents/random_walk.py
@@ -1,0 +1,26 @@
+"""The docs example: a complete agent in ~20 lines."""
+import math
+import random
+
+from gsl_bench.agent import GSLAgent, Observation, Waypoint
+
+
+class RandomWalkAgent(GSLAgent):
+    """Pick a random free direction, step 0.5 m."""
+
+    def __init__(self, config=None):
+        self.rng = random.Random((config or {}).get('seed', 0))
+        self.step_size = float((config or {}).get('step_size', 0.5))
+        self.obs = None
+
+    def observe(self, obs: Observation) -> None:
+        self.obs = obs
+
+    def act(self) -> Waypoint:
+        for _ in range(20):                       # rejection-sample a free target
+            th = self.rng.uniform(-math.pi, math.pi)
+            x = self.obs.x + self.step_size * math.cos(th)
+            y = self.obs.y + self.step_size * math.sin(th)
+            if self.obs.map.is_free(x, y):
+                return Waypoint(x, y, theta=th)
+        return Waypoint(self.obs.x, self.obs.y)   # boxed in: stay

--- a/gsl_bench/gsl_bench/agents/surge_cast.py
+++ b/gsl_bench/gsl_bench/agents/surge_cast.py
@@ -1,0 +1,127 @@
+"""Moth-inspired reactive chemotaxis (Kuwana/Cardé & Willis silkworm-moth model).
+
+Three states, switched purely on the latest gas reading:
+  SURGE  - gas_ppm > gas_threshold: drive straight upwind.
+  CAST   - lost the hit: crosswind zigzag (shared with ZigzagAgent), amplitude
+           growing each leg, trying to re-cross the plume.
+  SPIRAL - CAST failed to reacquire for lost_steps_to_spiral steps: widen into
+           an outward spiral around the point the plume was lost, until any
+           whiff is re-detected.
+Re-detecting gas at any point drops straight back to SURGE.
+"""
+import math
+
+from gsl_bench.agent import GSLAgent, Observation, Waypoint
+from gsl_bench.agents._casting import crosswind_step
+
+SURGE, CAST, SPIRAL = 'SURGE', 'CAST', 'SPIRAL'
+
+
+class SurgeCastAgent(GSLAgent):
+
+    def __init__(self, config=None):
+        cfg = config or {}
+        self.gas_threshold = float(cfg.get('gas_threshold', 50.0))
+        self.step_size = float(cfg.get('step_size', 0.5))
+        self.leg_length0 = float(cfg.get('leg_length', 1.0))
+        self.amplitude_growth = float(cfg.get('amplitude_growth', 0.3))
+        self.lost_steps_to_spiral = int(cfg.get('lost_steps_to_spiral', 40))
+        self.spiral_growth = float(cfg.get('spiral_growth', 0.15))
+        self.obs = None
+        self._reset_state()
+
+    def _reset_state(self):
+        self.state = SURGE
+        self.side = 1
+        self.leg_length = self.leg_length0
+        self.leg_dist = 0.0
+        self.steps_since_detect = 0
+        self.spiral_cx = None
+        self.spiral_cy = None
+        self.spiral_angle = 0.0
+        self.spiral_radius = self.step_size
+
+    def reset(self, scenario) -> None:
+        self._reset_state()
+
+    def observe(self, obs: Observation) -> None:
+        self.obs = obs
+
+    def act(self) -> Waypoint:
+        obs = self.obs
+        if obs.gas_ppm > self.gas_threshold and obs.wind_speed > 1e-3:
+            self._enter_surge()
+            return self._surge()
+
+        self.steps_since_detect += 1
+
+        if self.steps_since_detect > self.lost_steps_to_spiral:
+            if self.state != SPIRAL:
+                self._enter_spiral()
+            return self._spiral()
+
+        if self.state != CAST:
+            self._enter_cast()
+        return self._cast()
+
+    # ------------------------------------------------------------------
+    # State transitions
+    # ------------------------------------------------------------------
+
+    def _enter_surge(self):
+        self.state = SURGE
+        self.steps_since_detect = 0
+        self.leg_length = self.leg_length0
+        self.leg_dist = 0.0
+
+    def _enter_cast(self):
+        self.state = CAST
+        self.leg_length = self.leg_length0
+        self.leg_dist = 0.0
+
+    def _enter_spiral(self):
+        self.state = SPIRAL
+        self.spiral_cx, self.spiral_cy = self.obs.x, self.obs.y
+        self.spiral_angle = 0.0
+        self.spiral_radius = self.step_size
+
+    # ------------------------------------------------------------------
+    # Per-state motion
+    # ------------------------------------------------------------------
+
+    def _surge(self) -> Waypoint:
+        upwind = self.obs.wind_direction + math.pi
+        for dth in (0.0, 0.4, -0.4, 0.8, -0.8, 1.2, -1.2):
+            th = upwind + dth
+            x = self.obs.x + self.step_size * math.cos(th)
+            y = self.obs.y + self.step_size * math.sin(th)
+            if self.obs.map.is_free(x, y):
+                return Waypoint(x, y, theta=th)
+        return Waypoint(self.obs.x, self.obs.y)
+
+    def _cast(self) -> Waypoint:
+        x, y, th = crosswind_step(self.obs, self.side, self.step_size)
+        self.leg_dist += self.step_size
+        if self.leg_dist >= self.leg_length:
+            self.side *= -1
+            self.leg_dist = 0.0
+            self.leg_length += self.amplitude_growth
+        return Waypoint(x, y, theta=th)
+
+    def _spiral(self) -> Waypoint:
+        """Archimedean spiral about the point the plume was lost; radius grows
+        a fixed amount each full revolution."""
+        d_theta = self.step_size / max(self.spiral_radius, 0.1)
+        self.spiral_angle += d_theta
+        if self.spiral_angle >= 2 * math.pi:
+            self.spiral_angle -= 2 * math.pi
+            self.spiral_radius += self.spiral_growth
+
+        th = self.spiral_angle
+        for r in (self.spiral_radius, self.spiral_radius + self.spiral_growth,
+                  self.spiral_radius + 2 * self.spiral_growth):
+            x = self.spiral_cx + r * math.cos(th)
+            y = self.spiral_cy + r * math.sin(th)
+            if self.obs.map.is_free(x, y):
+                return Waypoint(x, y, theta=th)
+        return Waypoint(self.obs.x, self.obs.y)

--- a/gsl_bench/gsl_bench/agents/upwind_greedy.py
+++ b/gsl_bench/gsl_bench/agents/upwind_greedy.py
@@ -1,0 +1,41 @@
+"""Classical sanity baseline: surge upwind on a gas hit, random-walk otherwise.
+
+The anemometer's wind_direction points DOWNWIND (the direction the gas travels),
+so the source lies at wind_direction + pi.
+"""
+import math
+import random
+
+from gsl_bench.agent import GSLAgent, Observation, Waypoint
+
+
+class UpwindGreedyAgent(GSLAgent):
+
+    def __init__(self, config=None):
+        cfg = config or {}
+        self.rng = random.Random(cfg.get('seed', 0))
+        self.gas_threshold = float(cfg.get('gas_threshold', 50.0))
+        self.step_size = float(cfg.get('step_size', 0.5))
+        self.obs = None
+
+    def observe(self, obs: Observation) -> None:
+        self.obs = obs
+
+    def act(self) -> Waypoint:
+        if self.obs.gas_ppm > self.gas_threshold and self.obs.wind_speed > 1e-3:
+            upwind = self.obs.wind_direction + math.pi
+            # Fan out around the upwind bearing so a blocked surge still makes progress.
+            for dth in (0.0, 0.4, -0.4, 0.8, -0.8, 1.2, -1.2):
+                th = upwind + dth
+                x = self.obs.x + self.step_size * math.cos(th)
+                y = self.obs.y + self.step_size * math.sin(th)
+                if self.obs.map.is_free(x, y):
+                    return Waypoint(x, y, theta=th)
+
+        for _ in range(20):                        # casting: no gas (or boxed in)
+            th = self.rng.uniform(-math.pi, math.pi)
+            x = self.obs.x + self.step_size * math.cos(th)
+            y = self.obs.y + self.step_size * math.sin(th)
+            if self.obs.map.is_free(x, y):
+                return Waypoint(x, y, theta=th)
+        return Waypoint(self.obs.x, self.obs.y)

--- a/gsl_bench/gsl_bench/agents/zigzag.py
+++ b/gsl_bench/gsl_bench/agents/zigzag.py
@@ -1,0 +1,45 @@
+"""Open-loop crosswind sweep with a slow upwind drift.
+
+Gas-blind precursor to surge-cast's CAST state: turns happen on a fixed
+crosswind-distance schedule, never on gas readings.
+"""
+from gsl_bench.agent import GSLAgent, Observation, Waypoint
+from gsl_bench.agents._casting import crosswind_step
+from gsl_bench.agents.random_walk import RandomWalkAgent
+
+
+class ZigzagAgent(GSLAgent):
+
+    def __init__(self, config=None):
+        cfg = config or {}
+        self.step_size = float(cfg.get('step_size', 0.5))
+        self.leg_length = float(cfg.get('leg_length', 2.0))
+        self.amplitude_growth = float(cfg.get('amplitude_growth', 0.0))
+        self.upwind_drift = float(cfg.get('upwind_drift', 0.15))
+        self._fallback = RandomWalkAgent(cfg)   # no wind vector -> can't zigzag
+        self.side = 1
+        self.leg_dist = 0.0
+        self.obs = None
+
+    def reset(self, scenario) -> None:
+        self.side = 1
+        self.leg_dist = 0.0
+
+    def observe(self, obs: Observation) -> None:
+        self.obs = obs
+        self._fallback.observe(obs)
+
+    def act(self) -> Waypoint:
+        if self.obs.wind_speed <= 1e-3:
+            return self._fallback.act()
+
+        x, y, th = crosswind_step(
+            self.obs, self.side, self.step_size, self.upwind_drift)
+
+        self.leg_dist += self.step_size
+        if self.leg_dist >= self.leg_length:
+            self.side *= -1
+            self.leg_dist = 0.0
+            self.leg_length += self.amplitude_growth
+
+        return Waypoint(x, y, theta=th)

--- a/gsl_bench/gsl_bench/eval/episode_runner.py
+++ b/gsl_bench/gsl_bench/eval/episode_runner.py
@@ -1,0 +1,884 @@
+"""gsl_bench eval — the batch runner. One Python port of the bash drivers.
+
+    ros2 run gsl_bench eval --agent gpulaika --suite nav7 --runs 5 --escape
+
+Owns: process-group isolation, headless display, bake-if-needed, the install-tree
+patches, env launch + ground-truth wait, the runner node, wall timeouts, cleanup,
+and the aggregate report. Everything that used to be copy-pasted between three
+bash scripts and drifted.
+"""
+import argparse
+import atexit
+import filecmp
+import json
+import os
+import re
+import shutil
+import signal
+import subprocess
+import sys
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import yaml
+
+from gsl_bench.eval import metrics, report, scenario_paths, suites
+
+TUNED_NAV2_PARAMS = Path(
+    '/home/efe/ros2_ws/src/base/gaden_config/navigation_config/nav2_params.yaml')
+
+BOLD, DIM, CYAN, GREEN, YELLOW, RED, RESET = (
+    '\033[1m', '\033[2m', '\033[36m', '\033[32m', '\033[33m', '\033[31m', '\033[0m')
+
+_XVFB_PROC: Optional[subprocess.Popen] = None
+_LIVE_PROCS: List[subprocess.Popen] = []   # launch processes whose trees we must reap
+_CLEANED = False
+
+
+# ---------------------------------------------------------------------------
+# Process hygiene
+# ---------------------------------------------------------------------------
+
+def reexec_under_setsid():
+    """Re-exec in a fresh session so cleanup is pgid-scoped.
+
+    Everything we spawn (ros2 launch, the node, Xvfb and their whole subtrees)
+    inherits this pgid, so kill_ros can kill by pgid instead of by name — which is
+    load-bearing when several jobs are packed on one host: a name-based
+    `pkill -f "ros2 run"` would take out a sibling job's processes too.
+
+    `setsid -w` is required: plain `setsid cmd` forks and exits immediately, so the
+    parent would think the sweep finished in a second while it ran on detached.
+    """
+    if os.environ.get('GSLB_SETSID_DONE'):
+        return
+    os.environ['GSLB_SETSID_DONE'] = '1'
+    os.execvp('setsid', ['setsid', '-w', sys.executable, '-u'] + sys.argv)
+
+
+# A ROS node binary we are allowed to reap when it is on OUR domain. Deliberately
+# an allowlist of executable paths, not a loose name match: `pkill -f ros` on a
+# shared host kills sibling jobs.
+_ROS_BIN = re.compile(
+    r'/opt/ros/[^/]+/lib/|/install/(gaden|basic_sim|nav2|olfaction|gsl_bench/lib/gsl_bench/runner_node)'
+    r'|basic_sim|gaden_|ros2cli\.daemon')
+
+
+def _descendants(root_pid: int) -> List[int]:
+    """Every live descendant of root_pid, deepest first.
+
+    Must be called while root_pid is still ALIVE. `ros2 launch` starts each node with
+    its own session (start_new_session), so those nodes are NOT in our process group
+    and a pgid-scoped kill structurally cannot reach them — kill the launch parent
+    first and they simply reparent to init and keep publishing. That is the zombie
+    cross-talk that poisoned whole sweeps: an orphan from run N republishing on a
+    reused ROS_DOMAIN_ID in run N+1. So walk the tree before touching the parent.
+    """
+    ps = subprocess.run(['ps', '-eo', 'pid=,ppid='],
+                        capture_output=True, text=True).stdout
+    children = {}
+    for line in ps.splitlines():
+        try:
+            pid, ppid = (int(v) for v in line.split())
+        except ValueError:
+            continue
+        children.setdefault(ppid, []).append(pid)
+
+    out, stack = [], [root_pid]
+    while stack:
+        pid = stack.pop()
+        for c in children.get(pid, []):
+            out.append(c)
+            stack.append(c)
+    return list(reversed(out))
+
+
+def kill_tree(proc: Optional[subprocess.Popen]):
+    """Kill a launch process and its whole (multi-session) descendant tree."""
+    if proc is None or proc.poll() is not None:
+        pids = []
+    else:
+        pids = _descendants(proc.pid)
+    for pid in pids:
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+    if proc is not None and proc.poll() is None:
+        try:
+            proc.kill()
+        except OSError:
+            pass
+
+
+def reap_domain(domain: Optional[str]) -> int:
+    """Backstop: kill leftover ROS nodes that are on OUR ROS_DOMAIN_ID.
+
+    Catches orphans a previous crashed sweep left behind. Domain-scoped by reading
+    each process's own environ, so a co-resident job on a different domain is never
+    touched — unlike a name-based pkill.
+    """
+    if not domain:
+        return 0
+    me, killed = os.getpid(), 0
+    needle = f'ROS_DOMAIN_ID={domain}'.encode()
+    for p in Path('/proc').iterdir():
+        if not p.name.isdigit():
+            continue
+        pid = int(p.name)
+        if pid == me:
+            continue
+        try:
+            if needle not in (p / 'environ').read_bytes().split(b'\0'):
+                continue
+            cmd = (p / 'cmdline').read_bytes().replace(b'\0', b' ').decode(errors='ignore')
+        except OSError:
+            continue
+        if not _ROS_BIN.search(cmd):
+            continue
+        try:
+            os.kill(pid, signal.SIGKILL)
+            killed += 1
+        except OSError:
+            pass
+    return killed
+
+
+def kill_ros(domain_id: Optional[str] = None):
+    """Kill our own process group, reap any stragglers on our domain, stop the daemon."""
+    domain = domain_id or os.environ.get('ROS_DOMAIN_ID')
+
+    try:
+        my_pgid = os.getpgid(0)
+    except OSError:
+        my_pgid = None
+
+    if my_pgid is not None:
+        out = subprocess.run(['pgrep', '-g', str(my_pgid)],
+                             capture_output=True, text=True).stdout.split()
+        me = os.getpid()
+        for pid_s in out:
+            pid = int(pid_s)
+            if pid == me:
+                continue
+            comm = subprocess.run(['ps', '-o', 'comm=', '-p', pid_s],
+                                  capture_output=True, text=True).stdout.strip()
+            if comm in ('Xvfb', 'tee'):     # our own long-lived infrastructure
+                continue
+            try:
+                os.kill(pid, signal.SIGKILL)
+            except OSError:
+                pass
+
+    reap_domain(domain)
+
+    # The ros2 CLI daemon deliberately daemonizes OUT of our process group, so the
+    # pgid kill above cannot reach it. Left alive it holds FastRTPS shared-memory
+    # ports open and poisons the next job that reuses this ROS_DOMAIN_ID.
+    subprocess.run(['ros2', 'daemon', 'stop'],
+                   capture_output=True, timeout=30, check=False)
+    time.sleep(2)
+
+
+def _cleanup():
+    global _CLEANED
+    if _CLEANED:
+        return
+    _CLEANED = True
+    for proc in list(_LIVE_PROCS):
+        kill_tree(proc)
+    kill_ros()
+    if _XVFB_PROC is not None and _XVFB_PROC.poll() is None:
+        try:
+            _XVFB_PROC.kill()
+        except OSError:
+            pass
+
+
+def start_xvfb() -> int:
+    """Headless display. benchmark_env's stock launch hardcodes xterm + rviz.
+
+    The display number must be unique per packed task: a bare `pkill -9 Xvfb` (or two
+    tasks both on :99) silently kills a co-resident task's display mid-run, and the
+    launch then dies with no error. Key it off ROS_DOMAIN_ID when we have one.
+    """
+    global _XVFB_PROC
+    num = int(os.environ.get('ROS_DOMAIN_ID') or (99 + os.getpid() % 512))
+    subprocess.run(['pkill', '-9', '-f', f'Xvfb :{num} '], check=False)
+    time.sleep(1)
+    log = open(f'/tmp/gslb_xvfb_{num}.log', 'wb')
+    _XVFB_PROC = subprocess.Popen(
+        ['Xvfb', f':{num}', '-screen', '0', '1024x768x24'], stdout=log, stderr=log)
+    os.environ['DISPLAY'] = f':{num}'
+    os.environ['LIBGL_ALWAYS_SOFTWARE'] = '1'
+    os.environ['GALLIUM_DRIVER'] = 'llvmpipe'
+    time.sleep(3)
+    return num
+
+
+# ---------------------------------------------------------------------------
+# Install-tree patches
+# ---------------------------------------------------------------------------
+
+def patch_no_rviz(share: Path) -> bool:
+    """Stop the stock launch from starting rviz2 and xterm.
+
+    rviz2 is not exposed as a launch arg, and even under Xvfb it eats enough CPU on a
+    loaded host that gaden_environment's occupancyMap3D response misses the node's
+    startup timeout — a silent hang, no error. Patches the INSTALLED copy only.
+    """
+    f = share / 'launch' / 'main_simbot_launch.py'
+    if not f.is_file():
+        return False
+    text = f.read_text()
+    orig = text
+    text = text.replace('"use_rviz": "True"', '"use_rviz": "False"')
+    text = re.sub(r'\s*prefix\s*=\s*[\'"]xterm -hold -e[\'"]\s*,', '', text)
+    if text == orig:
+        return False
+    try:
+        f.write_text(text)     # read-only install tree (enroot/Pyxis) -> skip, Xvfb covers us
+        return True
+    except OSError:
+        return False
+
+
+def patch_nav2_params(share: Path) -> bool:
+    """Install the tuned nav2 params (no RotateToGoal critic).
+
+    Stock benchmark_env ships the untuned default, which wedges the robot at walls
+    under Nav2 drive.
+    """
+    target = share / 'navigation_config' / 'nav2_params.yaml'
+    if not TUNED_NAV2_PARAMS.is_file() or not target.parent.is_dir():
+        return False
+    if target.is_file() and filecmp.cmp(TUNED_NAV2_PARAMS, target, shallow=False):
+        return False           # already identical (e.g. baked into a container image)
+    try:
+        shutil.copy(TUNED_NAV2_PARAMS, target)
+        return True
+    except OSError:
+        return False
+
+
+def patch_lidar_config(scenario: str) -> bool:
+    """360 deg / 72 rays / 3 m — what every checkpoint here was trained against.
+
+    MUST run AFTER preproc: preproc regenerates BasicSimScene.yaml from empty_point.
+    """
+    f = scenario_paths.basic_sim_scene(scenario)
+    if not f.is_file():
+        return False
+    text = f.read_text()
+    if re.search(r'maxAngleRad:\s*6\.2832', text):
+        return False
+    for pat, sub in [
+        (r'minAngleRad:\s*\S+', 'minAngleRad: 0.0'),
+        (r'maxAngleRad:\s*\S+', 'maxAngleRad: 6.2832  # 2pi — full 360 deg'),
+        (r'angleResolutionRad:\s*\S+', 'angleResolutionRad: 0.08727  # 2pi / 72'),
+        (r'maxDistance:\s*\S+', 'maxDistance: 3.0  # matches LIDAR_MAX_RANGE'),
+    ]:
+        text = re.sub(pat, sub, text, count=1)
+    try:
+        f.write_text(text)
+        return True
+    except OSError:
+        return False
+
+
+def patch_playback_loop(scenario: str, sim: str) -> bool:
+    """Make gas playback loop instead of running off the end of the bake.
+
+    Every scenario ships loop:false, so a long episode outlasts the baked iterations
+    and spams "File ... does not exist!" forever. Recomputed from the ACTUAL result
+    dir each run so it self-heals after a re-bake. Loops back to
+    playback_initial_iteration (already mature gas), not 0, so there is no
+    gas-buildup discontinuity.
+    """
+    scene = scenario_paths.scene1_yaml(scenario)
+    rdir = scenario_paths.result_dir(scenario, sim)
+    if not scene.is_file() or not rdir.is_dir():
+        return False
+    text = scene.read_text()
+    m = re.search(r'playback_initial_iteration:\s*(\d+)', text)
+    if not m:
+        return False
+    initial = int(m.group(1))
+    iters = [int(mm.group(1)) for f in rdir.iterdir()
+             if (mm := re.match(r'iteration_(\d+)$', f.name))]
+    if not iters:
+        return False
+    max_iter = max(iters)
+    if max_iter <= initial:
+        return False
+    block = f'playback_loop:\n  loop: true\n  from: {initial}\n  to: {max_iter}'
+    new_text, n = re.subn(
+        r'playback_loop:\s*\n\s*loop:\s*\S+\s*\n\s*from:\s*\d+\s*\n\s*to:\s*\d+',
+        block, text)
+    if not n:
+        return False
+    try:
+        scene.write_text(new_text)
+        return True
+    except OSError:
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Baking
+# ---------------------------------------------------------------------------
+
+def is_baked(scenario: str, sim: str) -> bool:
+    """Baked iff result/ is non-empty AND newer than sim.yaml and config.yaml."""
+    rdir = scenario_paths.result_dir(scenario, sim)
+    if not rdir.is_dir():
+        return False
+    files = list(rdir.iterdir())
+    if not files:
+        return False
+    newest = max(f.stat().st_mtime for f in files)
+    cdir = scenario_paths.config_dir(scenario)
+    for cfg in (cdir / 'simulations' / sim / 'sim.yaml', cdir / 'config.yaml'):
+        if cfg.is_file() and cfg.stat().st_mtime > newest:
+            return False
+    return True
+
+
+def bake_if_needed(scenario: str, sim: str, skip: bool) -> bool:
+    if skip or is_baked(scenario, sim):
+        return True
+    print(f'  {YELLOW}Baking gas{RESET} (missing or stale) — this is slow...')
+    for launch in ('gaden_preproc_launch.py', 'gaden_sim_launch.py'):
+        r = subprocess.run(
+            ['ros2', 'launch', 'benchmark_env', launch,
+             f'scenario:={scenario}', f'simulation:={sim}'],
+            capture_output=True, text=True)
+        if r.returncode != 0:
+            print(f'  {RED}{launch} failed (rc={r.returncode}){RESET}')
+            return False
+    return True
+
+
+# ---------------------------------------------------------------------------
+# One run
+# ---------------------------------------------------------------------------
+
+def wait_for_pose(ns: str, timeout_s: float = 120.0) -> bool:
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            r = subprocess.run(
+                ['ros2', 'topic', 'echo', f'/{ns}/ground_truth', '--once'],
+                capture_output=True, text=True, timeout=10, check=False)
+        except subprocess.TimeoutExpired:
+            # `ros2 topic echo` itself can hang past its own timeout when the
+            # graph is mid-bringup — treat like an empty response and keep
+            # retrying instead of letting this blow up the whole sweep.
+            continue
+        if 'header' in r.stdout:
+            return True
+        time.sleep(2)
+    return False
+
+
+def _fmt(v) -> str:
+    """ROS rejects '3' for a DOUBLE parameter — whole numbers must carry a decimal."""
+    if isinstance(v, bool):
+        return 'true' if v else 'false'
+    if isinstance(v, float):
+        return repr(float(v))
+    return str(v)
+
+
+def write_stub_result(path: Path, scenario: str, sim: str, agent: str, status: str,
+                      source, start, wall_s: float, harness: dict):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, 'w') as f:
+        json.dump({
+            'schema': 1, 'scenario': scenario, 'sim': sim, 'agent': agent,
+            'agent_config': {}, 'status': status, 'success': False, 'steps': 0,
+            'sim_time_s': None, 'wall_time_s': round(wall_s, 1),
+            'travel_distance_m': None, 'final_distance_m': None,
+            'source': list(source), 'start': list(start),
+            'escapes': 0, 'clamped_steps': 0, 'drive_timeouts': 0,
+            'harness': harness,
+            'timestamp': datetime.now().isoformat(timespec='seconds'),
+        }, f, indent=2)
+
+
+def realistic_share() -> Optional[Path]:
+    try:
+        prefix = subprocess.run(
+            ['ros2', 'pkg', 'prefix', 'benchmark_env_realistic'],
+            capture_output=True, text=True, check=True).stdout.strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    d = Path(prefix) / 'share' / 'benchmark_env_realistic'
+    return d if d.is_dir() else None
+
+
+def start_visual(scenario: str, start, log_dir: Path) -> List[subprocess.Popen]:
+    """Launch the world-align relay + rviz2 for watch mode. Returns their procs."""
+    procs: List[subprocess.Popen] = []
+    yaw = scenario_paths.start_yaw(scenario)
+    align = subprocess.Popen(
+        ['ros2', 'run', 'gsl_bench', 'world_align', '--ros-args',
+         '-p', f'start_x:={_fmt(float(start[0]))}',
+         '-p', f'start_y:={_fmt(float(start[1]))}',
+         '-p', f'yaw:={_fmt(float(yaw))}'],
+        stdout=open(log_dir / 'world_align.log', 'wb'), stderr=subprocess.STDOUT)
+    procs.append(align)
+
+    share = realistic_share()
+    rviz_cfg = share / 'navigation_config' / 'gsl_watch.rviz' if share else None
+    if rviz_cfg and rviz_cfg.is_file():
+        rviz = subprocess.Popen(
+            ['rviz2', '-d', str(rviz_cfg)],
+            stdout=open(log_dir / 'rviz.log', 'wb'), stderr=subprocess.STDOUT)
+        procs.append(rviz)
+        print(f'  {BOLD}rviz{RESET}: {rviz_cfg.name}  (align start=({start[0]:.1f},'
+              f'{start[1]:.1f}) yaw={yaw:.2f})')
+    else:
+        print(f'  {YELLOW}gsl_watch.rviz not found — align node only{RESET}')
+    for p in procs:
+        _LIVE_PROCS.append(p)
+    return procs
+
+
+def run_one(args, scenario: str, sim: str, run_dir: Path, agent_cfg_path: Optional[Path],
+            source, start, harness: dict) -> dict:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    result_file = run_dir / 'result.json'
+    t0 = time.time()
+
+    env_log = open(run_dir / 'env.log', 'wb')
+    launch_pkg = args.launch
+    launch_file = ('realistic_launch.py' if launch_pkg == 'benchmark_env_realistic'
+                   else 'main_simbot_launch.py')
+    launch_cmd = ['ros2', 'launch', launch_pkg, launch_file,
+                  f'scenario:={scenario}', 'configuration:=config1', f'simulation:={sim}',
+                  f'namespace:={args.namespace}']
+    if launch_pkg == 'benchmark_env_realistic':
+        launch_cmd.append(f'motion:={args.motion}')
+        launch_cmd.append(f'nav_profile:={args.nav_profile}')
+        launch_cmd.append(f'lidar_max_range:={_fmt(float(args.lidar_max_range))}')
+        launch_cmd.append(f'wall_outlets:={args.wall_outlets}')
+        # DirectDrive + ground-truth isolation: when the policy runs on
+        # ground-truth pose/service map, DirectDrive must navigate in the same
+        # (world) frame — ground_truth pose topic + the scenario's static
+        # world-frame occupancy.yaml — or the world-frame drive targets would be
+        # misinterpreted in the SLAM frame.
+        if (args.motion == 'directdrive' and args.pose_source == 'ground_truth'):
+            occ_yaml = scenario_paths.occupancy_yaml(scenario)
+            launch_cmd.append('drive_pose_source:=topic')
+            launch_cmd.append(f'drive_map_yaml:={occ_yaml}')
+    env_proc = subprocess.Popen(
+        launch_cmd, stdout=env_log, stderr=subprocess.STDOUT)
+    _LIVE_PROCS.append(env_proc)
+
+    print('  waiting for ground_truth...')
+    if not wait_for_pose(args.namespace):
+        # Never start the agent against a dead env: it would burn the whole
+        # wall-timeout budget before failing, turning a 2-minute abort into a
+        # 30-minute one.
+        print(f'  {RED}env never published ground_truth — aborting run{RESET}')
+        write_stub_result(result_file, scenario, sim, args.agent, 'env_dead',
+                          source, start, time.time() - t0, harness)
+        kill_tree(env_proc)
+        _LIVE_PROCS.remove(env_proc)
+        kill_ros()
+        time.sleep(3)
+        return json.loads(result_file.read_text())
+
+    print('  pose online, starting agent.')
+    time.sleep(3)
+
+    vis_procs: List[subprocess.Popen] = []
+    if getattr(args, 'visual', False):
+        vis_procs = start_visual(scenario, start, run_dir)
+
+    cmd = ['ros2', 'run', 'gsl_bench', 'runner_node', '--ros-args',
+           '-p', f'agent:={args.agent}',
+           '-p', f'scenario_name:={scenario}',
+           '-p', f'sim_name:={sim}',
+           '-p', f'true_source_x:={_fmt(float(source[0]))}',
+           '-p', f'true_source_y:={_fmt(float(source[1]))}',
+           '-p', f'start_x:={_fmt(float(start[0]))}',
+           '-p', f'start_y:={_fmt(float(start[1]))}',
+           '-p', f'max_steps:={int(args.max_steps)}',
+           '-p', f'max_travel_distance_m:={_fmt(float(harness.get("max_travel_distance_m", 0.0)))}',
+           '-p', f'max_sim_time_s:={_fmt(float(harness.get("max_sim_time_s", 0.0)))}',
+           '-p', f'step_delay:={_fmt(float(args.step_delay))}',
+           '-p', f'success_radius:={_fmt(float(args.success_radius))}',
+           '-p', f'nav_goal_tolerance:={_fmt(float(args.nav_goal_tolerance))}',
+           '-p', f'drive_timeout:={_fmt(float(args.drive_timeout))}',
+           '-p', f'max_hop:={_fmt(float(args.max_hop))}',
+           '-p', f'robot_radius:={_fmt(float(args.robot_radius))}',
+            '-p', f'escape:={_fmt(bool(args.escape))}',
+            '-p', f'namespace:={args.namespace}',
+            '-p', f'result_file:={result_file}',
+            '-p', f'pose_source:={args.pose_source}',
+           '-p', f'map_source:={args.map_source}',
+            '-p', f'motion:={args.motion}',
+            '-p', f'nav_profile:={args.nav_profile}',
+            # The whole sim stack (basic_sim /clock, cartographer, Nav2 — see
+            # main_simbot_launch.py and nav2_realistic_launch.py) runs on sim time.
+            # runner_node MUST match, or its goal stamps (get_clock().now()) carry
+            # wall-epoch time while TF is at sim time: the controller then errors
+            # "Transform data too old when converting from map to odom", produces no
+            # motion, and the harness counts the step anyway (0 travel, 600 fake
+            # Nav2 actions). _sim_time()/max_sim_time budgeting is also wall-based
+            # without this. Runner starts after /clock is already flowing.
+            '-p', 'use_sim_time:=true']
+    if agent_cfg_path is not None:
+        cmd += ['-p', f'agent_config:={agent_cfg_path}']
+
+    node_log = open(run_dir / 'node.log', 'wb')
+    node_proc = subprocess.Popen(cmd, stdout=node_log, stderr=subprocess.STDOUT)
+
+    status = 'done'
+    while node_proc.poll() is None:
+        if time.time() - t0 > args.wall_timeout:
+            status = 'wall_timeout'
+            print(f'  {YELLOW}WALL TIMEOUT{RESET} after {time.time() - t0:.0f}s — killing.')
+            node_proc.terminate()
+            time.sleep(2)
+            node_proc.kill()
+            break
+        time.sleep(2)
+
+    wall_s = time.time() - t0
+    if not result_file.is_file():
+        write_stub_result(
+            result_file, scenario, sim, args.agent,
+            'wall_timeout' if status == 'wall_timeout' else 'crashed',
+            source, start, wall_s, harness)
+    else:
+        res = json.loads(result_file.read_text())
+        res['wall_time_s'] = round(wall_s, 1)
+        result_file.write_text(json.dumps(res, indent=2))
+
+    res = json.loads(result_file.read_text())
+    if res.get('success'):
+        print(f'  {GREEN}SUCCESS{RESET}  steps={res["steps"]}  '
+              f'd={res["final_distance_m"]}m  ({wall_s:.0f}s wall)')
+    else:
+        print(f'  {YELLOW}not solved{RESET}  status={res["status"]}  '
+              f'steps={res.get("steps")}  ({wall_s:.0f}s wall)')
+
+    for p in vis_procs:
+        kill_tree(p)
+        if p in _LIVE_PROCS:
+            _LIVE_PROCS.remove(p)
+    # Tree-kill the env FIRST, while the launch parent is still alive and its
+    # (separately-sessioned) nodes are still reachable through it.
+    kill_tree(env_proc)
+    _LIVE_PROCS.remove(env_proc)
+    kill_ros()
+    time.sleep(3)
+    return res
+
+
+def label_success_within_budget(result_file: Path, budget: Optional[dict]) -> None:
+    """Post-hoc relabel a run against the 5x-oracle success budget.
+
+    The runner terminates a run the instant it reaches the source (0.5 m), so its
+    raw `success` really means "reached the source at all" — the robot may have
+    wandered up to 10x the oracle distance getting there. The published metric is
+    stricter: a reach only counts if it was efficient (travel <= 5x oracle). We
+    preserve the raw reach as `reached_source` and overwrite `success` with the
+    budget-gated verdict so metrics/report headline the stricter number.
+
+    Runs with no oracle record (budget is None) keep success == reached_source.
+    """
+    if not result_file.is_file():
+        return
+    try:
+        res = json.loads(result_file.read_text())
+    except (json.JSONDecodeError, OSError):
+        return
+    reached = bool(res.get('success'))
+    res['reached_source'] = reached
+    if budget is not None:
+        res.update(budget)
+        travel = res.get('travel_distance_m')
+        within = (travel is not None
+                  and travel <= budget['success_budget_distance_m'])
+        res['success_within_budget'] = bool(reached and within)
+        res['success'] = res['success_within_budget']
+    else:
+        res['success_within_budget'] = reached
+    result_file.write_text(json.dumps(res, indent=2))
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def parse_args(argv: List[str]):
+    ap = argparse.ArgumentParser(prog='gsl_bench eval')
+    ap.add_argument('--agent', required=True,
+                    help="registered name (random_walk, upwind_greedy, gpulaika) "
+                         "or 'pkg.module:ClassName'")
+    ap.add_argument('--agent-config', type=Path, default=None,
+                    help='YAML handed to the agent constructor')
+    ap.add_argument('--suite', default=None, help='nav7 | all')
+    ap.add_argument('--scenario', default=None,
+                    help='scenario name, or a comma-separated list')
+    ap.add_argument('--runs', type=int, default=5)
+    ap.add_argument('--out', type=Path,
+                    default=Path('/home/efe/ros2_ws/Results'))
+    ap.add_argument('--wall-timeout', type=float, default=1800.0)
+    ap.add_argument('--max-steps', type=int, default=600)
+    ap.add_argument('--oracle-budgets', type=Path, default=None,
+                    help='JSON manifest from `ros2 run gsl_bench oracle` '
+                         '({"<scenario>_<sim>": {"travel_distance_m":.., "sim_time_s":..}}). '
+                         'When set, each scenario is scored against a 5x/10x/20x envelope '
+                         'of its oracle record (see the three --*-budget-multiplier flags), '
+                         'on top of --max-steps.')
+    ap.add_argument('--budget-multiplier', type=float, default=10.0,
+                    help='DISTANCE termination multiplier: the episode is terminated as a '
+                         'failure once travel exceeds this x oracle distance '
+                         '(only with --oracle-budgets)')
+    ap.add_argument('--time-budget-multiplier', type=float, default=20.0,
+                    help='TIME termination multiplier: the episode is terminated as a '
+                         'failure once sim time exceeds this x oracle time '
+                         '(only with --oracle-budgets)')
+    ap.add_argument('--success-budget-multiplier', type=float, default=5.0,
+                    help='SUCCESS labelling multiplier: reaching the source only counts as '
+                         'success_within_budget if travel <= this x oracle distance. The '
+                         'robot keeps running past this up to the termination budget, so '
+                         'reaches between 5x and 10x are recorded but not counted '
+                         '(only with --oracle-budgets)')
+    ap.add_argument('--step-delay', type=float, default=0.5)
+    ap.add_argument('--success-radius', type=float, default=0.5)
+    ap.add_argument('--nav-goal-tolerance', type=float, default=0.10)
+    ap.add_argument('--drive-timeout', type=float, default=30.0)
+    ap.add_argument('--max-hop', type=float, default=1.0)
+    ap.add_argument('--robot-radius', type=float, default=0.25)
+    ap.add_argument('--namespace', default='PioneerP3DX')
+    ap.add_argument('--escape', action='store_true',
+                    help='harness stuck-escape recovery (recorded in every result)')
+    ap.add_argument('--skip-bake', action='store_true')
+    ap.add_argument('--domain-id', type=int, default=None)
+    ap.add_argument('--pose-source', default='ground_truth',
+                    choices=['ground_truth', 'tf'],
+                    help='ground_truth: perfect pose from /ground_truth topic; '
+                         'tf: pose from TF lookup (map -> base_link)')
+    ap.add_argument('--map-source', default='service',
+                    choices=['service', 'slam'],
+                    help='service: ground-truth map from Gaden; '
+                         'slam: incremental map from Cartographer topic')
+    ap.add_argument('--realistic', action='store_true',
+                    help='shortcut for --pose-source tf --map-source slam '
+                         '--launch benchmark_env_realistic')
+    ap.add_argument('--visual', action='store_true',
+                    help='open a live RViz (SLAM map + gas + robot + goal) on the '
+                         'shared VNC display :99 for each run, with the GADEN '
+                         'world<->SLAM map origin fix. Realistic mode only; intended '
+                         'for watching one scenario (--scenario X --runs 1), not '
+                         'headless sweeps')
+    ap.add_argument('--launch', default='benchmark_env',
+                    help='launch package for the environment '
+                         '(benchmark_env or benchmark_env_realistic)')
+    ap.add_argument('--motion', default='nav2', choices=['nav2', 'directdrive'],
+                    help='drive mechanism, benchmark_env_realistic only: nav2 (full '
+                         'Nav2 stack) or directdrive (rotate-then-go A* on the live '
+                         'SLAM map, no Nav2 — bypasses Nav2 planning failures)')
+    ap.add_argument('--nav-profile', default='faithful',
+                    choices=['standard', 'faithful'],
+                    help='benchmark_env_realistic Nav2 parameters. faithful restores '
+                         'the original ROS1 DWA reverse and rotation behavior; ignored '
+                         'when --motion directdrive is selected')
+    ap.add_argument('--lidar-max-range', type=float, default=3.0,
+                    help='benchmark_env_realistic only: BasicSim sensor range in '
+                         'meters. The agent\'s own lidar features stay clipped to '
+                         '3.0 in obs_cache regardless of this value')
+    ap.add_argument('--wall-outlets', default='true', choices=['true', 'false'],
+                    help='benchmark_env_realistic only: mark GADEN outlet cells as '
+                         'occupied in the map the realistic lidar sees, so they map '
+                         'as walls like the ground-truth path (default true)')
+    args = ap.parse_args(argv)
+    if not args.suite and not args.scenario:
+        args.suite = 'nav7'
+    if args.realistic:
+        args.pose_source = 'tf'
+        args.map_source = 'slam'
+        args.launch = 'benchmark_env_realistic'
+    if args.visual and args.launch != 'benchmark_env_realistic':
+        ap.error('--visual needs the SLAM map — pass --realistic')
+    if args.agent == 'adsm':
+        if not args.realistic:
+            ap.error('ADSM currently supports realistic perception only; pass --realistic')
+        if args.escape:
+            ap.error('canonical ADSM requires harness escape to remain disabled')
+        if args.motion != 'nav2':
+            ap.error('ADSM continuous goal updates require --motion nav2')
+        args.nav_profile = 'faithful'
+        args.max_hop = max(args.max_hop, 3.0)
+    return args
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    args = parse_args(argv)
+
+    if args.domain_id is not None:
+        os.environ['ROS_DOMAIN_ID'] = str(args.domain_id)
+    elif not os.environ.get('ROS_DOMAIN_ID'):
+        print(f'{YELLOW}Warning: ROS_DOMAIN_ID unset. Never run two sweeps at once on '
+              f'one host without distinct --domain-id.{RESET}')
+
+    reexec_under_setsid()   # everything below runs in our own session
+
+    atexit.register(_cleanup)
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(1))
+    signal.signal(signal.SIGINT, lambda *_: sys.exit(1))
+
+    scenario_list = ([s.strip() for s in args.scenario.split(',') if s.strip()]
+                     if args.scenario else suites.resolve_suite(args.suite))
+    share = scenario_paths.install_share_dir()
+
+    stamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    agent_tag = re.sub(r'[^A-Za-z0-9_.-]', '_', args.agent)
+    out_root = args.out / f'{agent_tag}_{stamp}'
+    out_root.mkdir(parents=True, exist_ok=True)
+
+    harness = {
+        'success_radius': args.success_radius, 'max_steps': args.max_steps,
+        'step_delay': args.step_delay, 'nav_goal_tolerance': args.nav_goal_tolerance,
+        'drive_timeout': args.drive_timeout, 'escape': bool(args.escape),
+        'max_hop': args.max_hop, 'robot_radius': args.robot_radius,
+        'lidar': '360deg/72ray/3m', 'motion': args.motion,
+        'nav_profile': args.nav_profile,
+        'pose_source': args.pose_source, 'map_source': args.map_source,
+        'launch': args.launch,
+        'lidar_max_range': args.lidar_max_range,
+        'wall_outlets': args.wall_outlets,
+    }
+
+    print(f'\n{BOLD}{CYAN} gsl_bench eval{RESET}')
+    print(f'  agent     : {BOLD}{args.agent}{RESET}')
+    print(f'  scenarios : {len(scenario_list)} x {args.runs} runs = '
+          f'{len(scenario_list) * args.runs}')
+    print(f'  escape    : {"ON" if args.escape else "OFF"}')
+    print(f'  pose      : {BOLD}{args.pose_source}{RESET}  '
+          f'map: {BOLD}{args.map_source}{RESET}  '
+          f'launch: {args.launch}')
+    print(f'  output    : {BOLD}{out_root}{RESET}\n')
+
+    if args.visual:
+        # Watch mode: use the shared VNC display (:99) instead of a private
+        # headless Xvfb, so rviz2 is viewable. watch.sh brings up Xvfb + x11vnc.
+        os.environ['DISPLAY'] = os.environ.get('DISPLAY', ':99')
+        os.environ.setdefault('LIBGL_ALWAYS_SOFTWARE', '1')
+        os.environ.setdefault('GALLIUM_DRIVER', 'llvmpipe')
+        print(f'  {BOLD}visual mode{RESET}: rviz on DISPLAY={os.environ["DISPLAY"]}'
+              f'  (view over VNC :5900)')
+    else:
+        display = start_xvfb()
+        print(f'  {DIM}headless display :{display}{RESET}')
+
+    kill_ros()
+    if patch_no_rviz(share):
+        print(f'  {DIM}patched install launch: no rviz, no xterm{RESET}')
+    if patch_nav2_params(share):
+        print(f'  {DIM}patched install nav2_params: tuned (no RotateToGoal){RESET}')
+    # Start from a clean daemon: a stale graph cache makes `ros2 topic echo --once`
+    # return nothing while the graph underneath is healthy, so every run would look
+    # like "env never started".
+    subprocess.run(['ros2', 'daemon', 'start'], capture_output=True, check=False)
+    time.sleep(2)
+
+    base_cfg = {}
+    if args.agent_config:
+        base_cfg = yaml.safe_load(args.agent_config.read_text()) or {}
+
+    oracle_budgets = {}
+    if args.oracle_budgets:
+        oracle_budgets = json.loads(args.oracle_budgets.read_text())
+        print(f'  {DIM}oracle budgets: {args.oracle_budgets} '
+              f'(x{args.budget_multiplier}){RESET}')
+
+    total = len(scenario_list) * args.runs
+    done = 0
+    for scenario in scenario_list:
+        if not scenario_paths.scenario_dir(scenario).is_dir():
+            print(f'{RED}Unknown scenario: {scenario} — skipping{RESET}')
+            continue
+        sim = scenario_paths.resolve_sim(scenario)
+        print(f'\n{DIM}{"=" * 50}{RESET}\n{BOLD} {scenario}{RESET} ({sim})')
+
+        if not bake_if_needed(scenario, sim, args.skip_bake):
+            print(f'{RED}bake failed — skipping {scenario}{RESET}')
+            continue
+        patch_playback_loop(scenario, sim)   # after the bake: keyed off the result dir
+        patch_lidar_config(scenario)         # after preproc: it regenerates the scene
+        patch_nav2_params(share)
+
+        source = scenario_paths.source_xy(scenario, sim)
+        start = scenario_paths.start_xy(scenario)
+        wind = scenario_paths.wind_csv(scenario)
+        print(f'  source ({source[0]:.2f}, {source[1]:.2f})  '
+              f'start ({start[0]:.2f}, {start[1]:.2f})')
+
+        scen_harness = dict(harness)
+        scen_budget = None
+        if oracle_budgets:
+            rec = oracle_budgets.get(f'{scenario}_{sim}')
+            if rec is None:
+                print(f'  {YELLOW}no oracle record for {scenario}_{sim} — '
+                      f'falling back to max_steps only{RESET}')
+            else:
+                oracle_dist = float(rec['travel_distance_m'])
+                oracle_time = float(rec['sim_time_s'])
+                scen_harness['max_travel_distance_m'] = args.budget_multiplier * oracle_dist
+                scen_harness['max_sim_time_s'] = args.time_budget_multiplier * oracle_time
+                scen_budget = {
+                    'oracle_travel_distance_m': round(oracle_dist, 3),
+                    'oracle_sim_time_s': round(oracle_time, 3),
+                    'success_budget_distance_m': round(
+                        args.success_budget_multiplier * oracle_dist, 3),
+                    'success_budget_multiplier': args.success_budget_multiplier,
+                }
+                print(f'  budget    : success<={scen_budget["success_budget_distance_m"]:.1f}m'
+                      f'  terminate dist<={scen_harness["max_travel_distance_m"]:.1f}m'
+                      f'  time<={scen_harness["max_sim_time_s"]:.1f}s')
+
+        # Per-scenario agent config: the wind CSV is a property of the scenario, not
+        # of the agent, so the runner injects it rather than the user hardcoding it.
+        scen_dir = out_root / f'{scenario}_{sim}'
+        scen_dir.mkdir(parents=True, exist_ok=True)
+        agent_cfg_path = None
+        if base_cfg or wind:
+            cfg = dict(base_cfg)
+            if wind and not cfg.get('wind_file'):
+                cfg['wind_file'] = str(wind)
+            agent_cfg_path = scen_dir / 'agent_config.yaml'
+            agent_cfg_path.write_text(yaml.safe_dump(cfg))
+
+        for i in range(1, args.runs + 1):
+            done += 1
+            print(f'\n{BOLD} [{done}/{total}] {scenario} run {i}/{args.runs}{RESET} '
+                  f'{DIM}{datetime.now():%H:%M:%S}{RESET}')
+            run_dir = scen_dir / f'run_{i}'
+            run_one(args, scenario, sim, run_dir, agent_cfg_path,
+                    source, start, scen_harness)
+            label_success_within_budget(run_dir / 'result.json', scen_budget)
+
+    text = report.write_all(out_root)
+    print('\n' + text)
+    print(f'Results: {BOLD}{out_root}{RESET}')
+
+    runs = metrics.load_runs(out_root)
+    agg = metrics.aggregate(runs)
+    o = agg['overall']
+    print(f"{BOLD}{GREEN}Overall: {o['n_success']}/{o['n']} "
+          f"({o['success_rate'] * 100:.0f}%){RESET}\n")
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/gsl_bench/gsl_bench/eval/metrics.py
+++ b/gsl_bench/gsl_bench/eval/metrics.py
@@ -1,0 +1,134 @@
+"""Per-run result.json -> per-scenario and overall metrics. Pure functions, no ROS.
+
+TT = mean sim_time_s over SUCCESSFUL runs (time-to-source).
+TD = mean travel_distance_m over SUCCESSFUL runs (traveled distance).
+Both are only meaningful over successes: a failed run's time is just the step cap.
+"""
+import json
+import random
+from collections import Counter
+from math import sqrt
+from pathlib import Path
+from statistics import mean, median
+from typing import Dict, List, Optional
+
+# Fixed seed so the same result tree always yields the same CI bands (reports are
+# regenerated and diffed; a non-deterministic bootstrap would churn them).
+_BOOT_SEED = 20260718
+_BOOT_ITERS = 2000
+
+
+def wilson_interval(k: int, n: int, z: float = 1.96):
+    """95% Wilson score interval for a proportion k/n. Robust near 0% / 100%
+    and at small n (5 runs), unlike the normal approximation. Returns (lo, hi)."""
+    if n == 0:
+        return None
+    p = k / n
+    denom = 1 + z * z / n
+    centre = (p + z * z / (2 * n)) / denom
+    half = (z * sqrt(p * (1 - p) / n + z * z / (4 * n * n))) / denom
+    return (round(max(0.0, centre - half), 3), round(min(1.0, centre + half), 3))
+
+
+def bootstrap_ci(vals, iters: int = _BOOT_ITERS):
+    """95% bootstrap percentile CI for the mean of `vals`. Returns (lo, hi), or
+    None when there are too few samples to resample meaningfully (<2)."""
+    vals = [v for v in vals if v is not None]
+    if len(vals) < 2:
+        return None
+    rng = random.Random(_BOOT_SEED)
+    n = len(vals)
+    means = []
+    for _ in range(iters):
+        means.append(sum(vals[rng.randrange(n)] for _ in range(n)) / n)
+    means.sort()
+    lo = means[int(0.025 * iters)]
+    hi = means[int(0.975 * iters)]
+    return (round(lo, 2), round(hi, 2))
+
+
+def load_runs(root: Path) -> List[dict]:
+    runs = []
+    for p in sorted(Path(root).rglob('result.json')):
+        try:
+            with open(p) as f:
+                r = json.load(f)
+            r['_path'] = str(p)
+            runs.append(r)
+        except (json.JSONDecodeError, OSError):
+            continue
+    return runs
+
+
+def _mean(vals) -> Optional[float]:
+    vals = [v for v in vals if v is not None]
+    return round(mean(vals), 2) if vals else None
+
+
+def _median(vals) -> Optional[float]:
+    vals = [v for v in vals if v is not None]
+    return round(median(vals), 2) if vals else None
+
+
+def _summarize(runs: List[dict]) -> dict:
+    # `success` is the budget-gated verdict (reached within 5x oracle distance).
+    # `reached_source` is the raw reach; on older result trees it may be absent,
+    # in which case it defaults to `success` so pre-budget runs still summarize.
+    succ = [r for r in runs if r.get('success')]
+    fail = [r for r in runs if not r.get('success')]
+    n = len(runs)
+    n_reached = sum(1 for r in runs if r.get('reached_source', r.get('success')))
+    steps = [r.get('steps') for r in succ]
+    times = [r.get('sim_time_s') for r in succ]
+    dists = [r.get('travel_distance_m') for r in succ]
+    return {
+        'n': n,
+        'n_success': len(succ),
+        'success_rate': round(len(succ) / n, 3) if n else 0.0,
+        'success_ci': wilson_interval(len(succ), n),
+        'n_reached': n_reached,
+        'reached_rate': round(n_reached / n, 3) if n else 0.0,
+        'reached_ci': wilson_interval(n_reached, n),
+        'mean_steps': _mean(steps),
+        'median_steps': _median(steps),
+        'steps_ci': bootstrap_ci(steps),
+        'mean_time_s': _mean(times),                                        # TT
+        'time_ci': bootstrap_ci(times),
+        'mean_distance_m': _mean(dists),                                    # TD
+        'distance_ci': bootstrap_ci(dists),
+        'mean_final_distance_m_failures': _mean(r.get('final_distance_m') for r in fail),
+        'status_counts': dict(Counter(r.get('status', 'unknown') for r in runs)),
+    }
+
+
+def aggregate(runs: List[dict]) -> Dict[str, dict]:
+    """{'per_scenario': {name: summary}, 'overall': summary, 'harness_mismatch': [...]}"""
+    per_scenario: Dict[str, dict] = {}
+    by_scenario: Dict[str, List[dict]] = {}
+    for r in runs:
+        by_scenario.setdefault(r.get('scenario', '?'), []).append(r)
+    for scen in sorted(by_scenario):
+        per_scenario[scen] = _summarize(by_scenario[scen])
+    return {
+        'per_scenario': per_scenario,
+        'overall': _summarize(runs),
+        'harness_mismatch': harness_mismatch(runs),
+    }
+
+
+def harness_mismatch(runs: List[dict]) -> List[str]:
+    """Keys whose harness setting is not identical across all runs — the fairness guard.
+
+    Comparing methods scored under different success radii, step caps, or with escape
+    on for one and off for another is meaningless, so we make it loud instead of silent.
+    """
+    blocks = [r.get('harness', {}) for r in runs if r.get('harness')]
+    if len(blocks) < 2:
+        return []
+    # These are oracle-derived per-scenario budgets: they are *supposed* to differ
+    # across scenarios, so a difference here is not an unfairness (the multipliers
+    # behind them are what must match, and those live in the run's budget fields).
+    per_scenario = {'max_travel_distance_m', 'max_sim_time_s'}
+    keys = set().union(*(b.keys() for b in blocks)) - per_scenario
+    return sorted(k for k in keys if len({json.dumps(b.get(k), sort_keys=True)
+                                          for b in blocks}) > 1)

--- a/gsl_bench/gsl_bench/eval/oracle.py
+++ b/gsl_bench/gsl_bench/eval/oracle.py
@@ -1,0 +1,965 @@
+"""The oracle runner: one privileged, honest physical drive straight to the
+true source, per scenario. Not a search — it knows the source location (which
+GSLAgent deliberately never exposes to real agents) and drives a single A*
+path to it over the ground-truth occupancy grid, no exploration, no
+uncertainty. What comes back (travel_distance_m, sim_time_s) is meant to be
+multiplied by a budget factor and fed back in as a per-scenario termination
+cap for real agent runs (see episode_runner's --oracle-budgets).
+
+The path is planned ONCE up front (A* over the dilated ground-truth grid,
+simplified to turning points, then resampled to ~--step-size spacing) and
+executed as a chain of deterministic cmd_vel hops — a proportional
+rotate-then-go controller, ported directly from gaden_rl_node.py's
+OSL_DET_DRIVE (`_start_cmdvel_move`/`_cmd_vel_tick`), the same mechanism
+already proven in production to drive short (~0.5m) waypoints without
+wedging. Two things that do NOT work in this deployment and are deliberately
+avoided: (1) sending each hop (or one long goal) as a Nav2 NavigateToPose
+action — Nav2's local controller (DWB) + SimpleProgressChecker aborts every
+~10s on zero net movement at a doorway, and its recovery behaviors then burn
+~150s per hop before giving up, wedging the ENTIRE wall-timeout budget on one
+chokepoint (confirmed on 24/29 scenarios in the first oracle sweep,
+2026-07-18, which used exactly this Nav2-hop mechanism). Driving cmd_vel
+directly has no such recovery/abort loop to get stuck in. (2) aiming each hop
+straight at the source (Euclidean, re-decided per hop, no route memory) walks
+into the same doorway/wall repeatedly — A* avoids that by construction, it
+never proposes a path through occupied cells. Default --launch benchmark_env:
+benchmark_env_realistic doesn't start the occupancy service this needs (see
+--launch help). Reads the true source position from /ground_truth directly —
+this script bypasses the agent abstraction on purpose, real agents never see it.
+
+    ros2 run gsl_bench oracle --suite nav7 --runs 1
+"""
+import argparse
+import atexit
+import heapq
+import json
+import math
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+from typing import List, Optional
+
+import numpy as np
+import rclpy
+from geometry_msgs.msg import PoseWithCovarianceStamped, Twist
+from rclpy.clock import Clock, ClockType
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+from scipy.ndimage import distance_transform_edt
+
+from efe_igdm.mapping.occupancy_grid import (
+    OccupancyGridMap, load_3d_occupancy_grid_from_service,
+)
+from efe_igdm.planning.navigator import Navigator
+
+from gsl_bench.eval import scenario_paths, suites
+from gsl_bench.eval.episode_runner import (
+    BOLD, CYAN, DIM, GREEN, RED, RESET, YELLOW,
+    _LIVE_PROCS, _cleanup, _fmt, bake_if_needed, kill_ros, kill_tree,
+    patch_lidar_config, patch_nav2_params, patch_no_rviz, patch_playback_loop,
+    reexec_under_setsid, start_xvfb, wait_for_pose,
+)
+
+
+class OracleNode(Node):
+    """One episode: plan an A* path start->source over the ground-truth grid,
+    teleport to start, then drive the path as a chain of deterministic cmd_vel
+    hops (rotate-then-go, no Nav2) until within success_radius, recording
+    travel distance / sim time / wall time."""
+
+    def __init__(self, ns: str, start_xy, source_xy, success_radius: float,
+                 wall_timeout: float, result_file: Path,
+                 robot_radius: float = 0.25, step_size: float = 0.5,
+                 det_linear: float = 0.3, det_gain: float = 2.0,
+                 det_arrive_tol: float = 0.15, det_hop_timeout: float = 12.0,
+                 drive_mode: str = 'cmdvel', nav2_goal_tolerance: float = 0.15,
+                 plan_margin: float = 0.30, nav2_stride: float = 1.5,
+                 occupancy_service: str = '/gaden_environment/occupancyMap3D',
+                 occupancy_z_level: int = 5, occupancy_timeout: float = 300.0):
+        super().__init__('gsl_bench_oracle')
+        self._ns = ns
+        self._start_x, self._start_y = start_xy
+        self._source_x, self._source_y = source_xy
+        self._success_radius = success_radius
+        self._wall_timeout = wall_timeout
+        self._result_file = result_file
+        self._robot_radius = robot_radius
+        self._det_linear = det_linear
+        self._det_gain = det_gain
+        self._det_arrive_tol = det_arrive_tol
+        self._det_hop_timeout = det_hop_timeout
+        self._drive_mode = drive_mode
+        self._nav2_goal_tolerance = nav2_goal_tolerance
+        # A* clearance = physical radius + a safety margin, so no planned waypoint
+        # sits TANGENT to a wall. The EDT threshold admits cells exactly
+        # robot_radius from the nearest obstacle; a waypoint there puts the robot
+        # body flush against the wall, and Nav2's DWB (which weaves toward the
+        # point rather than tracking a line the way cmd_vel's rotate-then-go does)
+        # grazes it — BasicSim's hard-collision then zeroes the motion and the
+        # robot FREEZES, wedged, while the per-hop cancel churns past it (observed
+        # 2026-07-18 on the 4 tight scenarios: robot stuck at one pose for 14+
+        # hops). The margin keeps the path off the walls so Nav2 has room to weave.
+        self._plan_clearance = robot_radius + max(0.0, plan_margin)
+        # Nav2 is built to navigate metres between goals, not 0.5m micro-hops:
+        # fed hops finer than its own goal tolerance it never leaves goal-approach
+        # mode. In nav2 mode plan a COARSER path (turning points resampled to
+        # ~nav2_stride) so it actually path-navigates each leg; cmd_vel keeps the
+        # fine step_size its proportional controller was tuned for.
+        self._plan_stride = (max(step_size, nav2_stride)
+                             if drive_mode == 'nav2' else step_size)
+
+        self._travel_distance_m = 0.0
+        self._last_xy: Optional[tuple] = None
+        self._current_theta: Optional[float] = None
+        self._placed = False
+        self._teleport_wait_stamp_ns: Optional[int] = None
+        self._n_hops = 0
+        self._episode_start_ns: Optional[int] = None
+        self._start_wall: Optional[float] = None
+        self._done = False
+        self._last_pose_wall: Optional[float] = None
+
+        self._cmdvel_active = False
+        self._waypoint_x: Optional[float] = None
+        self._waypoint_y: Optional[float] = None
+        self._waypoint_start_ns: int = 0
+        self._nav2_hop_active = False
+        self._nav2_goal_send_ns: Optional[int] = None
+        self._nav2_canceling = False
+        self._nav2_reject_streak = 0
+        self._nav2_max_rejects = 8
+        self._nav2_timeout_streak = 0
+        self._nav2_max_timeouts = 3
+        self._nav2_pending_retry = False
+        self._nav2_retry_ns = 0
+        self._nav2_last_target: Optional[tuple] = None
+        # Action-result futures and pose/timer callbacks may run on different
+        # MultiThreadedExecutor workers.  In particular, a result callback can
+        # clear _nav2_hop_active while a pose callback simultaneously observes
+        # it false; both then enter _maybe_send_next_hop and consume two path
+        # entries.  Apart from sending concurrent goals, the second dispatch can
+        # exhaust the path and report nav2_failed while the first (final) goal is
+        # still driving.  Serialize every path-index/state transition here.
+        self._dispatch_lock = threading.RLock()
+
+        self.get_logger().info(
+            f'Waiting up to {occupancy_timeout:.0f}s for {occupancy_service} ...')
+        grid_2d, _outlet_mask, params = load_3d_occupancy_grid_from_service(
+            self, z_level=occupancy_z_level, service_name=occupancy_service,
+            timeout_sec=occupancy_timeout)
+        self._occ_map = OccupancyGridMap(grid_2d, params)
+        if self._occ_map.origin_x == 0.0 and self._occ_map.origin_y == 0.0:
+            self._occ_map.origin_x = -0.2
+            self._occ_map.origin_y = -0.2
+
+        self._path = self._plan_path(
+            (self._start_x, self._start_y), (self._source_x, self._source_y),
+            self._plan_stride)
+        # Inflation radius is a graded Nav2 cost, not a lethal boundary. Use the
+        # matched 0.55m clearance whenever it leaves the map connected, but do not
+        # declare a genuinely narrow scenario impossible solely because that soft
+        # cost radius seals its doorway. Relax in 0.10m steps, never below the
+        # physical robot radius + 0.10m safety clearance.
+        if self._path is None and self._drive_mode == 'nav2':
+            requested_clearance = self._plan_clearance
+            minimum_clearance = self._robot_radius + 0.10
+            candidate = requested_clearance - 0.10
+            while self._path is None and candidate >= minimum_clearance - 1e-9:
+                self._plan_clearance = candidate
+                self.get_logger().warn(
+                    f'No path at {requested_clearance:.2f}m Nav2 clearance; '
+                    f'trying narrow-passage clearance {candidate:.2f}m.')
+                self._path = self._plan_path(
+                    (self._start_x, self._start_y),
+                    (self._source_x, self._source_y), self._plan_stride)
+                candidate -= 0.10
+        if self._path is not None and self._drive_mode == 'nav2':
+            # A* starts at the containing cell centre, which can produce a first
+            # waypoint only a few centimetres from the teleported pose. Nav2
+            # consistently rejects that no-op goal; it is not route progress and
+            # used to waste the entire rejection budget before the real drive.
+            while (self._path and math.hypot(
+                    self._path[0][0] - self._start_x,
+                    self._path[0][1] - self._start_y) <= self._nav2_goal_tolerance):
+                self._path.pop(0)
+        self._path_idx = 0
+        if self._path is None:
+            self.get_logger().error(
+                'No A* path from start to source over the ground-truth grid — aborting.')
+            self._write_result(status='no_path')
+            os._exit(2)
+        self.get_logger().info(
+            f'Planned path: {len(self._path)} waypoints @ ~{self._plan_stride}m '
+            f'spacing (clearance {self._plan_clearance:.2f}m).')
+
+        self.create_subscription(
+            PoseWithCovarianceStamped, f'/{ns}/ground_truth', self._pose_callback, 10)
+        self._place_pub = self.create_publisher(
+            PoseWithCovarianceStamped, f'/{ns}/initialpose', 10)
+
+        # Keep one publisher/timer setup for both modes. The timer is a no-op in
+        # Nav2 mode; there is deliberately no cmd_vel fallback because oracle
+        # budgets must remain achievable by Nav2-driven benchmark agents.
+        self._cmd_vel_pub = self.create_publisher(Twist, f'/{ns}/cmd_vel', 10)
+        self.create_timer(0.05, self._cmd_vel_tick)
+        if self._drive_mode == 'nav2':
+            self._navigator = Navigator(self, on_complete_callback=self._on_nav2_hop_complete)
+            self.create_timer(1.0, self._nav2_hop_watchdog)
+            self.get_logger().info(
+                f'Drive mode: NAV2 (active per-hop cancel after '
+                f'{self._det_hop_timeout:.0f}s, tolerance={nav2_goal_tolerance:.2f}m; '
+                f'retry-on-rejection + skip, final leg targets source @ tol='
+                f'{self._success_radius:.2f}m)')
+        else:
+            self.get_logger().info('Drive mode: cmd_vel (deterministic rotate-then-go)')
+
+        self._watchdog = self.create_timer(
+            2.0, self._wall_watchdog, clock=Clock(clock_type=ClockType.STEADY_TIME))
+
+    def _pose_callback(self, msg: PoseWithCovarianceStamped):
+        x, y = msg.pose.pose.position.x, msg.pose.pose.position.y
+        q = msg.pose.pose.orientation
+        siny_cosp = 2.0 * (q.w * q.z + q.x * q.y)
+        cosy_cosp = 1.0 - 2.0 * (q.y * q.y + q.z * q.z)
+        self._current_theta = math.atan2(siny_cosp, cosy_cosp)
+        self._last_pose_wall = time.monotonic()
+
+        if self._last_xy is not None:
+            d = math.hypot(x - self._last_xy[0], y - self._last_xy[1])
+            if d < 1.0:   # skip the initial teleport jump, same guard obs_cache uses
+                self._travel_distance_m += d
+        self._last_xy = (x, y)
+
+        if self._done:
+            return
+
+        msg_stamp_ns = msg.header.stamp.sec * 1_000_000_000 + msg.header.stamp.nanosec
+
+        if not self._placed:
+            self._placed = True
+            self.get_logger().info(
+                f'Placing robot at start ({self._start_x:.2f}, {self._start_y:.2f})')
+            self._place_robot(self._start_x, self._start_y)
+            # BasicSim's /clock (and every header.stamp derived from it) is elapsed
+            # sim time since BasicSim launched, NOT wall-clock epoch time — comparing
+            # it against self.get_clock().now() (wall clock, since this node never
+            # sets use_sim_time) would make the gate below permanently true. Must
+            # compare stamp-vs-stamp, both on BasicSim's own clock, same as
+            # runner_node's last_scan_stamp_ns gate.
+            self._teleport_wait_stamp_ns = msg_stamp_ns
+            return
+
+        # Wait for a pose whose OWN stamp postdates the placement — comparing against
+        # "now" at callback time is always true (time only moves forward) and would
+        # let the very next pose through immediately, before the teleport is visible.
+        if (self._teleport_wait_stamp_ns is not None
+                and msg_stamp_ns <= self._teleport_wait_stamp_ns):
+            return
+
+        if self._episode_start_ns is None:
+            self._episode_start_ns = self.get_clock().now().nanoseconds
+            self._start_wall = time.monotonic()
+
+        # _nav2_pending_retry must gate this too: after a goal rejection the retry
+        # is deliberately delayed (costmap warmup) and re-issued by the watchdog;
+        # without this guard the ~10-30Hz pose stream re-fires the hop immediately,
+        # defeating the backoff and torching all retries in a few ms.
+        if (not self._cmdvel_active and not self._nav2_hop_active
+                and not self._nav2_pending_retry):
+            self._maybe_send_next_hop()
+
+    def _plan_path(self, start_xy, goal_xy, step_size: float):
+        """A* over the ground-truth grid (dilated by robot_radius), simplified to
+        turning points via line-of-sight pruning, then resampled to ~step_size
+        spacing. Returns a list of (x, y) waypoints (start excluded, goal
+        included), or None if the grid has no free path start->goal. Ported from
+        directdrive_nav.py's proven _astar/_simplify/_los onto OccupancyGridMap's
+        own (row-major, non-flipped) world_to_grid/grid_to_world convention.
+        """
+        res = self._occ_map.resolution
+        occ = self._occ_map.grid > 0
+        # binary_dilation's default structuring element is a 4-connected cross, so
+        # N iterations grows a DIAMOND, not a disk: full margin along the axes but
+        # only ~margin/sqrt(2) along the diagonals — exactly where A*'s diagonal
+        # moves cut doorways/corners, silently shortchanging the intended
+        # robot_radius clearance there and causing the path to clip walls the
+        # planner believed were clear (confirmed 2026-07-18: raising robot_radius
+        # 0.25->0.35 barely helped, since the diagonal shortfall scales the same
+        # way regardless of the input radius). distance_transform_edt gives the
+        # true Euclidean distance to the nearest occupied cell, so the margin is
+        # circular and angle-independent.
+        occ = distance_transform_edt(~occ) * res <= self._plan_clearance
+        H, W = occ.shape
+
+        def w2c(pt):
+            gx, gy = self._occ_map.world_to_grid(*pt)
+            return (gy, gx)
+
+        def c2w(rc):
+            r, c = rc
+            return (self._occ_map.origin_x + (c + 0.5) * res,
+                    self._occ_map.origin_y + (r + 0.5) * res)
+
+        def nearest_free(r, c):
+            if 0 <= r < H and 0 <= c < W and not occ[r, c]:
+                return r, c
+            free = np.argwhere(~occ)
+            if free.size == 0:
+                return r, c
+            d = np.hypot(free[:, 0] - r, free[:, 1] - c)
+            return tuple(free[d.argmin()])
+
+        def los(a, b):
+            r0, c0 = a
+            r1, c1 = b
+            n = int(max(abs(r1 - r0), abs(c1 - c0)))
+            if n == 0:
+                return True
+            for k in range(n + 1):
+                r = int(round(r0 + (r1 - r0) * k / n))
+                c = int(round(c0 + (c1 - c0) * k / n))
+                if occ[r, c]:
+                    return False
+            return True
+
+        sr, sc = nearest_free(*w2c(start_xy))
+        gr, gc = nearest_free(*w2c(goal_xy))
+
+        def h(r, c):
+            return math.hypot(r - gr, c - gc)
+
+        pq = [(h(sr, sc), 0.0, (sr, sc))]
+        came = {(sr, sc): None}
+        cost = {(sr, sc): 0.0}
+        found = False
+        while pq:
+            _, g_, cur = heapq.heappop(pq)
+            if cur == (gr, gc):
+                found = True
+                break
+            r, c = cur
+            for dr, dc in ((-1, 0), (1, 0), (0, -1), (0, 1),
+                           (-1, -1), (-1, 1), (1, -1), (1, 1)):
+                nr, nc = r + dr, c + dc
+                if 0 <= nr < H and 0 <= nc < W and not occ[nr, nc]:
+                    step = 1.4142 if dr and dc else 1.0
+                    ng = g_ + step
+                    if ng < cost.get((nr, nc), 1e18):
+                        cost[(nr, nc)] = ng
+                        came[(nr, nc)] = cur
+                        heapq.heappush(pq, (ng + h(nr, nc), ng, (nr, nc)))
+        if not found:
+            return None
+
+        cells = []
+        cur = (gr, gc)
+        while cur is not None:
+            cells.append(cur)
+            cur = came[cur]
+        cells = cells[::-1]
+
+        if len(cells) <= 2:
+            simplified = cells
+        else:
+            simplified = [cells[0]]
+            i = 0
+            while i < len(cells) - 1:
+                j = len(cells) - 1
+                while j > i + 1 and not los(cells[i], cells[j]):
+                    j -= 1
+                simplified.append(cells[j])
+                i = j
+
+        turning_points = [c2w(c) for c in simplified]
+        waypoints = [start_xy]
+        for nxt in turning_points:
+            px, py = waypoints[-1]
+            seg_d = math.hypot(nxt[0] - px, nxt[1] - py)
+            n_steps = max(1, int(math.ceil(seg_d / step_size)))
+            for k in range(1, n_steps + 1):
+                t = k / n_steps
+                waypoints.append((px + (nxt[0] - px) * t, py + (nxt[1] - py) * t))
+        return waypoints[1:]   # drop the duplicated start point
+
+    def _maybe_send_next_hop(self):
+        with self._dispatch_lock:
+            if self._done:
+                return
+            # Callers normally test these flags themselves, but that test and
+            # this method were not atomic under MultiThreadedExecutor.  Make the
+            # dispatch method authoritative so a racing callback is harmless.
+            if (self._drive_mode == 'nav2'
+                    and (self._nav2_hop_active or self._nav2_pending_retry
+                         or self._nav2_canceling)):
+                return
+            if self._drive_mode != 'nav2' and self._cmdvel_active:
+                return
+            self._dispatch_next_hop_locked()
+
+    def _dispatch_next_hop_locked(self):
+        """Dispatch one path entry with ``_dispatch_lock`` held."""
+        rx, ry = (self._last_xy if self._last_xy is not None
+                  else (self._start_x, self._start_y))
+        final_d = math.hypot(rx - self._source_x, ry - self._source_y)
+        if final_d < self._success_radius:
+            self._end_episode('success', final_d)
+            return
+        if self._path_idx >= len(self._path):
+            self._end_episode('nav2_failed', final_d)
+            return
+
+        tx, ty = self._path[self._path_idx]
+        self._path_idx += 1
+        self._n_hops += 1
+        # Final leg (nav2): aim at the SOURCE itself with tolerance = success_radius,
+        # not at the precise last A* waypoint (tol 0.15m). Nav2 then drives as close
+        # as its costmap allows and reports the goal reached once inside
+        # success_radius — exactly the criterion the real agents are scored by, so
+        # a success here is one a Nav2-driven agent could reproduce. A tight 0.15m
+        # waypoint next to the source instead just gets rejected as too close to the
+        # wall the source sits on, stranding the robot metres out.
+        is_final = self._drive_mode == 'nav2' and self._path_idx >= len(self._path)
+        goal_x, goal_y = (self._source_x, self._source_y) if is_final else (tx, ty)
+        goal_tol = self._success_radius if is_final else self._nav2_goal_tolerance
+        self.get_logger().info(
+            f'[hop {self._n_hops:3d}/{len(self._path)}] ({rx:.2f},{ry:.2f}) -> '
+            f'({goal_x:.2f},{goal_y:.2f}) d2src={final_d:.2f}m'
+            f'{" [SOURCE, tol=%.2f]" % goal_tol if is_final else ""}')
+        if self._drive_mode == 'nav2':
+            self._nav2_hop_active = True
+            self._nav2_canceling = False
+            self._nav2_last_target = (goal_x, goal_y)
+            self._nav2_goal_send_ns = self.get_clock().now().nanoseconds
+            # Distance-proportional cancel: a ~1.5m nav2 leg needs more than the
+            # flat per-hop timeout to plan+drive; scale it so we still abort a
+            # genuinely-wedged hop but don't cut short an honest long leg.
+            hop_d = math.hypot(goal_x - rx, goal_y - ry)
+            self._nav2_hop_timeout = max(self._det_hop_timeout, 6.0 + 5.0 * hop_d)
+            self._navigator.send_goal(goal_x, goal_y, tolerance=goal_tol)
+        else:
+            self._start_cmdvel_move(tx, ty)
+
+    def _on_nav2_hop_complete(self):
+        """Navigator's on_complete fires on success, abort, cancel, AND rejection.
+        A near-instant completion (< reject_thresh, and not one we canceled) is a
+        Nav2 *goal rejection* — almost always because the local/global costmap
+        isn't warmed up yet when the first goals go out, so it rejects every one.
+        Blindly calling _maybe_send_next_hop then torches the whole planned path in
+        a few hundred ms (observed 2026-07-18: 15 hops fired in 0.15s, robot never
+        moved). Instead: DON'T advance — step the index back to re-issue the SAME
+        waypoint after a short warmup delay, and only skip it after max_rejects
+        tries. A watchdog cancellation retries the same required waypoint rather
+        than pretending a timed-out leg was completed."""
+        with self._dispatch_lock:
+            elapsed = (99.0 if self._nav2_goal_send_ns is None
+                       else (self.get_clock().now().nanoseconds - self._nav2_goal_send_ns) * 1e-9)
+            was_cancel = self._nav2_canceling
+            was_reject = (not was_cancel) and elapsed < 1.0
+            self._nav2_hop_active = False
+            self._nav2_canceling = False
+            self._nav2_goal_send_ns = None
+            if was_reject:
+                self._nav2_reject_streak += 1
+                if self._nav2_reject_streak <= self._nav2_max_rejects:
+                    self._path_idx = max(0, self._path_idx - 1)   # retry same waypoint
+                    self._nav2_retry_ns = (self.get_clock().now().nanoseconds
+                                           + int(1.2e9))           # after costmap warmup
+                    self._nav2_pending_retry = True
+                    self.get_logger().warn(
+                        f'[hop {self._n_hops:3d}] NAV2 goal rejected (costmap warming?) '
+                        f'— retry {self._nav2_reject_streak}/{self._nav2_max_rejects} in 1.2s')
+                    return
+            # Persistent rejection (not warmup) means Nav2 genuinely refuses this
+            # waypoint — it's inside its costmap inflation. We do NOT fall back to
+            # a cmd_vel drive that would thread it anyway: the oracle budget must be
+            # achievable by the Nav2-driven agents (gpulaika/adsm) it caps, so the
+            # oracle must reach the source the SAME way they do. Cheating with
+            # cmd_vel would publish a budget no Nav2 agent could follow and imply a
+            # source that is, for a Nav2 robot, unreachable. Skip the waypoint; if
+            # the source vicinity as a whole is Nav2-unreachable the run ends
+            # nav2_failed — an honest signal about the scenario, not a bug to mask.
+                self.get_logger().warn(
+                    f'[hop {self._n_hops:3d}] Nav2 rejected {self._nav2_max_rejects}x '
+                    f'— skipping waypoint (no cmd_vel cheat).')
+                self._nav2_reject_streak = 0
+            elif was_cancel:
+                # A watchdog cancellation says the robot did NOT reach this
+                # waypoint.  Advancing used to strand it on the wrong side of a
+                # doorway while later goals marched through the remaining path.
+                # Retry the same ground-truth route constraint; if Nav2 cannot
+                # execute it repeatedly, fail honestly instead of fabricating
+                # progress by skipping it.
+                self._nav2_timeout_streak += 1
+                if self._nav2_timeout_streak <= self._nav2_max_timeouts:
+                    self._path_idx = max(0, self._path_idx - 1)
+                    self._nav2_retry_ns = (self.get_clock().now().nanoseconds
+                                           + int(1.2e9))
+                    self._nav2_pending_retry = True
+                    self.get_logger().warn(
+                        f'[hop {self._n_hops:3d}] timed-out waypoint not reached '
+                        f'— retry {self._nav2_timeout_streak}/'
+                        f'{self._nav2_max_timeouts} in 1.2s')
+                    return
+                rx, ry = (self._last_xy if self._last_xy is not None
+                          else (self._start_x, self._start_y))
+                final_d = math.hypot(rx - self._source_x, ry - self._source_y)
+                self.get_logger().error(
+                    f'Nav2 failed the same required waypoint '
+                    f'{self._nav2_max_timeouts + 1} times; route is not executable.')
+                self._end_episode('nav2_failed', final_d)
+                return
+            else:
+                self._nav2_reject_streak = 0
+                self._nav2_timeout_streak = 0
+            self._maybe_send_next_hop()
+
+    def _nav2_hop_watchdog(self):
+        """Active per-hop cancel: don't wait for Nav2's own SimpleProgressChecker
+        + recovery-behavior tree to give up (~150s) — cancel and move to the next
+        waypoint after det_hop_timeout, same principle as gaden_rl_node.py's
+        per-step drive-timeout cancel in its (non-det-drive) Nav2 path."""
+        if self._nav2_pending_retry and not self._nav2_hop_active:
+            if self.get_clock().now().nanoseconds >= self._nav2_retry_ns:
+                self._nav2_pending_retry = False
+                self._maybe_send_next_hop()
+            return
+        if not self._nav2_hop_active or self._nav2_canceling or self._nav2_goal_send_ns is None:
+            return
+        elapsed = (self.get_clock().now().nanoseconds - self._nav2_goal_send_ns) * 1e-9
+        if elapsed > getattr(self, '_nav2_hop_timeout', self._det_hop_timeout):
+            self._nav2_canceling = True
+            self.get_logger().warn(
+                f'[hop {self._n_hops:3d}] NAV2 HOP TIMEOUT after {elapsed:.1f}s — canceling.')
+            self._navigator.cancel_current_goal()
+
+    def _start_cmdvel_move(self, x: float, y: float):
+        """Begin a deterministic cmd_vel drive to (x, y). Ported from
+        gaden_rl_node.py's _start_cmdvel_move — _cmd_vel_tick drives it and
+        clears _cmdvel_active on arrival/timeout."""
+        self._waypoint_x = float(x)
+        self._waypoint_y = float(y)
+        self._waypoint_start_ns = self.get_clock().now().nanoseconds
+        self._cmdvel_active = True
+
+    def _cmd_vel_tick(self):
+        """Proportional rotate-then-go controller: turn to face the target, then
+        drive straight to it. Bypasses Nav2/DWB so it never wedges on near-wall
+        hops and lands ON the commanded point. Stops on arrival or per-hop
+        timeout. Ported from gaden_rl_node.py's OSL_DET_DRIVE _cmd_vel_tick."""
+        if not self._cmdvel_active or self._waypoint_x is None:
+            return
+        if self._last_xy is None or self._current_theta is None:
+            return
+        rx, ry = self._last_xy
+        dx = self._waypoint_x - rx
+        dy = self._waypoint_y - ry
+        dist = math.hypot(dx, dy)
+        timed_out = ((self.get_clock().now().nanoseconds - self._waypoint_start_ns)
+                     > self._det_hop_timeout * 1e9)
+        if dist < self._det_arrive_tol or timed_out:
+            self._cmd_vel_pub.publish(Twist())   # stop
+            self._cmdvel_active = False
+            self._maybe_send_next_hop()
+            return
+        heading_error = math.atan2(dy, dx) - self._current_theta
+        heading_error = math.atan2(math.sin(heading_error), math.cos(heading_error))
+        tw = Twist()
+        tw.linear.x = 0.0 if abs(heading_error) > 0.8 else self._det_linear
+        tw.angular.z = self._det_gain * heading_error
+        self._cmd_vel_pub.publish(tw)
+
+    def _place_robot(self, x: float, y: float):
+        msg = PoseWithCovarianceStamped()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = 'map'
+        msg.pose.pose.position.x = float(x)
+        msg.pose.pose.position.y = float(y)
+        msg.pose.pose.orientation.w = 1.0
+        msg.pose.covariance = [0.0] * 36
+        self._place_pub.publish(msg)
+
+    def _wall_watchdog(self):
+        now_w = time.monotonic()
+        if self._done:
+            return
+        if self._last_pose_wall is not None and now_w - self._last_pose_wall > 120.0:
+            self.get_logger().error('ENV DEAD — no pose for 120s. Aborting.')
+            self._write_result(status='env_dead')
+            os._exit(3)
+        if (self._start_wall is not None
+                and now_w - self._start_wall > self._wall_timeout):
+            rx, ry = (self._last_xy if self._last_xy is not None
+                      else (self._start_x, self._start_y))
+            final_d = math.hypot(rx - self._source_x, ry - self._source_y)
+            self.get_logger().warn(
+                f'WALL TIMEOUT after {now_w - self._start_wall:.0f}s — giving up.')
+            self._end_episode('nav2_timeout', final_d)
+
+    def _sim_time(self) -> float:
+        if self._episode_start_ns is None:
+            return 0.0
+        return (self.get_clock().now().nanoseconds - self._episode_start_ns) * 1e-9
+
+    def _write_result(self, status: str, final_distance_m: Optional[float] = None):
+        result = {
+            'schema': 1,
+            'status': status,
+            'source': [self._source_x, self._source_y],
+            'start': [self._start_x, self._start_y],
+            'travel_distance_m': round(self._travel_distance_m, 3),
+            'sim_time_s': round(self._sim_time(), 2),
+            'wall_time_s': (round(time.monotonic() - self._start_wall, 1)
+                             if self._start_wall is not None else None),
+            'final_distance_m': None if final_distance_m is None else round(final_distance_m, 3),
+            'timestamp': datetime.now().isoformat(timespec='seconds'),
+        }
+        os.makedirs(os.path.dirname(os.path.abspath(self._result_file)), exist_ok=True)
+        with open(self._result_file, 'w') as f:
+            json.dump(result, f, indent=2)
+            f.flush()
+            os.fsync(f.fileno())
+
+    def _end_episode(self, status: str, final_distance_m: float):
+        self._done = True
+        if self._drive_mode == 'nav2':
+            self._navigator.cancel_current_goal()
+        else:
+            self._cmd_vel_pub.publish(Twist())
+        self.get_logger().info(
+            f'{status.upper()} — {self._travel_distance_m:.1f} m travelled, '
+            f'{self._sim_time():.1f} s sim time, final_d={final_distance_m:.2f} m')
+        self._write_result(status, final_distance_m)
+        os._exit(0)
+
+
+def run_one_oracle(args, scenario: str, sim: str, run_dir: Path,
+                    source, start) -> dict:
+    run_dir.mkdir(parents=True, exist_ok=True)
+    result_file = run_dir / 'oracle_result.json'
+    t0 = time.time()
+
+    env_log = open(run_dir / 'env.log', 'wb')
+    launch_pkg = args.launch
+    launch_file = ('realistic_launch.py' if launch_pkg == 'benchmark_env_realistic'
+                   else 'main_simbot_launch.py')
+    launch_cmd = ['ros2', 'launch', launch_pkg, launch_file,
+                  f'scenario:={scenario}', 'configuration:=config1', f'simulation:={sim}',
+                  f'namespace:={args.namespace}']
+    if launch_pkg == 'benchmark_env_realistic':
+        launch_cmd.append('motion:=nav2')
+    env_proc = subprocess.Popen(launch_cmd, stdout=env_log, stderr=subprocess.STDOUT)
+    _LIVE_PROCS.append(env_proc)
+
+    print('  waiting for ground_truth...')
+    if not wait_for_pose(args.namespace):
+        print(f'  {RED}env never published ground_truth — aborting run{RESET}')
+        write_stub_oracle_result(result_file, source, start, 'env_dead')
+        kill_tree(env_proc)
+        _LIVE_PROCS.remove(env_proc)
+        kill_ros()
+        time.sleep(3)
+        return json.loads(result_file.read_text())
+
+    print('  pose online, waiting for Nav2 lifecycle...')
+    nav_node = f'/{args.namespace}/bt_navigator'
+    nav_deadline = time.monotonic() + args.nav2_startup_timeout
+    nav_active = False
+    while time.monotonic() < nav_deadline and env_proc.poll() is None:
+        try:
+            state = subprocess.run(
+                ['ros2', 'lifecycle', 'get', nav_node], capture_output=True,
+                text=True, timeout=5.0, check=False)
+            if state.returncode == 0 and 'active' in state.stdout.lower():
+                nav_active = True
+                break
+        except subprocess.TimeoutExpired:
+            pass
+        time.sleep(1.0)
+    if not nav_active:
+        print(f'  {YELLOW}Nav2 did not reach lifecycle state active within '
+              f'{args.nav2_startup_timeout:.0f}s — relaunch required{RESET}')
+        write_stub_oracle_result(result_file, source, start, 'nav2_unavailable')
+        kill_tree(env_proc)
+        _LIVE_PROCS.remove(env_proc)
+        kill_ros()
+        time.sleep(3)
+        return json.loads(result_file.read_text())
+
+    print('  Nav2 active, sending oracle to run in-process.')
+    # Let costmaps receive their first update after lifecycle activation. Merely
+    # discovering the action server is insufficient: an inactive bt_navigator
+    # advertises the action but rejects every goal.
+    time.sleep(2)
+
+    cmd = [sys.executable, '-u', '-m', 'gsl_bench.eval.oracle', '--_run-node',
+           f'--namespace={args.namespace}',
+           f'--start-x={_fmt(float(start[0]))}', f'--start-y={_fmt(float(start[1]))}',
+           f'--source-x={_fmt(float(source[0]))}', f'--source-y={_fmt(float(source[1]))}',
+           f'--success-radius={_fmt(float(args.success_radius))}',
+           f'--wall-timeout={_fmt(float(args.wall_timeout))}',
+           f'--robot-radius={_fmt(float(args.robot_radius))}',
+           f'--step-size={_fmt(float(args.step_size))}',
+           f'--det-linear={_fmt(float(args.det_linear))}',
+           f'--det-gain={_fmt(float(args.det_gain))}',
+           f'--det-arrive-tol={_fmt(float(args.det_arrive_tol))}',
+           f'--det-hop-timeout={_fmt(float(args.det_hop_timeout))}',
+           f'--drive-mode={args.drive_mode}',
+           f'--nav2-goal-tolerance={_fmt(float(args.nav2_goal_tolerance))}',
+           f'--plan-margin={_fmt(float(args.plan_margin))}',
+           f'--nav2-stride={_fmt(float(args.nav2_stride))}',
+           f'--result-file={result_file}']
+    node_log = open(run_dir / 'node.log', 'wb')
+    node_proc = subprocess.Popen(cmd, stdout=node_log, stderr=subprocess.STDOUT)
+
+    status = 'done'
+    while node_proc.poll() is None:
+        if time.time() - t0 > args.wall_timeout + 60.0:
+            status = 'wall_timeout'
+            print(f'  {YELLOW}WALL TIMEOUT{RESET} after {time.time() - t0:.0f}s — killing.')
+            node_proc.terminate()
+            time.sleep(2)
+            node_proc.kill()
+            break
+        time.sleep(2)
+
+    if not result_file.is_file():
+        write_stub_oracle_result(
+            result_file, source, start,
+            'wall_timeout' if status == 'wall_timeout' else 'crashed')
+
+    res = json.loads(result_file.read_text())
+    res['scenario'] = scenario
+    res['sim'] = sim
+    result_file.write_text(json.dumps(res, indent=2))
+
+    if res.get('status') == 'success':
+        print(f'  {GREEN}ORACLE{RESET}  dist={res["travel_distance_m"]}m  '
+              f'time={res["sim_time_s"]}s  ({time.time() - t0:.0f}s wall)')
+    else:
+        print(f'  {YELLOW}oracle did not confirm success{RESET}  status={res["status"]}')
+
+    kill_tree(env_proc)
+    _LIVE_PROCS.remove(env_proc)
+    kill_ros()
+    time.sleep(3)
+    return res
+
+
+def write_stub_oracle_result(path: Path, source, start, status: str):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, 'w') as f:
+        json.dump({
+            'schema': 1, 'status': status, 'source': list(source), 'start': list(start),
+            'travel_distance_m': None, 'sim_time_s': None, 'wall_time_s': None,
+            'final_distance_m': None,
+            'timestamp': datetime.now().isoformat(timespec='seconds'),
+        }, f, indent=2)
+
+
+def _run_node_main(argv: List[str]):
+    """Entry point for the subprocess spawned by run_one_oracle: one OracleNode,
+    one episode, exit. Kept as a `python -m` invocation (not a console_script)
+    since it's an internal implementation detail of `oracle`, not a public CLI."""
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--_run-node', action='store_true')
+    ap.add_argument('--namespace', default='PioneerP3DX')
+    ap.add_argument('--start-x', type=float, required=True)
+    ap.add_argument('--start-y', type=float, required=True)
+    ap.add_argument('--source-x', type=float, required=True)
+    ap.add_argument('--source-y', type=float, required=True)
+    ap.add_argument('--success-radius', type=float, required=True)
+    ap.add_argument('--wall-timeout', type=float, required=True)
+    ap.add_argument('--robot-radius', type=float, default=0.25)
+    ap.add_argument('--step-size', type=float, default=0.5)
+    ap.add_argument('--det-linear', type=float, default=0.3)
+    ap.add_argument('--det-gain', type=float, default=2.0)
+    ap.add_argument('--det-arrive-tol', type=float, default=0.15)
+    ap.add_argument('--det-hop-timeout', type=float, default=12.0)
+    ap.add_argument('--drive-mode', choices=['cmdvel', 'nav2'], default='cmdvel')
+    ap.add_argument('--nav2-goal-tolerance', type=float, default=0.15)
+    ap.add_argument('--plan-margin', type=float, default=0.30)
+    ap.add_argument('--nav2-stride', type=float, default=1.5)
+    ap.add_argument('--result-file', type=Path, required=True)
+    a = ap.parse_args(argv)
+
+    rclpy.init()
+    node = OracleNode(
+        ns=a.namespace, start_xy=(a.start_x, a.start_y),
+        source_xy=(a.source_x, a.source_y), success_radius=a.success_radius,
+        wall_timeout=a.wall_timeout, result_file=a.result_file,
+        robot_radius=a.robot_radius, step_size=a.step_size,
+        det_linear=a.det_linear, det_gain=a.det_gain,
+        det_arrive_tol=a.det_arrive_tol, det_hop_timeout=a.det_hop_timeout,
+        drive_mode=a.drive_mode, nav2_goal_tolerance=a.nav2_goal_tolerance,
+        plan_margin=a.plan_margin, nav2_stride=a.nav2_stride)
+    executor = MultiThreadedExecutor(num_threads=2)
+    executor.add_node(node)
+    executor.spin()
+
+
+def parse_args(argv: List[str]):
+    ap = argparse.ArgumentParser(prog='gsl_bench oracle')
+    ap.add_argument('--suite', default=None, help='nav7 | all')
+    ap.add_argument('--scenario', default=None,
+                    help='scenario name, or a comma-separated list')
+    ap.add_argument('--runs', type=int, default=1)
+    ap.add_argument('--out', type=Path,
+                    default=Path('/home/efe/ros2_ws/Results/oracle_budgets.json'))
+    ap.add_argument('--wall-timeout', type=float, default=600.0)
+    ap.add_argument('--success-radius', type=float, default=0.5)
+    ap.add_argument('--robot-radius', type=float, default=0.25,
+                    help='true Euclidean clearance (via distance_transform_edt) used '
+                         'to inflate the ground-truth grid before A* planning')
+    ap.add_argument('--step-size', type=float, default=0.5,
+                    help='waypoint spacing along the planned path, same default as '
+                         'episode_runner/runner_node step_size_hint')
+    ap.add_argument('--det-linear', type=float, default=0.3,
+                    help='cmd_vel drive speed (m/s), same default as OSL_DET_LINEAR')
+    ap.add_argument('--det-gain', type=float, default=2.0,
+                    help='proportional heading gain, same default as OSL_DET_GAIN')
+    ap.add_argument('--det-arrive-tol', type=float, default=0.15,
+                    help='per-hop arrival tolerance (m), same default as OSL_DET_ARRIVE_TOL')
+    ap.add_argument('--det-hop-timeout', type=float, default=12.0,
+                    help='per-hop wall timeout (s) before skipping to the next waypoint '
+                         '(cmdvel mode) or canceling the goal (nav2 mode), same default '
+                         'as OSL_DET_TIMEOUT')
+    ap.add_argument('--drive-mode', choices=['cmdvel', 'nav2'], default='cmdvel',
+                    help="cmdvel (default): blind proportional rotate-then-go, no "
+                         "obstacle sensing, fails at genuinely tight passages that need "
+                         "local avoidance. nav2: real Nav2/DWB local controller per hop "
+                         "(can locally deform around tight corners cmdvel cannot thread) "
+                         "with an ACTIVE per-hop cancel after det-hop-timeout instead of "
+                         "waiting out Nav2's own ~150s SimpleProgressChecker+recovery.")
+    ap.add_argument('--nav2-goal-tolerance', type=float, default=0.15,
+                    help='Nav2 xy_goal_tolerance per hop, only used in --drive-mode=nav2')
+    ap.add_argument('--plan-margin', type=float, default=0.30,
+                    help='safety margin (m) added to robot_radius when inflating the '
+                         "ground-truth grid for A*; with the default 0.25m robot "
+                         "radius this matches Nav2's 0.55m inflation radius")
+    ap.add_argument('--nav2-stride', type=float, default=1.5,
+                    help='waypoint spacing (m) for the planned path in --drive-mode=nav2 '
+                         '(coarser than --step-size so Nav2 path-navigates each leg '
+                         'instead of churning 0.5m micro-hops); ignored in cmdvel mode')
+    ap.add_argument('--nav2-startup-timeout', type=float, default=60.0,
+                    help='seconds to wait for bt_navigator lifecycle state active')
+    ap.add_argument('--startup-retries', type=int, default=2,
+                    help='automatic environment relaunches after a zero-motion Nav2 '
+                         'startup failure (in addition to the requested run)')
+    ap.add_argument('--namespace', default='PioneerP3DX')
+    ap.add_argument('--skip-bake', action='store_true')
+    ap.add_argument('--domain-id', type=int, default=None)
+    ap.add_argument('--launch', default='benchmark_env',
+                    help='launch package for the environment: benchmark_env (default — '
+                         'ground-truth occupancy service, needed for A* planning) or '
+                         "benchmark_env_realistic (that launch doesn't start the occupancy "
+                         'service this needs, no fallback yet)')
+    args = ap.parse_args(argv)
+    if not args.suite and not args.scenario:
+        args.suite = 'nav7'
+    return args
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+    if argv and argv[0] == '--_run-node':
+        _run_node_main(argv)
+        return 0
+
+    args = parse_args(argv)
+
+    if args.domain_id is not None:
+        os.environ['ROS_DOMAIN_ID'] = str(args.domain_id)
+    elif not os.environ.get('ROS_DOMAIN_ID'):
+        print(f'{YELLOW}Warning: ROS_DOMAIN_ID unset.{RESET}')
+
+    reexec_under_setsid()
+
+    atexit.register(_cleanup)
+    signal.signal(signal.SIGTERM, lambda *_: sys.exit(1))
+    signal.signal(signal.SIGINT, lambda *_: sys.exit(1))
+
+    scenario_list = ([s.strip() for s in args.scenario.split(',') if s.strip()]
+                     if args.scenario else suites.resolve_suite(args.suite))
+    share = scenario_paths.install_share_dir()
+
+    stamp = datetime.now().strftime('%Y%m%d_%H%M%S')
+    run_root = args.out.parent / f'oracle_runs_{stamp}'
+    run_root.mkdir(parents=True, exist_ok=True)
+
+    print(f'\n{BOLD}{CYAN} gsl_bench oracle{RESET}')
+    print(f'  scenarios : {len(scenario_list)} x {args.runs} runs')
+    print(f'  launch    : {args.launch}')
+    print(f'  manifest  : {BOLD}{args.out}{RESET}\n')
+
+    display = start_xvfb()
+    print(f'  {DIM}headless display :{display}{RESET}')
+
+    kill_ros()
+    if patch_no_rviz(share):
+        print(f'  {DIM}patched install launch: no rviz, no xterm{RESET}')
+    if patch_nav2_params(share):
+        print(f'  {DIM}patched install nav2_params: tuned (no RotateToGoal){RESET}')
+    subprocess.run(['ros2', 'daemon', 'start'], capture_output=True, check=False)
+    time.sleep(2)
+
+    manifest = {}
+    for scenario in scenario_list:
+        if not scenario_paths.scenario_dir(scenario).is_dir():
+            print(f'{RED}Unknown scenario: {scenario} — skipping{RESET}')
+            continue
+        sim = scenario_paths.resolve_sim(scenario)
+        print(f'\n{DIM}{"=" * 50}{RESET}\n{BOLD} {scenario}{RESET} ({sim})')
+
+        if not bake_if_needed(scenario, sim, args.skip_bake):
+            print(f'{RED}bake failed — skipping {scenario}{RESET}')
+            continue
+        patch_playback_loop(scenario, sim)
+        patch_lidar_config(scenario)
+        patch_nav2_params(share)
+
+        source = scenario_paths.source_xy(scenario, sim)
+        start = scenario_paths.start_xy(scenario)
+        print(f'  source ({source[0]:.2f}, {source[1]:.2f})  '
+              f'start ({start[0]:.2f}, {start[1]:.2f})')
+
+        scen_dir = run_root / f'{scenario}_{sim}'
+        best = None
+        for i in range(1, args.runs + 1):
+            print(f'\n{BOLD} {scenario} oracle run {i}/{args.runs}{RESET}')
+            attempt = 0
+            while True:
+                suffix = '' if attempt == 0 else f'_retry_{attempt}'
+                res = run_one_oracle(
+                    args, scenario, sim, scen_dir / f'run_{i}{suffix}', source, start)
+                startup_failure = (
+                    res.get('status') == 'nav2_unavailable'
+                    or (res.get('status') == 'nav2_failed'
+                        and float(res.get('travel_distance_m') or 0.0) == 0.0))
+                if not startup_failure or attempt >= args.startup_retries:
+                    break
+                attempt += 1
+                print(f'  {YELLOW}Nav2 startup failure; automatically relaunching '
+                      f'(retry {attempt}/{args.startup_retries}){RESET}')
+            if res.get('status') == 'success' and (
+                    best is None or res['travel_distance_m'] < best['travel_distance_m']):
+                best = res
+        if best is not None:
+            manifest[f'{scenario}_{sim}'] = best
+        else:
+            print(f'{RED}no successful oracle run for {scenario}_{sim} — '
+                  f'omitted from manifest{RESET}')
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    args.out.write_text(json.dumps(manifest, indent=2))
+    print(f'\n{BOLD}{GREEN}Oracle manifest: {args.out}{RESET} '
+          f'({len(manifest)}/{len(scenario_list)} scenarios){RESET}')
+    return 0
+
+
+if __name__ == '__main__':
+    sys.exit(main())

--- a/gsl_bench/gsl_bench/eval/report.py
+++ b/gsl_bench/gsl_bench/eval/report.py
@@ -1,0 +1,126 @@
+"""Aggregate a results directory into a markdown table + CSV.
+
+    ros2 run gsl_bench report <results_dir>
+"""
+import argparse
+import csv
+import sys
+from pathlib import Path
+
+from gsl_bench.eval import metrics
+
+COLUMNS = ['scenario', 'success (CI)', 'reached', 'TT (s) [CI]', 'TD (m) [CI]',
+           'steps', 'fail modes']
+
+
+def _fail_modes(summary: dict) -> str:
+    bad = {k: v for k, v in summary['status_counts'].items() if k != 'success'}
+    return ', '.join(f'{k}x{v}' for k, v in sorted(bad.items())) or '—'
+
+
+def _rate(k: int, n: int, ci) -> str:
+    """e.g. '3/5 (30–79%)' — count plus 95% Wilson band."""
+    s = f'{k}/{n}'
+    if ci:
+        s += f' ({ci[0] * 100:.0f}–{ci[1] * 100:.0f}%)'
+    return s
+
+
+def _val(v, ci) -> str:
+    """e.g. '42.1 [38–47]' — mean plus 95% bootstrap band."""
+    if v is None:
+        return '—'
+    s = f'{v:.1f}'
+    if ci:
+        s += f' [{ci[0]:.0f}–{ci[1]:.0f}]'
+    return s
+
+
+def _row(name: str, s: dict) -> list:
+    return [
+        name,
+        _rate(s['n_success'], s['n'], s.get('success_ci')),
+        _rate(s.get('n_reached', s['n_success']), s['n'], s.get('reached_ci')),
+        _val(s['mean_time_s'], s.get('time_ci')),
+        _val(s['mean_distance_m'], s.get('distance_ci')),
+        '—' if s['mean_steps'] is None else f"{s['mean_steps']:.0f}",
+        _fail_modes(s),
+    ]
+
+
+def build_report(root: Path) -> str:
+    runs = metrics.load_runs(root)
+    if not runs:
+        return f'No result.json files under {root}\n'
+    agg = metrics.aggregate(runs)
+
+    lines = []
+    agents = sorted({r.get('agent', '?') for r in runs})
+    lines.append(f"# gsl_bench report — {', '.join(agents)}")
+    lines.append('')
+    lines.append(f'Runs: {agg["overall"]["n"]}  |  Source: `{root}`')
+    lines.append('')
+
+    if agg['harness_mismatch']:
+        lines.append('> **WARNING: mixed harness configs.** These runs were NOT scored '
+                     'under identical conditions, so the aggregate is not a fair '
+                     'comparison. Differing keys: '
+                     f'`{", ".join(agg["harness_mismatch"])}`')
+        lines.append('')
+
+    lines.append('| ' + ' | '.join(COLUMNS) + ' |')
+    lines.append('|' + '|'.join(['---'] * len(COLUMNS)) + '|')
+    for scen, s in agg['per_scenario'].items():
+        lines.append('| ' + ' | '.join(_row(scen, s)) + ' |')
+    lines.append('| **TOTAL** | ' + ' | '.join(_row('', agg['overall'])[1:]) + ' |')
+    lines.append('')
+
+    h = next((r.get('harness') for r in runs if r.get('harness')), None)
+    if h and not agg['harness_mismatch']:
+        lines.append('Harness: ' + ', '.join(f'{k}={v}' for k, v in sorted(h.items())))
+        lines.append('')
+    lines.append('success = reached the source within 5x the oracle distance; '
+                 'reached = reached it at all (up to the 10x/20x termination budget). '
+                 'TT/TD = mean time / traveled distance over successes. '
+                 'Bands are 95% CIs (Wilson for rates, bootstrap for means).')
+    lines.append('')
+    return '\n'.join(lines)
+
+
+def write_csv(root: Path, path: Path) -> None:
+    runs = metrics.load_runs(root)
+    fields = ['scenario', 'sim', 'agent', 'status', 'success', 'reached_source',
+              'success_within_budget', 'steps', 'sim_time_s',
+              'wall_time_s', 'travel_distance_m', 'final_distance_m',
+              'oracle_travel_distance_m', 'success_budget_distance_m',
+              'escapes', 'clamped_steps', 'drive_timeouts']
+    with open(path, 'w', newline='') as f:
+        w = csv.DictWriter(f, fieldnames=fields, extrasaction='ignore')
+        w.writeheader()
+        for r in runs:
+            w.writerow(r)
+
+
+def write_all(root: Path) -> str:
+    """Write results.csv + report.md into root and return the report text."""
+    text = build_report(root)
+    (Path(root) / 'report.md').write_text(text)
+    write_csv(Path(root), Path(root) / 'results.csv')
+    return text
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser(prog='gsl_bench report')
+    ap.add_argument('results_dir', type=Path)
+    ap.add_argument('--write', action='store_true',
+                    help='also write report.md and results.csv into the directory')
+    args = ap.parse_args(argv if argv is not None else sys.argv[1:])
+
+    if args.write:
+        print(write_all(args.results_dir))
+    else:
+        print(build_report(args.results_dir))
+
+
+if __name__ == '__main__':
+    main()

--- a/gsl_bench/gsl_bench/eval/scenario_paths.py
+++ b/gsl_bench/gsl_bench/eval/scenario_paths.py
@@ -1,0 +1,115 @@
+"""Where every scenario datum lives. Pure functions, no ROS runtime needed.
+
+All paths point into the INSTALL tree (install/benchmark_env/share/benchmark_env),
+because that is what the launch files read and what the patches must edit.
+"""
+import os
+import subprocess
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+import yaml
+
+
+def install_share_dir() -> Path:
+    prefix = os.environ.get('GSLB_BENCHMARK_ENV_PREFIX')
+    if not prefix:
+        prefix = subprocess.run(
+            ['ros2', 'pkg', 'prefix', 'benchmark_env'],
+            capture_output=True, text=True, check=True).stdout.strip()
+    d = Path(prefix) / 'share' / 'benchmark_env'
+    if not d.is_dir():
+        raise RuntimeError(
+            f'benchmark_env share dir not found at {d} — '
+            'run: colcon build --packages-select benchmark_env')
+    return d
+
+
+def scenarios_dir() -> Path:
+    return install_share_dir() / 'scenarios'
+
+
+def scenario_dir(name: str) -> Path:
+    return scenarios_dir() / name
+
+
+def config_dir(name: str) -> Path:
+    return scenario_dir(name) / 'environment_configurations' / 'config1'
+
+
+def list_scenarios() -> List[str]:
+    return sorted(p.name for p in scenarios_dir().iterdir() if p.is_dir())
+
+
+def _load_yaml(path: Path) -> dict:
+    try:
+        with open(path) as f:
+            return yaml.safe_load(f) or {}
+    except FileNotFoundError:
+        return {}
+
+
+def resolve_sim(name: str) -> str:
+    """Which simulation folder scene1 plays back."""
+    d = _load_yaml(config_dir(name) / 'scenes' / 'scene1.yaml')
+    try:
+        return str(d['simulations'][0]['sim'])
+    except (KeyError, IndexError, TypeError):
+        return 'sim1'
+
+
+def source_xy(name: str, sim: str) -> Tuple[float, float]:
+    d = _load_yaml(config_dir(name) / 'simulations' / sim / 'sim.yaml')
+    pos = d['source']['position']
+    return float(pos[0]), float(pos[1])
+
+
+def start_xy(name: str) -> Tuple[float, float]:
+    d = _load_yaml(config_dir(name) / 'config.yaml')
+    pt = d['empty_point']
+    return float(pt[0]), float(pt[1])
+
+
+def start_yaw(name: str) -> float:
+    """Robot start heading (rad) from BasicSimScene robots[0].angle. 0 for all
+    current scenarios; used to align GADEN's world frame to the SLAM map frame."""
+    d = _load_yaml(basic_sim_scene(name))
+    try:
+        return float(d['robots'][0].get('angle', 0.0) or 0.0)
+    except (KeyError, IndexError, TypeError):
+        return 0.0
+
+
+def playback_initial_iteration(name: str) -> Optional[int]:
+    d = _load_yaml(config_dir(name) / 'scenes' / 'scene1.yaml')
+    v = d.get('playback_initial_iteration')
+    return None if v is None else int(v)
+
+
+def wind_csv(name: str) -> Optional[Path]:
+    """Preferred: wind_simulations/1ms/. Fallback: the first one found."""
+    preferred = scenario_dir(name) / 'wind_simulations' / '1ms' / 'wind_at_cell_centers_0.csv'
+    if preferred.is_file():
+        return preferred
+    root = scenario_dir(name) / 'wind_simulations'
+    if not root.is_dir():
+        return None
+    found = sorted(root.glob('*/wind_at_cell_centers_0.csv'))
+    return found[0] if found else None
+
+
+def result_dir(name: str, sim: str) -> Path:
+    return config_dir(name) / 'simulations' / sim / 'result'
+
+
+def basic_sim_scene(name: str) -> Path:
+    return config_dir(name) / 'BasicSimScene.yaml'
+
+
+def occupancy_yaml(name: str) -> Path:
+    """The scenario's static ground-truth occupancy map (world frame)."""
+    return config_dir(name) / 'occupancy.yaml'
+
+
+def scene1_yaml(name: str) -> Path:
+    return config_dir(name) / 'scenes' / 'scene1.yaml'

--- a/gsl_bench/gsl_bench/eval/suites.py
+++ b/gsl_bench/gsl_bench/eval/suites.py
@@ -1,0 +1,42 @@
+"""Named scenario suites."""
+from typing import List
+
+from gsl_bench.eval import scenario_paths
+
+# One representative of each map family — the 7-map suite every published number
+# in this project is quoted against (7 scenarios x 5 runs = 35).
+NAV7 = [
+    '4_rooms_start_a',
+    '10x6_u_left_1',
+    '10x6_u_right_1',
+    'curved_labrinth_left_1',
+    'curved_labrinth_right_1',
+    'many_rooms_1',
+    'ultimate_1',
+]
+
+# The full published benchmark: every scenario family, every variant, House09
+# deliberately excluded (its occupancy voxelization is unreliable). These are
+# exactly the keys of Results/oracle_budgets_nav2_reliable.json — the oracle has
+# a budget for each, so all 29 can be scored against a 5x/10x/20x envelope.
+BENCHMARK29 = [
+    '10x6_u_left_1', '10x6_u_left_2', '10x6_u_left_3', '10x6_u_left_4',
+    '10x6_u_right_1', '10x6_u_right_2', '10x6_u_right_3', '10x6_u_right_4',
+    '4_rooms_start_a', '4_rooms_start_b', '4_rooms_start_c', '4_rooms_start_d',
+    '4_rooms_start_e',
+    'curved_labrinth_left_1', 'curved_labrinth_left_2', 'curved_labrinth_left_3',
+    'curved_labrinth_right_1', 'curved_labrinth_right_2', 'curved_labrinth_right_3',
+    'many_rooms_1', 'many_rooms_2', 'many_rooms_3', 'many_rooms_4',
+    'ultimate_1', 'ultimate_2', 'ultimate_3', 'ultimate_4', 'ultimate_5',
+    'ultimate_6',
+]
+
+
+def resolve_suite(name: str) -> List[str]:
+    if name == 'nav7':
+        return list(NAV7)
+    if name == 'benchmark29':
+        return list(BENCHMARK29)
+    if name == 'all':
+        return scenario_paths.list_scenarios()
+    raise KeyError(f"Unknown suite '{name}'. Known: nav7, benchmark29, all.")

--- a/gsl_bench/gsl_bench/eval/world_align.py
+++ b/gsl_bench/gsl_bench/eval/world_align.py
@@ -1,0 +1,101 @@
+"""Align GADEN's world-frame markers into the SLAM map frame for visualization.
+
+The problem: GADEN publishes gas/source markers in a TF frame literally named
+`"map"`, but their coordinates are WORLD coordinates (origin at world 0,0). In
+realistic mode the SLAM stack's `"map"` frame is anchored at the robot's START
+pose, not world 0,0. Same frame name, different origin, so the gas plume would
+render offset from the SLAM map by exactly the robot-start translation.
+
+This node bridges the two without renaming the load-bearing SLAM `"map"` frame:
+
+  1. Broadcasts a static TF `map -> gaden_world` that places the world origin at
+     `-start` inside the SLAM frame (a pure translation when the start yaw is 0,
+     which it is for every benchmark scenario; the general rotated case is handled
+     too).
+  2. Relays GADEN's `/Gas_Distribution` and `/source_visualization` markers onto
+     new topics with `frame_id` rewritten to `gaden_world`, so RViz (fixed frame
+     `map`) transforms them by our static TF and draws them at the right spot.
+
+No GADEN rebuild: geometry is untouched, only the header frame is re-stamped, and
+the relay publishes to *new* topics so there is no self-loop.
+
+    ros2 run gsl_bench world_align --ros-args \
+        -p start_x:=11.0 -p start_y:=2.0 -p yaw:=0.0
+"""
+import math
+
+import rclpy
+from geometry_msgs.msg import TransformStamped
+from rclpy.node import Node
+from tf2_ros import StaticTransformBroadcaster
+from visualization_msgs.msg import Marker, MarkerArray
+
+WORLD_FRAME = 'gaden_world'
+SLAM_FRAME = 'map'
+
+
+class WorldAlign(Node):
+    def __init__(self):
+        super().__init__('gsl_world_align')
+        self.declare_parameter('start_x', 0.0)
+        self.declare_parameter('start_y', 0.0)
+        self.declare_parameter('yaw', 0.0)
+        sx = float(self.get_parameter('start_x').value)
+        sy = float(self.get_parameter('start_y').value)
+        yaw = float(self.get_parameter('yaw').value)
+
+        self._broadcast_static_tf(sx, sy, yaw)
+
+        # Relay GADEN markers (frame "map"/world) -> aligned topics (frame gaden_world).
+        self._gas_pub = self.create_publisher(Marker, '/gsl_bench/gas_aligned', 1)
+        self._src_pub = self.create_publisher(MarkerArray, '/gsl_bench/source_aligned', 1)
+        self.create_subscription(Marker, '/Gas_Distribution', self._on_gas, 1)
+        self.create_subscription(MarkerArray, '/source_visualization', self._on_src, 1)
+        self.get_logger().info(
+            f'world_align: map->{WORLD_FRAME} at start=({sx:.2f},{sy:.2f}) yaw={yaw:.3f}; '
+            f'relaying gas/source to /gsl_bench/*_aligned')
+
+    def _broadcast_static_tf(self, sx: float, sy: float, yaw: float):
+        # We want a world point p_w to render at p_map = R(-yaw)*(p_w - start).
+        # A TF map->gaden_world maps p_map = R_q * p_w + t, so R_q = R(-yaw) and
+        # t = -R(-yaw)*start.
+        rot = -yaw
+        c, s = math.cos(rot), math.sin(rot)
+        tx = -(c * sx - s * sy)
+        ty = -(s * sx + c * sy)
+        t = TransformStamped()
+        t.header.stamp = self.get_clock().now().to_msg()
+        t.header.frame_id = SLAM_FRAME
+        t.child_frame_id = WORLD_FRAME
+        t.transform.translation.x = tx
+        t.transform.translation.y = ty
+        t.transform.rotation.z = math.sin(rot / 2.0)
+        t.transform.rotation.w = math.cos(rot / 2.0)
+        self._static_tf = StaticTransformBroadcaster(self)
+        self._static_tf.sendTransform(t)
+
+    def _on_gas(self, msg: Marker):
+        msg.header.frame_id = WORLD_FRAME
+        self._gas_pub.publish(msg)
+
+    def _on_src(self, msg: MarkerArray):
+        for m in msg.markers:
+            m.header.frame_id = WORLD_FRAME
+        self._src_pub.publish(msg)
+
+
+def main(argv=None):
+    rclpy.init(args=argv)
+    node = WorldAlign()
+    try:
+        rclpy.spin(node)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        node.destroy_node()
+        if rclpy.ok():
+            rclpy.shutdown()
+
+
+if __name__ == '__main__':
+    main()

--- a/gsl_bench/gsl_bench/harness/obs_cache.py
+++ b/gsl_bench/gsl_bench/harness/obs_cache.py
@@ -1,0 +1,120 @@
+"""Latest-value cache for the four sensor topics; snapshot() mints an Observation.
+
+Async sensor rates are hidden from the agent: every callback overwrites the latest
+value here, and the decision loop takes one coherent snapshot per step.
+"""
+import math
+import time
+from typing import Optional
+
+import numpy as np
+
+from gsl_bench.agent import MapInfo, Observation
+
+
+class SensorCache:
+    """Plain (non-node) holder of the freshest reading from each sensor."""
+
+    def __init__(self, n_rays: int = 72, lidar_max: float = 3.0):
+        self.n_rays = int(n_rays)
+        self.lidar_max = float(lidar_max)
+
+        self.x: Optional[float] = None
+        self.y: Optional[float] = None
+        self.theta: float = 0.0
+
+        self.gas_ppm: float = 0.0
+        self._gas_seen: bool = False
+        self.wind_speed: float = 0.0
+        self.wind_direction: float = 0.0
+
+        self.lidar: Optional[np.ndarray] = None
+        self.lidar_msg = None
+        self.lidar_min: Optional[float] = None
+        self.last_scan_stamp_ns: int = 0
+
+        # Wall-clock liveness beat for the STEADY_TIME watchdog (never sim time:
+        # a dead simulator freezes /clock, which is exactly what we must detect).
+        self.last_pose_wall: Optional[float] = None
+
+        self.travel_distance_m: float = 0.0
+        self._last_xy: Optional[tuple] = None
+
+    # -- callbacks -------------------------------------------------------
+
+    def update_pose(self, msg, set_position=True):
+        """geometry_msgs/PoseWithCovarianceStamped from /<ns>/ground_truth.
+
+        In SLAM/TF mode (pose_source == 'tf') the caller passes set_position=False
+        so ground-truth world coordinates never leak into self.x/y.  Bookkeeping
+        fields (last_pose_wall, theta, travel_distance) are always updated.
+        """
+        self.last_pose_wall = time.monotonic()
+        x = msg.pose.pose.position.x
+        y = msg.pose.pose.position.y
+
+        q = msg.pose.pose.orientation
+        siny_cosp = 2.0 * (q.w * q.z + q.x * q.y)
+        cosy_cosp = 1.0 - 2.0 * (q.y * q.y + q.z * q.z)
+        if set_position:
+            self.theta = math.atan2(siny_cosp, cosy_cosp)
+
+        # Travelled path length. The d < 1.0 guard skips the one initial-placement
+        # jump, which is a teleport, not travel.
+        if self._last_xy is not None:
+            d = math.hypot(x - self._last_xy[0], y - self._last_xy[1])
+            if d < 1.0:
+                self.travel_distance_m += d
+        self._last_xy = (x, y)
+
+        if set_position:
+            self.x = x
+            self.y = y
+
+    def update_gas(self, msg):
+        """olfaction_msgs/GasSensor from /fake_pid/Sensor_reading."""
+        self.gas_ppm = float(msg.raw)
+        self._gas_seen = True
+
+    def update_wind(self, msg):
+        """olfaction_msgs/Anemometer from /fake_anemometer/WindSensor_reading.
+
+        fake_anemometer.cpp publishes wind_speed = u*u + v*v — the SQUARED
+        magnitude, it never takes the sqrt. Training and Python eval feed the true
+        magnitude, so the correction happens here, once, for every agent.
+        """
+        self.wind_speed = math.sqrt(max(0.0, float(msg.wind_speed)))
+        self.wind_direction = float(msg.wind_direction)
+
+    def update_lidar(self, msg):
+        """sensor_msgs/LaserScan from /<ns>/laser_scanner."""
+        st = msg.header.stamp
+        self.last_scan_stamp_ns = int(st.sec) * 1_000_000_000 + int(st.nanosec)
+        rng = np.asarray(msg.ranges, dtype=np.float32)
+        finite = np.isfinite(rng)
+        self.lidar_min = float(rng[finite].min()) if finite.any() else None
+        rng = np.where(finite, rng, self.lidar_max)
+        self.lidar = np.clip(rng, 0.0, self.lidar_max)
+        self.lidar_msg = msg
+
+    # -- snapshot --------------------------------------------------------
+
+    def ready(self) -> bool:
+        """All sensors needed to build an Observation have reported at least once."""
+        return self.x is not None and self.lidar is not None and self._gas_seen
+
+    def snapshot(self, step: int, sim_time: float, map_info: MapInfo) -> Observation:
+        return Observation(
+            x=float(self.x),
+            y=float(self.y),
+            theta=float(self.theta),
+            gas_ppm=float(self.gas_ppm),
+            wind_speed=float(self.wind_speed),
+            wind_direction=float(self.wind_direction),
+            lidar=self.lidar.copy(),
+            lidar_max_range=self.lidar_max,
+            step=int(step),
+            sim_time=float(sim_time),
+            map=map_info,
+            lidar_msg=self.lidar_msg,
+        )

--- a/gsl_bench/gsl_bench/harness/runner_node.py
+++ b/gsl_bench/gsl_bench/harness/runner_node.py
@@ -1,0 +1,1012 @@
+"""The generic gsl_bench harness node: one episode, any agent.
+
+This is gaden_rl_node.py with the policy carved out and a GSLAgent plugged in.
+It owns everything that is not method-specific:
+
+    sensors -> Observation -> agent.observe()/act() -> Waypoint
+            -> hop cap -> clamp to free space -> Nav2 drive (per-step timeout)
+            -> success / max_steps / env-dead termination -> result.json
+
+Run one episode and exit:
+
+    ros2 run gsl_bench runner_node --ros-args \
+        -p agent:=random_walk \
+        -p true_source_x:=2.0 -p true_source_y:=4.5 \
+        -p start_x:=8.1 -p start_y:=1.5 \
+        -p result_file:=/tmp/run/result.json
+"""
+import json
+import math
+import os
+import sys
+import time
+from datetime import datetime
+from typing import Optional
+
+import numpy as np
+import rclpy
+import yaml
+from rclpy.clock import Clock, ClockType
+from rclpy.callback_groups import MutuallyExclusiveCallbackGroup
+from rclpy.executors import MultiThreadedExecutor
+from rclpy.node import Node
+
+from geometry_msgs.msg import Point, PoseStamped, PoseWithCovarianceStamped
+from nav_msgs.msg import OccupancyGrid
+from olfaction_msgs.msg import Anemometer, GasSensor
+from sensor_msgs.msg import LaserScan
+from visualization_msgs.msg import Marker
+from rclpy.action import ActionClient
+from nav2_msgs.action import NavigateToPose
+import tf2_ros
+
+from efe_igdm.mapping.occupancy_grid import (
+    OccupancyGridMap, load_3d_occupancy_grid_from_service,
+)
+from efe_igdm.planning.navigator import Navigator
+
+from gsl_bench.agent import MapInfo, ScenarioInfo
+from gsl_bench.harness.obs_cache import SensorCache
+from gsl_bench.registry import load_agent_class
+
+# The escape planner lives in gaden_transfer (src/base). Imported lazily in
+# _setup_escape so the harness runs without it when escape is off.
+_SRC_BASE = '/home/efe/ros2_ws/src/base'
+if _SRC_BASE not in sys.path:
+    sys.path.insert(0, _SRC_BASE)
+
+
+class RunnerNode(Node):
+    """Runs exactly one episode of one agent, then writes result.json and exits."""
+
+    def __init__(self):
+        super().__init__('gsl_bench_runner')
+
+        self._declare_parameters()
+        self._load_parameters()
+        self._init_state()
+
+        if self._map_source == 'service':
+            self._load_occupancy_map()
+        else:
+            # SLAM mode: fetch the TRUE map extent once, HERE in __init__ (before
+            # the executor spins, so load_3d_occupancy_grid_from_service's own
+            # spin_until_future_complete is safe — calling it from a live spinning
+            # callback deadlocks). The live SLAM grid still owns the occupancy
+            # CONTENTS; we only need the true width/height so the policy's
+            # position + gas-history features normalize by the real map size the
+            # checkpoint was trained on, not the tiny initial SLAM patch.
+            self._true_map_wh = self._fetch_true_map_size()
+
+        self._load_agent()
+
+        if self._map_source == 'service':
+            self._setup_escape()
+
+        self._init_ros_interfaces()
+
+        if self._map_source == 'service':
+            self._agent.reset(ScenarioInfo(
+                name=self._scenario_name,
+                map=self._map_info,
+                start_x=self._start_x,
+                start_y=self._start_y,
+                max_steps=self._max_steps,
+                step_size_hint=self._step_size_hint,
+            ))
+            self._agent_reset_done = True
+
+            self.get_logger().info(
+                f'gsl_bench runner ready | agent={self._agent_spec} '
+                f'({self._agent.name()}) | scenario={self._scenario_name} | '
+                f'max_steps={self._max_steps} '
+                f'(dist_budget={self._max_travel_distance_m:.1f}m, '
+                f'time_budget={self._max_sim_time_s:.1f}s) | '
+                f'escape={"ON" if self._escape else "OFF"} | '
+                f'pose={self._pose_source} | map={self._map_source}')
+            self.get_logger().info(
+                f'Map: {self._map_info.width_m:.1f} x {self._map_info.height_m:.1f} m | '
+                f'start=({self._start_x:.2f},{self._start_y:.2f})')
+        else:
+            self.get_logger().info(
+                f'gsl_bench runner waiting for SLAM map on {self._slam_map_topic} ...')
+
+    # ------------------------------------------------------------------
+    # Parameters
+    # ------------------------------------------------------------------
+
+    def _declare_parameters(self):
+        self.declare_parameter('agent', '')
+        self.declare_parameter('agent_config', '')       # YAML path -> dict -> agent __init__
+        self.declare_parameter('scenario_name', '')
+        self.declare_parameter('sim_name', 'sim1')
+
+        # Success check only. NEVER handed to the agent.
+        self.declare_parameter('true_source_x', 0.0)
+        self.declare_parameter('true_source_y', 0.0)
+        # One-time initial placement via /initialpose.
+        self.declare_parameter('start_x', -999.0)
+        self.declare_parameter('start_y', -999.0)
+
+        self.declare_parameter('max_steps', 600)
+        # Oracle-derived per-scenario budgets (gsl_bench.eval.oracle). 0.0 = disabled,
+        # same sentinel convention as drive_timeout's eff <= 0.0.
+        self.declare_parameter('max_travel_distance_m', 0.0)
+        self.declare_parameter('max_sim_time_s', 0.0)
+        self.declare_parameter('step_delay', 0.5)
+        self.declare_parameter('success_radius', 0.5)
+        self.declare_parameter('nav_goal_tolerance', 0.10)
+        self.declare_parameter('drive_timeout', 30.0)
+        self.declare_parameter('nav2_server_timeout', 300.0)
+        self.declare_parameter('pose_stale_timeout', 120.0)
+        self.declare_parameter('max_hop', 1.0)
+        self.declare_parameter('robot_radius', 0.25)
+        self.declare_parameter('step_size_hint', 0.5)
+
+        self.declare_parameter('occupancy_service', '/gaden_environment/occupancyMap3D')
+        self.declare_parameter('occupancy_z_level', 5)
+        self.declare_parameter('occupancy_timeout', 300.0)
+
+        self.declare_parameter('namespace', 'PioneerP3DX')
+        self.declare_parameter('escape', False)
+        self.declare_parameter('publish_action_marker', True)
+        self.declare_parameter('result_file', '')
+        self.declare_parameter('pose_source', 'ground_truth')
+        self.declare_parameter('map_source', 'service')
+        self.declare_parameter('slam_map_topic', '')
+        self.declare_parameter('motion', 'nav2')
+        self.declare_parameter('nav_profile', 'standard')
+
+    def _load_parameters(self):
+        g = self.get_parameter
+        self._agent_spec: str = g('agent').value
+        self._agent_config_path: str = g('agent_config').value
+        self._scenario_name: str = g('scenario_name').value
+        self._sim_name: str = g('sim_name').value
+
+        self._true_source_x: float = float(g('true_source_x').value)
+        self._true_source_y: float = float(g('true_source_y').value)
+        self._start_x: float = float(g('start_x').value)
+        self._start_y: float = float(g('start_y').value)
+
+        self._max_steps: int = int(g('max_steps').value)
+        self._max_travel_distance_m: float = float(g('max_travel_distance_m').value)
+        self._max_sim_time_s: float = float(g('max_sim_time_s').value)
+        self._step_delay: float = float(g('step_delay').value)
+        self._success_radius: float = float(g('success_radius').value)
+        self._nav_goal_tolerance: float = float(g('nav_goal_tolerance').value)
+        self._drive_timeout: float = float(g('drive_timeout').value)
+        self._pose_stale_timeout: float = float(g('pose_stale_timeout').value)
+        self._max_hop: float = float(g('max_hop').value)
+        self._robot_radius: float = float(g('robot_radius').value)
+        self._step_size_hint: float = float(g('step_size_hint').value)
+
+        self._occ_service: str = g('occupancy_service').value
+        self._occ_z: int = int(g('occupancy_z_level').value)
+        self._occ_timeout: float = float(g('occupancy_timeout').value)
+
+        self._ns: str = g('namespace').value
+        self._escape_enabled: bool = bool(g('escape').value)
+        self._publish_marker: bool = bool(g('publish_action_marker').value)
+        self._result_file: str = g('result_file').value
+
+        self._pose_source: str = g('pose_source').value
+        self._map_source: str = g('map_source').value
+        self._slam_map_topic: str = g('slam_map_topic').value
+        self._motion: str = g('motion').value
+        self._nav_profile: str = g('nav_profile').value
+        if not self._slam_map_topic:
+            self._slam_map_topic = f'/{self._ns}/map'
+
+        if not self._agent_spec:
+            raise ValueError("Parameter 'agent' is required (e.g. -p agent:=random_walk).")
+        if not self._result_file:
+            raise ValueError("Parameter 'result_file' is required.")
+
+    def _init_state(self):
+        self._cache = SensorCache(lidar_max=3.0)
+        self._step: int = 0
+        self._done: bool = False
+        self._placed: bool = False          # initial /initialpose published
+        self._is_moving: bool = False
+        self._drive_goal_time = None        # node clock at goal send (sim-side timeout)
+        self._drive_goal_wall: Optional[float] = None   # monotonic mirror (wall backstop)
+        self._drive_canceling: bool = False
+        self._teleport_wait_stamp_ns: Optional[int] = None
+        self._last_step_time_ns: int = 0
+        self._episode_start_ns: Optional[int] = None
+        self._n_escapes: int = 0
+        self._n_clamped: int = 0
+        self._n_drive_timeouts: int = 0
+        self._n_action_starts: int = 0
+        self._n_goal_updates: int = 0
+        self._navigator = None
+        self._escape = None
+        self._slam_enabled = False
+        self._tf_buffer = None
+        self._tf_listener = None
+        self._gt_x: Optional[float] = None
+        self._gt_y: Optional[float] = None
+        self._gt_theta: Optional[float] = None
+        self._agent_reset_done: bool = False
+        self._slam_map_sub = None
+        self._tf_fallback_count: int = 0
+        self._true_map_wh: Optional[tuple] = None
+        self._motion_mode: str = 'stop_go'
+        self._decision_period_s: Optional[float] = None
+        self._goal_update_pub = None
+
+    # ------------------------------------------------------------------
+    # Startup
+    # ------------------------------------------------------------------
+
+    def _fetch_true_map_size(self):
+        """Query GADEN's ground-truth occupancy service for the real map
+        width/height only. MUST be called from __init__ (before the executor
+        spins): load_3d_occupancy_grid_from_service spins the node itself, which
+        deadlocks if the node is already being spun by the executor. Returns
+        (w, h) in meters, or None if unreachable (falls back to SLAM patch)."""
+        try:
+            _grid, _outlet, params = load_3d_occupancy_grid_from_service(
+                self, z_level=self._occ_z, service_name=self._occ_service,
+                timeout_sec=self._occ_timeout)
+            w = float(params['env_max'][0] - params['env_min'][0])
+            h = float(params['env_max'][1] - params['env_min'][1])
+            self.get_logger().info(f'True map size from service: {w:.1f}x{h:.1f} m')
+            return (w, h)
+        except Exception as exc:
+            self.get_logger().warn(
+                f'Could not fetch true map size ({exc}); '
+                f'position/gas features will use the SLAM patch size.')
+            return None
+
+    def _load_occupancy_map(self):
+        self.get_logger().info(
+            f'Waiting up to {self._occ_timeout:.0f}s for {self._occ_service} ...')
+        grid_2d, _outlet_mask, params = load_3d_occupancy_grid_from_service(
+            self,
+            z_level=self._occ_z,
+            service_name=self._occ_service,
+            timeout_sec=self._occ_timeout,
+        )
+        self._occ_map = OccupancyGridMap(grid_2d, params)
+        if self._occ_map.origin_x == 0.0 and self._occ_map.origin_y == 0.0:
+            self._occ_map.origin_x = -0.2
+            self._occ_map.origin_y = -0.2
+
+        self._map_info = MapInfo(
+            grid=self._occ_map.grid,
+            resolution=float(self._occ_map.resolution),
+            origin_x=float(self._occ_map.origin_x),
+            origin_y=float(self._occ_map.origin_y),
+            width_m=float(self._occ_map.real_world_width),
+            height_m=float(self._occ_map.real_world_height),
+        )
+        self.get_logger().info(
+            f'Occupancy map: {self._occ_map.width}x{self._occ_map.height} cells, '
+            f'{self._map_info.width_m:.2f}x{self._map_info.height_m:.2f} m')
+
+    def _load_agent(self):
+        self._agent_config = {}
+        if self._agent_config_path:
+            with open(self._agent_config_path) as f:
+                self._agent_config = yaml.safe_load(f) or {}
+        cls = load_agent_class(self._agent_spec)
+        try:
+            self._agent = cls(self._agent_config)
+        except TypeError:
+            # Agents with a no-arg __init__ are allowed.
+            self._agent = cls()
+        self._agent.initialize()
+        self._motion_mode = getattr(self._agent, 'motion_mode', 'stop_go')
+        if self._motion_mode not in ('stop_go', 'continuous'):
+            raise ValueError(f'Unsupported agent motion_mode={self._motion_mode!r}')
+        rate = getattr(self._agent, 'decision_rate_hz', None)
+        self._decision_period_s = (1.0 / float(rate)
+                                   if self._motion_mode == 'continuous' and rate else None)
+        requirements = {
+            'pose_source': (getattr(self._agent, 'required_pose_source', None), self._pose_source),
+            'map_source': (getattr(self._agent, 'required_map_source', None), self._map_source),
+            'motion': (getattr(self._agent, 'required_motion', None), self._motion),
+            'nav_profile': (getattr(self._agent, 'required_nav_profile', None), self._nav_profile),
+        }
+        bad = [f'{name}={actual!r} (requires {required!r})'
+               for name, (required, actual) in requirements.items()
+               if required is not None and required != actual]
+        if bad:
+            raise ValueError(f'{self._agent.name()} incompatible harness: ' + ', '.join(bad))
+        if self._motion_mode == 'continuous' and self._escape_enabled:
+            raise ValueError('Canonical continuous ADSM runs require escape:=false')
+        requested_reach = float(getattr(self._agent, 'max_goal_distance', self._max_hop))
+        self._effective_max_hop = max(self._max_hop, requested_reach)
+
+    def _setup_escape(self):
+        """Opt-in stuck-escape: SLAM the lidar, and when the agent is circling or
+        the map stops growing, drive to an unexplored frontier in short hops.
+
+        Default OFF so every method is scored on its own behaviour; when ON it is
+        recorded in result.json (it historically moves the 7-map score 28 -> 32).
+        """
+        if not self._escape_enabled:
+            return
+        try:
+            from gaden_transfer.gaden_transfer_lidar.escape_planner import CirclingEscape
+        except ImportError as exc:
+            self.get_logger().error(
+                f'escape:=true but the escape planner is not importable ({exc}) — disabled.')
+            return
+        try:
+            env_flag = os.environ.get('OSL_ESCAPE_USE_LIVE_GRID', None)
+            if env_flag is not None:
+                use_live = env_flag == '1'
+            else:
+                use_live = (self._map_source == 'slam')
+
+            live_provider = (lambda: self._occ_map) if use_live else None
+
+            self._escape = CirclingEscape(
+                self._occ_map,
+                robot_radius=self._robot_radius,
+                logger=self.get_logger(),
+                win=int(os.environ.get('OSL_ESCAPE_WIN', '25')),
+                ratio=float(os.environ.get('OSL_ESCAPE_RATIO', '0.2')),
+                streak=int(os.environ.get('OSL_ESCAPE_STREAK', '35')),
+                cooldown=int(os.environ.get('OSL_ESCAPE_COOLDOWN', '40')),
+                min_dist=float(os.environ.get('OSL_ESCAPE_MINDIST', '3.0')),
+                grow_win=int(os.environ.get('OSL_ESCAPE_GROW_WIN', '120')),
+                grow_min=int(os.environ.get('OSL_ESCAPE_GROW_MIN', '250')),
+                frontier_min_cells=int(os.environ.get('OSL_ESCAPE_FRONTIER_MIN', '12')),
+                target_mode=os.environ.get('OSL_ESCAPE_TARGET', 'largest'),
+                use_live_grid=use_live,
+                live_map_provider=live_provider,
+            )
+            mode_txt = ('live SLAM grid' if use_live else 'private LidarMapper grid')
+            self.get_logger().info(
+                f'Stuck-escape ENABLED (recorded in result.json). '
+                f'Map: {mode_txt}.')
+        except Exception as exc:
+            self.get_logger().error(f'Failed to init escape: {exc} — disabled.')
+            self._escape = None
+
+    def _init_ros_interfaces(self):
+        ns = self._ns
+        # Heavy sensor/step callbacks (pose lookup, policy inference, goal send) go
+        # in their own MutuallyExclusive group so they DON'T share the node's default
+        # group with rclpy's internal /clock subscription (added by use_sim_time).
+        # Otherwise the busy /ground_truth callback monopolises the default group and
+        # /clock is never processed under the MultiThreadedExecutor -> the sim clock
+        # FREEZES (see the watchdog comment below), the TF pose lookup then requests a
+        # stale frozen time and throws "extrapolation into the past" every tick, and
+        # the runner holds its origin placement pose and drives to wrong-frame goals.
+        # Isolating them keeps /clock (default group) serviceable on the 2nd thread.
+        self._cbg = MutuallyExclusiveCallbackGroup()
+        self.create_subscription(
+            PoseWithCovarianceStamped, f'/{ns}/ground_truth', self._pose_callback, 10,
+            callback_group=self._cbg)
+        self.create_subscription(
+            GasSensor, '/fake_pid/Sensor_reading', self._gas_callback, 10,
+            callback_group=self._cbg)
+        self.create_subscription(
+            Anemometer, '/fake_anemometer/WindSensor_reading', self._wind_callback, 10,
+            callback_group=self._cbg)
+        self.create_subscription(
+            LaserScan, f'/{ns}/laser_scanner', self._lidar_callback, 10,
+            callback_group=self._cbg)
+
+        self._place_pub = self.create_publisher(
+            PoseWithCovarianceStamped, f'/{ns}/initialpose', 10)
+        self._marker_pub = self.create_publisher(Marker, '/gsl_bench/target', 1)
+        # Always-on goal pose (frame map) for visualization: the Nav2 goal itself
+        # goes out as an action (not RViz-visualizable), so we mirror every target
+        # here — normal steps, escape hops, and continuous retargets alike.
+        self._goal_pub = self.create_publisher(PoseStamped, '/gsl_bench/goal', 1)
+        if self._motion_mode == 'continuous':
+            self._goal_update_pub = self.create_publisher(
+                PoseStamped, f'/{ns}/goal_update', 1)
+
+        if self._pose_source == 'tf':
+            self._tf_buffer = tf2_ros.Buffer()
+            self._tf_listener = tf2_ros.TransformListener(self._tf_buffer, self)
+            self.get_logger().info(
+                'Pose source: TF lookup (map -> {ns}_base_link) — noisy SLAM pose')
+
+        if self._map_source == 'slam':
+            self._slam_map_sub = self.create_subscription(
+                OccupancyGrid, self._slam_map_topic,
+                self._slam_map_callback, 10, callback_group=self._cbg)
+            self.get_logger().info(
+                f'Map source: SLAM topic ({self._slam_map_topic})')
+
+        # Nav2 pre-flight: Navigator.__init__ waits on the action server with NO
+        # timeout, so confirm it is up here and fail fast instead of hanging.
+        nav_wait = float(self.get_parameter('nav2_server_timeout').value)
+        pre = ActionClient(self, NavigateToPose, f'/{ns}/navigate_to_pose')
+        self.get_logger().info(
+            f'Waiting up to {nav_wait:.0f}s for Nav2 action server /{ns}/navigate_to_pose ...')
+        if not pre.wait_for_server(timeout_sec=nav_wait):
+            self.get_logger().error(
+                f'Nav2 action server /{ns}/navigate_to_pose not available after '
+                f'{nav_wait:.0f}s — aborting.')
+            self._write_result(success=False, status='env_dead')
+            os._exit(2)
+        pre.destroy()
+        self._navigator = Navigator(self, on_complete_callback=self._on_nav_complete)
+        self.get_logger().info(
+            f'Motion: Nav2 physical drive ({self._motion_mode}, '
+            f'tolerance={self._nav_goal_tolerance:.2f} m, '
+            f'max_goal={self._effective_max_hop:.2f} m)')
+
+        # Liveness watchdog. MUST run on a STEADY_TIME clock: a default timer follows
+        # the node clock, which freezes with the simulator — exactly the scenario this
+        # watchdog exists to catch.
+        self._watchdog = self.create_timer(
+            2.0, self._wall_watchdog, clock=Clock(clock_type=ClockType.STEADY_TIME))
+        self.get_logger().info(
+            f'Watchdog armed: env-dead abort after {self._pose_stale_timeout:.0f}s '
+            'without a pose; wall backstop on the per-step drive timeout.')
+
+    # ------------------------------------------------------------------
+    # Sensor callbacks
+    # ------------------------------------------------------------------
+
+    def _gas_callback(self, msg: GasSensor):
+        self._cache.update_gas(msg)
+
+    def _wind_callback(self, msg: Anemometer):
+        self._cache.update_wind(msg)
+
+    def _lidar_callback(self, msg: LaserScan):
+        self._cache.update_lidar(msg)
+        # Fold the scan into the escape planner's online map, but only once the
+        # episode is really running: before the first step the pose can still be the
+        # pre-placement spawn, which would map a phantom region.
+        if self._escape is not None and self._slam_enabled:
+            self._escape.update_scan(msg, self._cache.x, self._cache.y, self._cache.theta)
+
+    def _slam_map_callback(self, msg: OccupancyGrid):
+        w = msg.info.width
+        h = msg.info.height
+        res = msg.info.resolution
+        ox = msg.info.origin.position.x
+        oy = msg.info.origin.position.y
+
+        # Threshold at 50, not "== 0": slam_toolbox publishes an already
+        # binarized {0, 100, -1}, so this is a no-op for it, but cartographer's
+        # occupancy_grid_node publishes a continuous 0-100 probability (any
+        # cell short of absolute certainty reads e.g. 24, not exactly 0) —
+        # treating "== 0" as the only free value made every cell "occupied"
+        # and boxed the robot in at spawn under cartographer.
+        grid = np.array(msg.data, dtype=np.int8).reshape(h, w)
+        grid = np.where(grid < 0, -1, np.where(grid >= 50, 1, 0)).astype(np.int8)
+
+        params = {
+            'env_min': [ox, oy, 0.0],
+            'env_max': [ox + w * res, oy + h * res, 0.0],
+            'num_cells': [w, h, 1],
+            'cell_size': res,
+            'z_level': 0,
+            'z_height': 0.0,
+        }
+        self._occ_map = OccupancyGridMap(grid, params)
+        self._map_info = MapInfo(
+            grid=self._occ_map.grid,
+            resolution=float(res),
+            origin_x=float(ox),
+            origin_y=float(oy),
+            width_m=float(w * res),
+            height_m=float(h * res),
+        )
+
+        if not self._agent_reset_done:
+            self._agent_reset_done = True
+            self._setup_escape()
+            # The agent gets the TRUE map size for its position/gas normalization
+            # (matching the training convention) while _map_info keeps the SLAM
+            # patch size for escape/collision. Grid stays the SLAM grid either way.
+            agent_map = self._map_info
+            if self._true_map_wh is not None:
+                agent_map = MapInfo(
+                    grid=self._map_info.grid, resolution=self._map_info.resolution,
+                    origin_x=self._map_info.origin_x, origin_y=self._map_info.origin_y,
+                    width_m=self._true_map_wh[0], height_m=self._true_map_wh[1])
+            self._agent.reset(ScenarioInfo(
+                name=self._scenario_name,
+                map=agent_map,
+                start_x=self._start_x,
+                start_y=self._start_y,
+                max_steps=self._max_steps,
+                step_size_hint=self._step_size_hint,
+            ))
+            self.get_logger().info(
+                f'SLAM map received ({w}x{h}, {w*res:.1f}x{h*res:.1f}m) — agent ready | '
+                f'agent={self._agent_spec} ({self._agent.name()}) | '
+                f'scenario={self._scenario_name} | '
+                f'max_steps={self._max_steps} '
+                f'(dist_budget={self._max_travel_distance_m:.1f}m, '
+                f'time_budget={self._max_sim_time_s:.1f}s) | '
+                f'escape={"ON" if self._escape else "OFF"} | '
+                f'pose={self._pose_source} | map={self._map_source}')
+
+    def _pose_callback(self, msg: PoseWithCovarianceStamped):
+        """The tick. Everything downstream is driven by pose arrivals."""
+        self._gt_x = msg.pose.pose.position.x
+        self._gt_y = msg.pose.pose.position.y
+        gq = msg.pose.pose.orientation
+        self._gt_theta = math.atan2(
+            2.0 * (gq.w * gq.z + gq.x * gq.y),
+            1.0 - 2.0 * (gq.y * gq.y + gq.z * gq.z))
+        self._cache.update_pose(msg, set_position=(self._pose_source != 'tf'))
+
+        if self._pose_source == 'tf' and self._tf_buffer is not None:
+            try:
+                tf = self._tf_buffer.lookup_transform(
+                    'map', f'{self._ns}_base_link', rclpy.time.Time())
+                self._cache.x = tf.transform.translation.x
+                self._cache.y = tf.transform.translation.y
+                q = tf.transform.rotation
+                siny_cosp = 2.0 * (q.w * q.z + q.x * q.y)
+                cosy_cosp = 1.0 - 2.0 * (q.y * q.y + q.z * q.z)
+                self._cache.theta = math.atan2(siny_cosp, cosy_cosp)
+                self._tf_fallback_count = 0
+            except (tf2_ros.LookupException,
+                    tf2_ros.ConnectivityException,
+                    tf2_ros.ExtrapolationException) as exc:
+                self._tf_fallback_count += 1
+                if self._tf_fallback_count <= 3 or self._tf_fallback_count % 50 == 0:
+                    self.get_logger().warn(
+                        f'TF lookup map->{self._ns}_base_link failed '
+                        f'(#{self._tf_fallback_count}): {exc}. '
+                        f'Holding last SLAM pose.')
+
+        if self._done:
+            return
+
+        # (1) Driving: hold the step loop until Nav2 completes, with a per-step timeout.
+        if self._is_moving and self._motion_mode == 'stop_go':
+            self._check_drive_timeout()
+            return
+
+        # (2) One-time initial placement.
+        if not self._placed:
+            self._placed = True
+            if self._start_x > -998.0 and self._start_y > -998.0:
+                self.get_logger().info(
+                    f'Placing robot at start ({self._start_x:.2f}, {self._start_y:.2f})')
+                self._place_robot(self._start_x, self._start_y)
+                self._last_step_time_ns = self.get_clock().now().nanoseconds
+                return
+
+        # (3) Fresh-scan gate: without it, step 0's lidar is from the pre-placement pose.
+        if (self._teleport_wait_stamp_ns is not None
+                and self._cache.last_scan_stamp_ns <= self._teleport_wait_stamp_ns):
+            return
+
+        # (4) Rate gate.
+        now_ns = self.get_clock().now().nanoseconds
+        delay = (self._decision_period_s if self._motion_mode == 'continuous'
+                 else self._step_delay)
+        if now_ns - self._last_step_time_ns < int(delay * 1e9):
+            return
+        self._last_step_time_ns = now_ns
+
+        if self._episode_start_ns is None:
+            self._episode_start_ns = now_ns
+
+        self._take_step()
+
+    def _check_drive_timeout(self):
+        """Cancel a wedged Nav2 goal so the agent re-decides instead of waiting ~150s
+        for the behaviour tree to give up."""
+        eff = self._drive_timeout
+        if self._escape is not None and self._escape.escaping:
+            eff = min(self._drive_timeout, 10.0)   # escape hops are short; fail them fast
+        # Snapshot: _on_nav_complete nulls _drive_goal_time from another executor
+        # thread, so re-reading it after the guard can yield None mid-subtraction.
+        goal_time = self._drive_goal_time
+        if eff <= 0.0 or goal_time is None or self._drive_canceling:
+            return
+        elapsed = (self.get_clock().now() - goal_time).nanoseconds * 1e-9
+        if elapsed > eff:
+            self._drive_canceling = True
+            self._n_drive_timeouts += 1
+            self.get_logger().warn(
+                f'[Step {self._step:3d}] DRIVE TIMEOUT — goal not reached in '
+                f'{elapsed:.1f}s (> {eff:.1f}s); canceling, re-deciding.')
+            if self._navigator is not None:
+                self._navigator.cancel_current_goal()
+
+    def _on_nav_complete(self):
+        """Nav2 goal finished (success / abort / reject / cancel)."""
+        self._is_moving = False
+        self._drive_goal_time = None
+        self._drive_goal_wall = None
+        self._drive_canceling = False
+
+    def _wall_watchdog(self):
+        """The only thing here that keeps ticking when the simulator is gone.
+
+        Every other timeout is measured on the node clock and the step loop runs off
+        pose callbacks — both driven by the sim. When the sim dies they die with it,
+        and the run hangs until the batch wall timeout (observed: a single step
+        blocking 6.3 h).
+        """
+        now_w = time.monotonic()
+
+        # (1) Simulator liveness.
+        if (self._pose_stale_timeout > 0.0 and self._cache.last_pose_wall is not None
+                and not self._done):
+            stale = now_w - self._cache.last_pose_wall
+            if stale > self._pose_stale_timeout:
+                self.get_logger().error(
+                    f'ENV DEAD — no pose for {stale:.0f}s wall '
+                    f'(> {self._pose_stale_timeout:.0f}s). Aborting.')
+                self._write_result(success=False, status='env_dead')
+                os._exit(3)
+
+        # (2) Wall backstop for the per-step drive timeout: only fires when the
+        # sim-time path cannot run at all. Deliberately slack so it never pre-empts it.
+        if self._motion_mode == 'continuous':
+            # A continuously retargeted action may legitimately span the episode;
+            # Nav2's progress checker handles controller stalls in this mode.
+            return
+        if not self._is_moving or self._drive_canceling:
+            return
+        goal_wall = self._drive_goal_wall
+        if goal_wall is None:
+            return
+        eff = self._drive_timeout
+        if self._escape is not None and self._escape.escaping:
+            eff = min(self._drive_timeout, 10.0)
+        if eff <= 0.0:
+            return
+        limit = max(eff * 3.0, eff + 30.0)
+        if now_w - goal_wall > limit:
+            self._drive_canceling = True
+            self._n_drive_timeouts += 1
+            self.get_logger().warn(
+                f'[Step {self._step:3d}] WALL-CLOCK DRIVE TIMEOUT — '
+                f'{now_w - goal_wall:.1f}s wall (> {limit:.1f}s) with no goal completion; '
+                'canceling, re-deciding.')
+            if self._navigator is not None:
+                self._navigator.cancel_current_goal()
+
+    # ------------------------------------------------------------------
+    # Decision loop
+    # ------------------------------------------------------------------
+
+    def _take_step(self):
+        if self._done or not self._cache.ready():
+            return
+        if self._map_source == 'slam' and not self._agent_reset_done:
+            return
+
+        rx, ry = self._cache.x, self._cache.y
+
+        eval_x = self._gt_x if self._gt_x is not None else rx
+        eval_y = self._gt_y if self._gt_y is not None else ry
+
+        # --- termination checks ---
+        dist_to_source = math.hypot(eval_x - self._true_source_x, eval_y - self._true_source_y)
+        if dist_to_source < self._success_radius:
+            # The old drivers grep for this exact line; keep it verbatim.
+            self.get_logger().info(
+                f'Source found at step {self._step}!  Distance: {dist_to_source:.3f} m')
+            self._end_episode(success=True, status='success')
+            return
+        if self._step >= self._max_steps:
+            self.get_logger().warn(f'Max steps ({self._max_steps}) reached. Episode failed.')
+            self._end_episode(success=False, status='max_steps')
+            return
+        if (self._max_travel_distance_m > 0.0
+                and self._cache.travel_distance_m >= self._max_travel_distance_m):
+            self.get_logger().warn(
+                f'Max travel distance ({self._max_travel_distance_m:.1f} m) reached '
+                f'({self._cache.travel_distance_m:.1f} m travelled). Episode failed.')
+            self._end_episode(success=False, status='max_travel_distance')
+            return
+        if self._max_sim_time_s > 0.0 and self._sim_time() >= self._max_sim_time_s:
+            self.get_logger().warn(
+                f'Max sim time ({self._max_sim_time_s:.1f} s) reached '
+                f'({self._sim_time():.1f} s elapsed). Episode failed.')
+            self._end_episode(success=False, status='max_sim_time')
+            return
+
+        # --- optional escape (harness-level recovery) ---
+        if self._escape is not None:
+            self._slam_enabled = True   # pose is confirmed post-placement
+            og = 1 if self._cache.gas_ppm > self._escape.src_gas_eps else 0
+            self._escape.record_step(
+                rx, ry, og, self._cache.wind_speed, self._cache.wind_direction)
+            if self._escape.escaping:
+                wp = self._escape.next_waypoint(rx, ry)
+                if wp is not None:
+                    self._drive(float(wp[0]), float(wp[1]), theta=None)
+                    self._step += 1
+                    return
+                # path exhausted -> fall through and let the agent decide again
+            else:
+                info = self._escape.start_escape_if_stuck(rx, ry, self._step)
+                if info is not None:
+                    tx, ty, fsize, fdist, nwp = info
+                    self._n_escapes += 1
+                    self.get_logger().warn(
+                        f'[Step {self._step:3d}] STUCK ({self._escape.stuck_reason}) → '
+                        f'escape to ({tx:.2f},{ty:.2f}) via {nwp} hops '
+                        f'[frontier {fsize} cells, {fdist:.1f}m away]')
+                    wp = self._escape.next_waypoint(rx, ry)
+                    if wp is not None:
+                        self._drive(float(wp[0]), float(wp[1]), theta=None)
+                        self._step += 1
+                        return
+
+        # --- the agent ---
+        obs = self._cache.snapshot(self._step, self._sim_time(), self._map_info)
+        try:
+            self._agent.observe(obs)
+            wp = self._agent.act()
+        except Exception as exc:
+            import traceback
+            self.get_logger().error(f'Agent raised: {exc}\n{traceback.format_exc()}')
+            self._end_episode(success=False, status='agent_error')
+            return
+
+        if wp is None:
+            self.get_logger().error('Agent returned None from act(); expected a Waypoint.')
+            self._end_episode(success=False, status='agent_error')
+            return
+
+        tx, ty = float(wp.x), float(wp.y)
+        theta = wp.theta if wp.theta is None else float(wp.theta)
+
+        # --- sanitize: cap the hop, then clamp into free space ---
+        tx, ty = self._cap_hop(rx, ry, tx, ty)
+        ray = math.atan2(ty - ry, tx - rx) if (tx, ty) != (rx, ry) else (theta or 0.0)
+        tx, ty, collided = self._clamp_to_free(rx, ry, tx, ty, ray)
+        if collided:
+            self._n_clamped += 1
+
+        lm = self._cache.lidar_min
+        lidar_text = 'n/a' if lm is None else f'{lm:.2f}'
+        # yaw diagnostic: the lidar array is rolled by _cache.theta (SLAM/TF yaw
+        # in tf mode), while the physical scan is cast at the TRUE body yaw
+        # (_gt_theta). Any gap here rotates the whole lidar pattern into wrong
+        # obs slots. err wrapped to [-180,180].
+        yaw_slam = math.degrees(self._cache.theta)
+        if self._gt_theta is not None:
+            yaw_err = math.degrees(math.atan2(
+                math.sin(self._cache.theta - self._gt_theta),
+                math.cos(self._cache.theta - self._gt_theta)))
+            yaw_text = (f' yaw(slam={yaw_slam:.1f},gt={math.degrees(self._gt_theta):.1f},'
+                        f'err={yaw_err:.1f}deg)')
+        else:
+            yaw_text = f' yaw(slam={yaw_slam:.1f}deg)'
+        self.get_logger().info(
+            f'[Step {self._step:3d}] Pos ({rx:.2f},{ry:.2f}) → Target ({tx:.2f},{ty:.2f}) | '
+            f'd2src={dist_to_source:.2f}m gas={self._cache.gas_ppm:.3f} '
+            f'wind=({self._cache.wind_speed:.2f}m/s,'
+            f'{math.degrees(self._cache.wind_direction):.1f}deg) '
+            f'lidar_min={lidar_text}m'
+            f'{yaw_text}'
+            f'{" COLLISION — clamped" if collided else ""}')
+
+        if self._publish_marker:
+            self._publish_target_marker(rx, ry, tx, ty)
+
+        self._drive(tx, ty, theta if theta is not None else ray)
+        self._step += 1
+
+    # ------------------------------------------------------------------
+    # Motion
+    # ------------------------------------------------------------------
+
+    def _publish_goal_pose(self, x: float, y: float, theta: Optional[float]):
+        """Mirror the current drive target on /gsl_bench/goal for RViz (frame map)."""
+        msg = PoseStamped()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = 'map'
+        msg.pose.position.x = float(x)
+        msg.pose.position.y = float(y)
+        yaw = 0.0 if theta is None else float(theta)
+        msg.pose.orientation.z = math.sin(yaw / 2.0)
+        msg.pose.orientation.w = math.cos(yaw / 2.0)
+        self._goal_pub.publish(msg)
+
+    def _drive(self, x: float, y: float, theta: Optional[float]):
+        """Physical Nav2 drive to (x, y). Never a teleport — that is eval policy."""
+        self._publish_goal_pose(x, y, theta)
+        if self._motion_mode == 'continuous' and self._is_moving:
+            msg = PoseStamped()
+            msg.header.stamp = self.get_clock().now().to_msg()
+            msg.header.frame_id = 'map'
+            msg.pose.position.x = float(x)
+            msg.pose.position.y = float(y)
+            yaw = 0.0 if theta is None else float(theta)
+            msg.pose.orientation.z = math.sin(yaw / 2.0)
+            msg.pose.orientation.w = math.cos(yaw / 2.0)
+            self._goal_update_pub.publish(msg)
+            self._n_goal_updates += 1
+            return
+        self._is_moving = True
+        self._drive_canceling = False
+        self._drive_goal_time = self.get_clock().now()
+        self._drive_goal_wall = time.monotonic()
+        if theta is None:
+            self._navigator.send_goal(
+                x, y, use_orientation=False, tolerance=self._nav_goal_tolerance)
+        else:
+            self._navigator.send_goal(
+                x, y, yaw=float(theta), use_orientation=True,
+                tolerance=self._nav_goal_tolerance)
+        self._n_action_starts += 1
+
+    def _place_robot(self, x: float, y: float):
+        """The one teleport allowed per episode: initial placement."""
+        msg = PoseWithCovarianceStamped()
+        msg.header.stamp = self.get_clock().now().to_msg()
+        msg.header.frame_id = 'map'
+        msg.pose.pose.position.x = float(x)
+        msg.pose.pose.position.y = float(y)
+        msg.pose.pose.orientation.w = 1.0
+        msg.pose.covariance = [0.0] * 36
+        self._place_pub.publish(msg)
+        # Arm the fresh-scan gate: the first step must wait for a scan stamped
+        # after this placement.
+        self._teleport_wait_stamp_ns = self._cache.last_scan_stamp_ns
+
+    def _cap_hop(self, rx, ry, tx, ty):
+        """Shorten an over-long request along its own ray; agents can't outrun the sim."""
+        d = math.hypot(tx - rx, ty - ry)
+        if d <= self._effective_max_hop or d < 1e-9:
+            return tx, ty
+        s = self._effective_max_hop / d
+        return rx + (tx - rx) * s, ry + (ty - ry) * s
+
+    def _clamp_to_free(self, rx, ry, tx, ty, theta):
+        """Validate the target; if blocked, walk back along the ray until free.
+
+        Mirrors the training-time collision logic: the robot would simply not move
+        if the target were inside a wall.
+
+        In SLAM mode (map_source == 'slam') unknown cells are treated as passable
+        so the robot can drive into unmapped territory and expand the map.
+        """
+        valid = (self._occ_map.is_valid_traversable((tx, ty), radius=self._robot_radius)
+                 if self._map_source == 'slam'
+                 else self._occ_map.is_valid((tx, ty), radius=self._robot_radius))
+        if valid:
+            return tx, ty, False
+        step = math.hypot(tx - rx, ty - ry) - 0.05
+        while step >= 0.1:
+            cx = rx + step * math.cos(theta)
+            cy = ry + step * math.sin(theta)
+            valid = (self._occ_map.is_valid_traversable((cx, cy), radius=self._robot_radius)
+                     if self._map_source == 'slam'
+                     else self._occ_map.is_valid((cx, cy), radius=self._robot_radius))
+            if valid:
+                return cx, cy, True
+            step -= 0.05
+        return rx, ry, True   # boxed in: stay put
+
+    def _publish_target_marker(self, rx, ry, tx, ty):
+        m = Marker()
+        m.header.frame_id = 'map'
+        m.header.stamp = self.get_clock().now().to_msg()
+        m.ns = 'gsl_bench_target'
+        m.id = 1
+        m.type = Marker.ARROW
+        m.action = Marker.ADD
+        m.scale.x, m.scale.y, m.scale.z = 0.06, 0.12, 0.12
+        m.color.a, m.color.r, m.color.g, m.color.b = 0.95, 0.95, 0.75, 0.05
+        m.points = [Point(x=float(rx), y=float(ry), z=0.12),
+                    Point(x=float(tx), y=float(ty), z=0.12)]
+        self._marker_pub.publish(m)
+
+    # ------------------------------------------------------------------
+    # Episode end
+    # ------------------------------------------------------------------
+
+    def _sim_time(self) -> float:
+        if self._episode_start_ns is None:
+            return 0.0
+        return (self.get_clock().now().nanoseconds - self._episode_start_ns) * 1e-9
+
+    def _write_result(self, success: bool, status: str):
+        rx = self._cache.x if self._cache.x is not None else float('nan')
+        ry = self._cache.y if self._cache.y is not None else float('nan')
+        eval_x = self._gt_x if self._gt_x is not None else rx
+        eval_y = self._gt_y if self._gt_y is not None else ry
+        final_d = (math.hypot(eval_x - self._true_source_x, eval_y - self._true_source_y)
+                   if eval_x is not None else None)
+        result = {
+            'schema': 1,
+            'scenario': self._scenario_name,
+            'sim': self._sim_name,
+            'agent': self._agent_spec,
+            'agent_config': self._agent_config,
+            'status': status,
+            'success': bool(success),
+            'steps': int(self._step),
+            'sim_time_s': round(self._sim_time(), 2),
+            'wall_time_s': None,               # filled in by episode_runner
+            'travel_distance_m': round(self._cache.travel_distance_m, 3),
+            'final_distance_m': None if final_d is None else round(final_d, 3),
+            'source': [self._true_source_x, self._true_source_y],
+            'start': [self._start_x, self._start_y],
+            'escapes': self._n_escapes,
+            'clamped_steps': self._n_clamped,
+            'drive_timeouts': self._n_drive_timeouts,
+            'nav_action_starts': self._n_action_starts,
+            'goal_updates': self._n_goal_updates,
+            'tf_fallback_count': self._tf_fallback_count,
+            'agent_metadata': self._agent.metadata(),
+            'harness': {
+                'success_radius': self._success_radius,
+                'max_steps': self._max_steps,
+                'max_travel_distance_m': self._max_travel_distance_m,
+                'max_sim_time_s': self._max_sim_time_s,
+                'step_delay': self._step_delay,
+                'nav_goal_tolerance': self._nav_goal_tolerance,
+                'drive_timeout': self._drive_timeout,
+                'escape': bool(self._escape is not None),
+                'max_hop': self._max_hop,
+                'effective_max_hop': self._effective_max_hop,
+                'motion_mode': self._motion_mode,
+                'decision_rate_hz': getattr(self._agent, 'decision_rate_hz', None),
+                'robot_radius': self._robot_radius,
+                'lidar': '360deg/72ray/3m',
+                'motion': self._motion,
+                'nav_profile': self._nav_profile,
+                'pose_source': self._pose_source,
+                'map_source': self._map_source,
+            },
+            'timestamp': datetime.now().isoformat(timespec='seconds'),
+        }
+        try:
+            os.makedirs(os.path.dirname(os.path.abspath(self._result_file)), exist_ok=True)
+            with open(self._result_file, 'w') as f:
+                json.dump(result, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+        except Exception as exc:
+            self.get_logger().error(f'Failed to write {self._result_file}: {exc}')
+
+    def _end_episode(self, success: bool, status: str):
+        self._done = True
+        self.get_logger().info(
+            f'{"SUCCESS" if success else "FAILURE"} ({status}) — {self._step} steps, '
+            f'{self._cache.travel_distance_m:.1f} m travelled')
+        self._write_result(success, status)
+        # os._exit() and not rclpy.shutdown(): we are inside a subscription callback,
+        # and shutdown here can deadlock tearing down the executor that is running us.
+        # The result file is already flushed and fsynced.
+        os._exit(0)
+
+
+def main(args=None):
+    rclpy.init(args=args)
+    node = None
+    try:
+        node = RunnerNode()
+        # >=3 threads: one is free to service rclpy's /clock subscription (default
+        # callback group) while the heavy sensor callbacks (their own _cbg group)
+        # and the Nav2 action feedback run — otherwise the sim clock starves/freezes.
+        executor = MultiThreadedExecutor(num_threads=4)
+        executor.add_node(node)
+        executor.spin()
+    except KeyboardInterrupt:
+        pass
+    finally:
+        if node is not None:
+            try:
+                node.destroy_node()
+            except Exception:
+                pass
+        try:
+            if rclpy.ok():
+                rclpy.shutdown()
+        except Exception:
+            pass
+
+
+if __name__ == '__main__':
+    main()

--- a/gsl_bench/gsl_bench/registry.py
+++ b/gsl_bench/gsl_bench/registry.py
@@ -1,0 +1,34 @@
+"""Agent lookup: by shipped name, by entry point, or by dotted path 'pkg.module:Class'."""
+import importlib
+from importlib.metadata import entry_points
+
+
+def _agent_entry_points():
+    eps = entry_points()
+    # Python 3.10+ returns a SelectableGroups; 3.8/3.9 returns a plain dict.
+    if hasattr(eps, 'select'):
+        return list(eps.select(group='gsl_bench.agents'))
+    return list(eps.get('gsl_bench.agents', []))
+
+
+def available_agents():
+    return sorted(ep.name for ep in _agent_entry_points())
+
+
+def load_agent_class(spec: str):
+    """Resolve an agent spec to a class.
+
+    'gpulaika'                    -> shipped/registered entry point
+    'mypkg.my_agent:MyAgent'      -> dotted path, no registration needed
+    """
+    if not spec:
+        raise KeyError("No agent given. Use a registered name or 'pkg.module:ClassName'.")
+    if ':' in spec:
+        mod, cls = spec.split(':', 1)
+        return getattr(importlib.import_module(mod), cls)
+    for ep in _agent_entry_points():
+        if ep.name == spec:
+            return ep.load()
+    raise KeyError(
+        f"Unknown agent '{spec}'. Available: {available_agents()} "
+        f"or use 'pkg.module:ClassName'.")

--- a/gsl_bench/package.xml
+++ b/gsl_bench/package.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>gsl_bench</name>
+  <version>0.1.0</version>
+  <description>NavSim-style modular benchmark for gas source localization: implement observe()/act(), the harness owns simulation, motion, timeouts and metrics.</description>
+  <maintainer email="efemantaroglu@gmail.com">efe</maintainer>
+  <license>TODO: License declaration</license>
+
+  <depend>rclpy</depend>
+  <depend>sensor_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>nav2_msgs</depend>
+  <depend>geometry_msgs</depend>
+  <depend>visualization_msgs</depend>
+  <depend>std_msgs</depend>
+  <depend>olfaction_msgs</depend>
+  <depend>efe_igdm</depend>
+  <exec_depend>adsm</exec_depend>
+
+  <exec_depend>benchmark_env</exec_depend>
+
+  <test_depend>ament_copyright</test_depend>
+  <test_depend>ament_flake8</test_depend>
+  <test_depend>ament_pep257</test_depend>
+  <test_depend>python3-pytest</test_depend>
+
+  <export>
+    <build_type>ament_python</build_type>
+  </export>
+</package>

--- a/gsl_bench/scripts/visualize_agent_runs.py
+++ b/gsl_bench/scripts/visualize_agent_runs.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Visual sanity check for zigzag / surge_cast — no ROS, no GADEN.
+
+Runs each agent's real observe()/act() loop against a synthetic Gaussian-plume
+world (open room, no walls: this is about the chemotaxis pattern itself, not
+obstacle navigation) and saves the trajectory + gas field as a PNG.
+
+    python3 visualize_agent_runs.py [--out-dir DIR] [--max-steps N]
+"""
+import argparse
+import math
+from pathlib import Path
+
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+from matplotlib.collections import LineCollection
+import numpy as np
+
+from gsl_bench.agent import MapInfo, Observation, ScenarioInfo, Waypoint
+from gsl_bench.agents.surge_cast import SurgeCastAgent
+from gsl_bench.agents.zigzag import ZigzagAgent
+
+# --- synthetic world ---------------------------------------------------
+
+WIDTH_M, HEIGHT_M = 12.0, 8.0
+RESOLUTION = 0.1
+SOURCE = (3.0, 4.0)
+WIND_DIR = 0.0                    # downwind bearing: gas blows toward +x
+WIND_SPEED = 0.6
+START = (11.5, 7.0)               # downwind, off-centerline: needs a real search
+GAS_THRESHOLD = 5.0
+SUCCESS_RADIUS = 0.5
+
+# same palette as the surge-cast state-machine diagram
+STATE_COLORS = {'SURGE': '#b5651d', 'CAST': '#1e7f72', 'SPIRAL': '#6a4c93'}
+
+
+def make_map() -> MapInfo:
+    h, w = int(HEIGHT_M / RESOLUTION), int(WIDTH_M / RESOLUTION)
+    grid = np.zeros((h, w), np.uint8)
+    return MapInfo(grid=grid, resolution=RESOLUTION, origin_x=0.0, origin_y=0.0,
+                    width_m=WIDTH_M, height_m=HEIGHT_M)
+
+
+def gas_field(x, y):
+    """Gaussian-plume centerline model: narrow near the source, widening and
+    diluting downwind. Tuned so the chosen START is just below gas_threshold —
+    the agent has to search before it gets a hit."""
+    ux, uy = math.cos(WIND_DIR), math.sin(WIND_DIR)
+    vx, vy = -math.sin(WIND_DIR), math.cos(WIND_DIR)
+    dx, dy = x - SOURCE[0], y - SOURCE[1]
+    along = dx * ux + dy * uy
+    across = dx * vx + dy * vy
+    if along <= 0.0:
+        return 80.0 * math.exp(2.5 * along) * math.exp(-(across ** 2) / (2 * 0.3 ** 2))
+    sigma = 0.3 + 0.12 * along
+    return 80.0 * math.exp(-0.08 * along) * math.exp(-(across ** 2) / (2 * sigma ** 2))
+
+
+def make_obs(m, x, y, step, rng):
+    gas = max(0.0, gas_field(x, y) + rng.normal(0, 0.5))
+    wind_dir = WIND_DIR + rng.normal(0, 0.05)
+    return Observation(
+        x=x, y=y, theta=0.0, gas_ppm=gas, wind_speed=WIND_SPEED,
+        wind_direction=wind_dir, lidar=np.full(72, 3.0, np.float32),
+        lidar_max_range=3.0, step=step, sim_time=float(step) * 0.5, map=m)
+
+
+def run_episode(agent, m, max_steps, rng, track_state=False, start=START):
+    agent.initialize()
+    agent.reset(ScenarioInfo('viz', m, start[0], start[1], max_steps, 0.5))
+    x, y = start
+    xs, ys, states = [x], [y], []
+    success_step = None
+    for step in range(max_steps):
+        agent.observe(make_obs(m, x, y, step, rng))
+        wp = agent.act()
+
+        # mirror the harness's hop cap (max_hop=1.0); no walls here to clamp against
+        d = math.hypot(wp.x - x, wp.y - y)
+        if d > 1.0:
+            s = 1.0 / d
+            wp = Waypoint(x + (wp.x - x) * s, y + (wp.y - y) * s)
+        x, y = wp.x, wp.y
+        xs.append(x)
+        ys.append(y)
+        if track_state:
+            states.append(getattr(agent, 'state', 'CAST'))
+
+        if math.hypot(x - SOURCE[0], y - SOURCE[1]) < SUCCESS_RADIUS:
+            success_step = step
+            break
+    return xs, ys, states, success_step
+
+
+def plot_run(xs, ys, states, success_step, title, out_path):
+    xx = np.linspace(0, WIDTH_M, 240)
+    yy = np.linspace(0, HEIGHT_M, 160)
+    field = np.array([[gas_field(x, y) for x in xx] for y in yy])
+
+    fig, ax = plt.subplots(figsize=(9, 6.2))
+    fig.patch.set_facecolor('#0e1512')
+    ax.set_facecolor('#0e1512')
+
+    cf = ax.contourf(xx, yy, field, levels=18, cmap='YlOrBr', alpha=0.55)
+    cb = fig.colorbar(cf, ax=ax, shrink=0.8, pad=0.02)
+    cb.set_label('gas concentration (ppm)', color='#e7efea')
+    cb.ax.yaxis.set_tick_params(color='#e7efea')
+    plt.setp(cb.ax.get_yticklabels(), color='#e7efea')
+
+    if states:
+        for i in range(len(xs) - 1):
+            c = STATE_COLORS.get(states[i], '#4fbfae')
+            ax.plot(xs[i:i + 2], ys[i:i + 2], color=c, linewidth=2.2, solid_capstyle='round')
+        handles = [plt.Line2D([0], [0], color=c, lw=2.5, label=s)
+                   for s, c in STATE_COLORS.items()]
+        ax.legend(handles=handles, loc='upper left', facecolor='#131b17',
+                  edgecolor='#2a3833', labelcolor='#e7efea', fontsize=9)
+    else:
+        pts = np.array([xs, ys]).T.reshape(-1, 1, 2)
+        segs = np.concatenate([pts[:-1], pts[1:]], axis=1)
+        lc = LineCollection(segs, cmap='BuGn', linewidth=2.4)
+        lc.set_array(np.linspace(0.25, 1.0, len(segs)))
+        ax.add_collection(lc)
+
+    ax.scatter([xs[0]], [ys[0]], marker='o', s=90, color='#e7efea',
+              edgecolor='#0e1512', zorder=5, label='start')
+    ax.scatter([xs[-1]], [ys[-1]], marker='X', s=110, color='#e7efea',
+              edgecolor='#0e1512', zorder=5, label='end')
+    ax.scatter([SOURCE[0]], [SOURCE[1]], marker='*', s=260, color='#ffe08a',
+              edgecolor='#0e1512', zorder=6, label='source')
+
+    status = f'FOUND @ step {success_step}' if success_step is not None else 'NOT FOUND (max_steps)'
+    ax.set_title(f'{title}  —  {status}', color='#e7efea', fontsize=13, pad=12)
+    ax.set_xlabel('x (m)', color='#8fa69c')
+    ax.set_ylabel('y (m)', color='#8fa69c')
+    ax.tick_params(colors='#8fa69c')
+    for spine in ax.spines.values():
+        spine.set_color('#2a3833')
+    ax.set_xlim(0, WIDTH_M)
+    ax.set_ylim(0, HEIGHT_M)
+    ax.set_aspect('equal')
+
+    fig.tight_layout()
+    fig.savefig(out_path, dpi=150, facecolor=fig.get_facecolor())
+    plt.close(fig)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--out-dir', type=Path, default=Path('.'))
+    ap.add_argument('--max-steps', type=int, default=400)
+    ap.add_argument('--seed', type=int, default=0)
+    args = ap.parse_args()
+    args.out_dir.mkdir(parents=True, exist_ok=True)
+
+    m = make_map()
+
+    rng = np.random.default_rng(args.seed)
+    zz = ZigzagAgent({'step_size': 0.5, 'leg_length': 1.0, 'amplitude_growth': 0.15,
+                      'upwind_drift': 0.03})
+    xs, ys, _, done = run_episode(zz, m, args.max_steps, rng)
+    out = args.out_dir / 'zigzag_run.png'
+    plot_run(xs, ys, [], done, 'ZigzagAgent', out)
+    print(f'zigzag:     {"FOUND" if done is not None else "max_steps"} '
+          f'({len(xs)} positions) -> {out}')
+
+    rng = np.random.default_rng(args.seed)
+    sc = SurgeCastAgent({'gas_threshold': GAS_THRESHOLD, 'step_size': 0.5,
+                        'leg_length': 1.0, 'amplitude_growth': 0.3,
+                        'lost_steps_to_spiral': 30, 'spiral_growth': 0.15})
+    xs, ys, states, done = run_episode(sc, m, args.max_steps, rng, track_state=True)
+    out = args.out_dir / 'surge_cast_run.png'
+    plot_run(xs, ys, states, done, 'SurgeCastAgent', out)
+    print(f'surge_cast: {"FOUND" if done is not None else "max_steps"} '
+          f'({len(xs)} positions) -> {out}')
+
+    # A second surge_cast scenario, tuned to actually trigger SPIRAL: start far
+    # enough off the plume's crosswind axis that CAST's early (still-narrow)
+    # legs can't reach back into it, and lost_steps_to_spiral is lowered so the
+    # agent gives up on casting before its legs would have grown wide enough.
+    rng = np.random.default_rng(args.seed)
+    sc_spiral = SurgeCastAgent({'gas_threshold': GAS_THRESHOLD, 'step_size': 0.5,
+                               'leg_length': 1.0, 'amplitude_growth': 0.3,
+                               'lost_steps_to_spiral': 10, 'spiral_growth': 0.15})
+    spiral_start = (7.0, 7.5)
+    xs, ys, states, done = run_episode(
+        sc_spiral, m, args.max_steps, rng, track_state=True, start=spiral_start)
+    out = args.out_dir / 'surge_cast_spiral_demo.png'
+    plot_run(xs, ys, states, done, 'SurgeCastAgent (SPIRAL demo)', out)
+    print(f'surge_cast (spiral demo): {"FOUND" if done is not None else "max_steps"} '
+          f'({len(xs)} positions), SPIRAL used: {"SPIRAL" in states} -> {out}')
+
+
+if __name__ == '__main__':
+    main()

--- a/gsl_bench/setup.cfg
+++ b/gsl_bench/setup.cfg
@@ -1,0 +1,4 @@
+[develop]
+script_dir=$base/lib/gsl_bench
+[install]
+install_scripts=$base/lib/gsl_bench

--- a/gsl_bench/setup.py
+++ b/gsl_bench/setup.py
@@ -1,0 +1,46 @@
+from setuptools import setup
+
+package_name = 'gsl_bench'
+
+setup(
+    name=package_name,
+    version='0.1.0',
+    packages=[
+        package_name,
+        f'{package_name}.harness',
+        f'{package_name}.eval',
+        f'{package_name}.agents',
+    ],
+    data_files=[
+        ('share/ament_index/resource_index/packages', ['resource/gsl_bench']),
+        ('share/gsl_bench', ['package.xml']),
+        ('share/gsl_bench/configs', ['configs/harness_default.yaml']),
+        ('share/gsl_bench/configs/agents', [
+            'configs/agents/gpulaika.yaml', 'configs/agents/adsm.yaml']),
+    ],
+    install_requires=['setuptools'],
+    zip_safe=True,
+    maintainer='efe',
+    maintainer_email='efemantaroglu@gmail.com',
+    description='Modular GSL benchmark: implement observe()/act(), the harness does the rest.',
+    license='TODO',
+    tests_require=['pytest'],
+    entry_points={
+        'console_scripts': [
+            'runner_node = gsl_bench.harness.runner_node:main',
+            'eval = gsl_bench.eval.episode_runner:main',
+            'report = gsl_bench.eval.report:main',
+            'oracle = gsl_bench.eval.oracle:main',
+            'world_align = gsl_bench.eval.world_align:main',
+        ],
+        # Third parties register their agents under this group from their own package.
+        'gsl_bench.agents': [
+            'random_walk = gsl_bench.agents.random_walk:RandomWalkAgent',
+            'upwind_greedy = gsl_bench.agents.upwind_greedy:UpwindGreedyAgent',
+            'gpulaika = gsl_bench.agents.gpulaika_agent:GpulaikaAgent',
+            'zigzag = gsl_bench.agents.zigzag:ZigzagAgent',
+            'surge_cast = gsl_bench.agents.surge_cast:SurgeCastAgent',
+            'adsm = gsl_bench.agents.adsm_agent:AdsmAgent',
+        ],
+    },
+)

--- a/gsl_bench/test/test_adsm_agent.py
+++ b/gsl_bench/test/test_adsm_agent.py
@@ -1,0 +1,49 @@
+import numpy as np
+import pytest
+
+from gsl_bench.agent import MapInfo, Observation, ScenarioInfo, Waypoint
+
+adsm_core_py = pytest.importorskip('adsm_core_py')
+from gsl_bench.agents.adsm_agent import AdsmAgent  # noqa: E402
+
+
+def _map():
+    grid = np.full((80, 80), -1, dtype=np.int8)
+    grid[20:60, 20:60] = 0
+    grid[35:40, 35:40] = 100
+    return MapInfo(grid, 0.1, 0.0, 0.0, 8.0, 8.0)
+
+
+def _obs(step, sim_time):
+    return Observation(
+        x=2.5, y=2.5, theta=0.0, gas_ppm=0.0,
+        wind_speed=0.3, wind_direction=0.0,
+        lidar=np.full(72, 3.0), lidar_max_range=3.0,
+        step=step, sim_time=sim_time, map=_map())
+
+
+def test_adsm_capabilities_and_deterministic_trace():
+    scenario = ScenarioInfo('test', _map(), 2.5, 2.5, 20, 0.5)
+    agents = [AdsmAgent({'seed': 42, 'rrt_max_iter': 30}) for _ in range(2)]
+    traces = []
+    for agent in agents:
+        agent.reset(scenario)
+        trace = []
+        for step in range(4):
+            agent.observe(_obs(step, float(step + 1)))
+            wp = agent.act()
+            assert isinstance(wp, Waypoint)
+            assert wp.theta == 0.0
+            trace.append((wp.x, wp.y, agent.metadata()['goal_type']))
+        traces.append(trace)
+    assert traces[0] == traces[1]
+    assert agents[0].motion_mode == 'continuous'
+    assert agents[0].decision_rate_hz == 1.0
+    assert agents[0].max_goal_distance == 3.0
+
+
+def test_cpp_binding_rejects_non_grid_input():
+    engine = adsm_core_py.Engine(adsm_core_py.Config())
+    engine.reset(1)
+    with pytest.raises(ValueError):
+        engine.step(0, 0, 0, 0, 0, 0, 0, np.zeros(5, dtype=np.int8), 0.1, 0, 0)

--- a/gsl_bench/test/test_motion_modes.py
+++ b/gsl_bench/test/test_motion_modes.py
@@ -1,0 +1,67 @@
+import math
+from types import SimpleNamespace
+
+from builtin_interfaces.msg import Time
+from gsl_bench.harness.runner_node import RunnerNode
+
+
+class _Now:
+    nanoseconds = 1_000_000_000
+
+    def to_msg(self):
+        return Time(sec=1, nanosec=0)
+
+
+class _Clock:
+    def now(self):
+        return _Now()
+
+
+class _Publisher:
+    def __init__(self):
+        self.messages = []
+
+    def publish(self, msg):
+        self.messages.append(msg)
+
+
+class _Navigator:
+    def __init__(self):
+        self.goals = []
+
+    def send_goal(self, *args, **kwargs):
+        self.goals.append((args, kwargs))
+
+
+def _runner(mode, moving=False):
+    return SimpleNamespace(
+        _motion_mode=mode, _is_moving=moving, _drive_canceling=False,
+        _drive_goal_time=None, _drive_goal_wall=None, _goal_update_pub=_Publisher(),
+        _navigator=_Navigator(), _nav_goal_tolerance=0.1,
+        _n_goal_updates=0, _n_action_starts=0, get_clock=lambda: _Clock())
+
+
+def test_continuous_drive_updates_active_goal_without_new_action():
+    r = _runner('continuous', moving=True)
+    RunnerNode._drive(r, 2.0, 3.0, 0.4)
+    assert not r._navigator.goals
+    assert r._n_goal_updates == 1
+    msg = r._goal_update_pub.messages[0]
+    assert (msg.pose.position.x, msg.pose.position.y) == (2.0, 3.0)
+    assert math.isclose(msg.pose.orientation.z, math.sin(0.2))
+
+
+def test_stop_go_and_first_continuous_goal_start_action():
+    for mode in ('stop_go', 'continuous'):
+        r = _runner(mode, moving=False)
+        RunnerNode._drive(r, 2.0, 3.0, 0.0)
+        assert len(r._navigator.goals) == 1
+        assert r._n_action_starts == 1
+        assert r._is_moving
+
+
+def test_per_agent_goal_reach_controls_cap():
+    r = SimpleNamespace(_effective_max_hop=3.0)
+    assert RunnerNode._cap_hop(r, 0.0, 0.0, 2.5, 0.0) == (2.5, 0.0)
+    x, y = RunnerNode._cap_hop(r, 0.0, 0.0, 6.0, 0.0)
+    assert (x, y) == (3.0, 0.0)

--- a/gsl_bench/test/test_offline.py
+++ b/gsl_bench/test/test_offline.py
@@ -1,0 +1,160 @@
+"""Offline checks: no ROS, no simulator. Run with: pytest src/gsl_bench/test"""
+import json
+import math
+import tempfile
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from gsl_bench.agent import MapInfo, Observation, ScenarioInfo, Waypoint
+from gsl_bench.eval import metrics
+from gsl_bench.registry import available_agents, load_agent_class
+
+
+def _map():
+    grid = np.zeros((60, 140), np.uint8)
+    grid[:, 100:102] = 1                      # a wall at x ~ 9.8-10.0 m
+    return MapInfo(grid=grid, resolution=0.1, origin_x=-0.2, origin_y=-0.2,
+                   width_m=14.0, height_m=6.0)
+
+
+def _obs(m, x=5.0, y=3.0, gas=0.0, wind_dir=0.0, wind_speed=0.0, step=0):
+    return Observation(x=x, y=y, theta=0.0, gas_ppm=gas, wind_speed=wind_speed,
+                       wind_direction=wind_dir, lidar=np.full(72, 2.5, np.float32),
+                       lidar_max_range=3.0, step=step, sim_time=float(step), map=m)
+
+
+def test_map_is_free():
+    m = _map()
+    assert m.is_free(5.0, 3.0)
+    assert not m.is_free(9.9, 3.0)            # inside the wall
+    assert not m.is_free(-5.0, 3.0)           # outside the map
+
+
+def test_registry_lists_shipped_agents():
+    assert {'random_walk', 'upwind_greedy', 'gpulaika',
+            'zigzag', 'surge_cast'} <= set(available_agents())
+
+
+@pytest.mark.parametrize('spec', ['random_walk', 'upwind_greedy', 'zigzag', 'surge_cast'])
+def test_baseline_agents_step_into_free_space(spec):
+    m = _map()
+    agent = load_agent_class(spec)({'seed': 3, 'gas_threshold': 0.1})
+    agent.initialize()
+    agent.reset(ScenarioInfo('t', m, 5.0, 3.0, 600, 0.5))
+    x, y = 5.0, 3.0
+    for step in range(10):
+        agent.observe(_obs(m, x, y, wind_dir=0.0, wind_speed=0.5, step=step))
+        wp = agent.act()
+        assert isinstance(wp, Waypoint)
+        assert math.hypot(wp.x - x, wp.y - y) <= 0.51
+        assert m.is_free(wp.x, wp.y)
+        x, y = wp.x, wp.y
+
+
+def test_upwind_greedy_goes_upwind_on_a_hit():
+    m = _map()
+    agent = load_agent_class('upwind_greedy')({'gas_threshold': 0.1})
+    agent.initialize()
+    agent.reset(ScenarioInfo('t', m, 5.0, 3.0, 600, 0.5))
+    # wind blowing toward +x means the source is toward -x
+    agent.observe(_obs(m, gas=1.0, wind_dir=0.0, wind_speed=0.5))
+    wp = agent.act()
+    assert wp.x < 5.0, 'should surge upwind (-x) on a gas hit'
+
+
+def test_zigzag_alternates_sides():
+    m = _map()
+    agent = load_agent_class('zigzag')({'leg_length': 0.5, 'step_size': 0.5,
+                                        'amplitude_growth': 0.0, 'upwind_drift': 0.0})
+    agent.initialize()
+    agent.reset(ScenarioInfo('t', m, 5.0, 3.0, 600, 0.5))
+    x, y = 5.0, 3.0
+    sides = []
+    for step in range(4):
+        agent.observe(_obs(m, x, y, wind_dir=0.0, wind_speed=0.5, step=step))
+        wp = agent.act()
+        sides.append(agent.side)
+        x, y = wp.x, wp.y
+    assert sides == [-1, 1, -1, 1], 'a full leg every step should flip side each call'
+
+
+def test_zigzag_falls_back_to_random_walk_with_no_wind():
+    m = _map()
+    agent = load_agent_class('zigzag')({'seed': 1})
+    agent.initialize()
+    agent.reset(ScenarioInfo('t', m, 5.0, 3.0, 600, 0.5))
+    agent.observe(_obs(m, wind_dir=0.0, wind_speed=0.0))
+    wp = agent.act()
+    assert isinstance(wp, Waypoint) and m.is_free(wp.x, wp.y)
+
+
+def test_surge_cast_surges_upwind_on_hit():
+    m = _map()
+    agent = load_agent_class('surge_cast')({'gas_threshold': 0.1})
+    agent.initialize()
+    agent.reset(ScenarioInfo('t', m, 5.0, 3.0, 600, 0.5))
+    agent.observe(_obs(m, gas=1.0, wind_dir=0.0, wind_speed=0.5))
+    wp = agent.act()
+    assert wp.x < 5.0, 'should surge upwind (-x) on a gas hit'
+    assert agent.state == 'SURGE'
+
+
+def test_surge_cast_casts_then_spirals_after_sustained_loss():
+    m = _map()
+    agent = load_agent_class('surge_cast')(
+        {'gas_threshold': 0.1, 'lost_steps_to_spiral': 3})
+    agent.initialize()
+    agent.reset(ScenarioInfo('t', m, 5.0, 3.0, 600, 0.5))
+
+    # one hit -> SURGE
+    agent.observe(_obs(m, gas=1.0, wind_dir=0.0, wind_speed=0.5, step=0))
+    agent.act()
+    assert agent.state == 'SURGE'
+
+    # lose the plume -> CAST
+    agent.observe(_obs(m, gas=0.0, wind_dir=0.0, wind_speed=0.5, step=1))
+    agent.act()
+    assert agent.state == 'CAST'
+
+    # keep losing it past lost_steps_to_spiral -> SPIRAL
+    for step in range(2, 6):
+        agent.observe(_obs(m, gas=0.0, wind_dir=0.0, wind_speed=0.5, step=step))
+        agent.act()
+    assert agent.state == 'SPIRAL'
+
+    # a fresh hit drops straight back to SURGE
+    agent.observe(_obs(m, gas=1.0, wind_dir=0.0, wind_speed=0.5, step=6))
+    agent.act()
+    assert agent.state == 'SURGE'
+
+
+def test_aggregate_and_fairness_guard():
+    runs = [
+        {'scenario': 's1', 'success': True, 'status': 'success', 'steps': 10,
+         'sim_time_s': 20.0, 'travel_distance_m': 5.0, 'final_distance_m': 0.4,
+         'harness': {'max_steps': 600, 'escape': False}},
+        {'scenario': 's1', 'success': False, 'status': 'max_steps', 'steps': 600,
+         'sim_time_s': 900.0, 'travel_distance_m': 90.0, 'final_distance_m': 7.0,
+         'harness': {'max_steps': 600, 'escape': False}},
+    ]
+    agg = metrics.aggregate(runs)
+    s = agg['per_scenario']['s1']
+    assert (s['n'], s['n_success'], s['success_rate']) == (2, 1, 0.5)
+    assert s['mean_time_s'] == 20.0        # TT over successes only
+    assert s['mean_distance_m'] == 5.0     # TD over successes only
+    assert s['mean_final_distance_m_failures'] == 7.0
+    assert agg['harness_mismatch'] == []
+
+    runs[1]['harness']['escape'] = True    # not comparable any more
+    assert metrics.aggregate(runs)['harness_mismatch'] == ['escape']
+
+
+def test_load_runs_reads_result_json():
+    with tempfile.TemporaryDirectory() as d:
+        p = Path(d) / 'run_1'
+        p.mkdir()
+        (p / 'result.json').write_text(json.dumps({'scenario': 's', 'success': True}))
+        runs = metrics.load_runs(Path(d))
+        assert len(runs) == 1 and runs[0]['scenario'] == 's'

--- a/gsl_benchmark/README.md
+++ b/gsl_benchmark/README.md
@@ -1,0 +1,108 @@
+# gsl_benchmark
+
+One place for the pieces that turn `gsl_bench` into **the** published GSL benchmark:
+a fixed 29-scenario suite, per-scenario oracle budgets, a 5×/10×/20× success-and-
+termination envelope, and confidence intervals over repeats.
+
+This folder does **not** fork any code. The engine is the `gsl_bench` ROS 2 package
+(the harness owns sim + Nav2 + metrics). Here we only wire in the defaults.
+
+```
+gsl_benchmark/
+├── run_benchmark.sh                  # run: pick agent, scenarios, repeats (headless)
+├── watch.sh                          # watch ONE scenario live in RViz (SLAM mode)
+├── aggregate.py                      # (re)aggregate a results dir with 95% CIs
+├── oracle_budgets_nav2_reliable.json # 29 per-scenario oracle distance/time budgets
+└── README.md
+```
+
+## What a benchmark run is
+
+- **Scenario** — one of 29 (`benchmark29` suite): map + gas source + robot start,
+  from `benchmark_env`. House09 is excluded. Realistic perception (SLAM pose +
+  online map) is available via `--realistic`.
+- **Method ("robot")** — a `gsl_bench` agent implementing `observe()`/`act()`
+  (`gpulaika`, `adsm`, `surge_cast`, …). Any checkpoint is loaded by the agent
+  from its `configs/agents/<agent>.yaml`.
+- **Repeats** — each scenario is run *N* times (default 5) for statistics.
+
+## Success & termination
+
+Per scenario the oracle (a privileged A*-to-source drive) gives a near-optimal
+`travel_distance_m` and `sim_time_s`. Every run is scored against a multiple of it:
+
+| threshold | multiplier | effect |
+|---|---|---|
+| **success** | 5× oracle distance | reaching within 0.5 m **and** ≤ 5× counts as success |
+| **terminate (distance)** | 10× oracle distance | run ends as failure past this |
+| **terminate (time)** | 20× oracle sim-time | run ends as failure past this |
+| **terminate (other)** | — | stuck / `max_steps` (600) / env-dead |
+
+`reached_source` (reached at all, up to 10×) is recorded separately from
+`success` (reached efficiently, ≤ 5×), so an inefficient reach is visible, not
+hidden.
+
+## Run it
+
+```bash
+cd /home/efe/ros2_ws/src/gsl_benchmark
+./run_benchmark.sh gpulaika          # 29 × 5 runs
+./run_benchmark.sh gpulaika 3        # 29 × 3 runs
+./run_benchmark.sh adsm 5 --realistic
+```
+
+Results land in `Results/<agent>_<timestamp>/` with per-run `result.json`,
+a `report.md` (per-scenario table with 95% CIs), and `results.csv`.
+
+## Watch a run live (RViz)
+
+```bash
+cd /home/efe/ros2_ws/src/gsl_benchmark
+./watch.sh 4_rooms_start_a            # one run, live, in RViz
+./watch.sh ultimate_1 gpulaika
+```
+
+Runs a single scenario in **realistic/SLAM** mode and opens RViz on the virtual
+display `:99` (it starts `Xvfb :99` + `x11vnc` on port 5900 for you). From your
+Mac, tunnel 5900 and open `vnc://localhost:5900` (see `../../REMOTE_VIEWING_README.md`).
+
+You see: the **SLAM map** (built online), the **gas plume**, the **robot** (axes +
+lidar), the current **goal** (cyan arrow) and per-step target, and the Nav2 plan.
+
+**Origin fix:** GADEN publishes gas in world coordinates under a frame also named
+`map`, while SLAM's `map` is anchored at the robot start — so raw, the plume would
+be offset. `watch.sh` (via `--visual`) launches `gsl_bench world_align`, which
+broadcasts a static TF `map → gaden_world` at `-start` and relays the gas/source
+markers into `gaden_world`, so plume, map, robot and goal all line up. It reads the
+per-scenario start from the scenario, so it is correct for every map (not a
+hardcoded offset).
+
+The same behaviour is available as a flag on the batch driver:
+`ros2 run gsl_bench eval --agent <a> --realistic --visual --scenario <s> --runs 1`.
+
+## Aggregate an existing results dir
+
+```bash
+source ../../install/setup.bash
+python3 aggregate.py <results_dir>              # recompute report + CIs
+python3 aggregate.py <results_dir> --relabel    # apply the 5× budget to old runs
+```
+
+CIs: **Wilson** score interval for success/reached rates (robust near 0/100 % and
+at N=5), **bootstrap** percentile interval for mean time / distance / steps.
+
+## Regenerating the oracle budgets
+
+`oracle_budgets_nav2_reliable.json` was produced by the privileged oracle
+(reliable Nav2 mode) and copied here from `Results/`. To rebuild:
+
+```bash
+ros2 run gsl_bench oracle --suite benchmark29 --drive-mode nav2 \
+  --out /home/efe/ros2_ws/Results/oracle_budgets.json
+```
+
+then copy the manifest into this folder.
+
+## Next step
+
+Docker deployment (packaging this as a reproducible container) — not done here yet.

--- a/gsl_benchmark/aggregate.py
+++ b/gsl_benchmark/aggregate.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Re-aggregate a gsl_bench results directory with 95% confidence intervals.
+
+`ros2 run gsl_bench eval` already writes report.md + results.csv at the end of a
+sweep. Use this when you want to (re)aggregate an *existing* results tree — e.g.
+one produced before the 5x-budget labelling existed, or to recompute after a
+different success budget.
+
+    source ../../install/setup.bash        # puts gsl_bench on PYTHONPATH
+    python3 aggregate.py <results_dir>
+    python3 aggregate.py <results_dir> --relabel        # apply 5x budget to old runs
+    python3 aggregate.py <results_dir> --relabel --success-budget-multiplier 3
+
+With --relabel each run's result.json is rewritten: `reached_source` = raw reach,
+`success` = reached within (multiplier x oracle distance). Without it, the runs
+are aggregated as-is (they already carry the labels from the eval run).
+"""
+import argparse
+import json
+from pathlib import Path
+
+from gsl_bench.eval import metrics, report
+
+HERE = Path(__file__).resolve().parent
+DEFAULT_ORACLE = HERE / 'oracle_budgets_nav2_reliable.json'
+
+
+def relabel_dir(root: Path, oracle: dict, multiplier: float) -> int:
+    """Overwrite success in every result.json under `root` with the budget verdict."""
+    n = 0
+    for p in sorted(root.rglob('result.json')):
+        try:
+            res = json.loads(p.read_text())
+        except (json.JSONDecodeError, OSError):
+            continue
+        reached = bool(res.get('reached_source', res.get('success')))
+        res['reached_source'] = reached
+        rec = oracle.get(f"{res.get('scenario')}_{res.get('sim')}")
+        if rec is None:
+            res['success_within_budget'] = reached
+            res['success'] = reached
+        else:
+            budget = multiplier * float(rec['travel_distance_m'])
+            travel = res.get('travel_distance_m')
+            within = travel is not None and travel <= budget
+            res['oracle_travel_distance_m'] = round(float(rec['travel_distance_m']), 3)
+            res['success_budget_distance_m'] = round(budget, 3)
+            res['success_budget_multiplier'] = multiplier
+            res['success_within_budget'] = bool(reached and within)
+            res['success'] = res['success_within_budget']
+        p.write_text(json.dumps(res, indent=2))
+        n += 1
+    return n
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(prog='gsl_benchmark aggregate')
+    ap.add_argument('results_dir', type=Path)
+    ap.add_argument('--relabel', action='store_true',
+                    help='rewrite success in each result.json using the 5x oracle budget')
+    ap.add_argument('--oracle-budgets', type=Path, default=DEFAULT_ORACLE)
+    ap.add_argument('--success-budget-multiplier', type=float, default=5.0)
+    ap.add_argument('--no-write', action='store_true',
+                    help='print the report but do not write report.md / results.csv')
+    args = ap.parse_args()
+
+    if args.relabel:
+        oracle = json.loads(args.oracle_budgets.read_text())
+        n = relabel_dir(args.results_dir, oracle, args.success_budget_multiplier)
+        print(f'relabelled {n} runs against {args.success_budget_multiplier}x oracle\n')
+
+    if args.no_write:
+        print(report.build_report(args.results_dir))
+    else:
+        print(report.write_all(args.results_dir))
+
+    runs = metrics.load_runs(args.results_dir)
+    o = metrics.aggregate(runs)['overall']
+    ci = o.get('success_ci')
+    band = f' (95% CI {ci[0] * 100:.0f}-{ci[1] * 100:.0f}%)' if ci else ''
+    print(f"Overall success: {o['n_success']}/{o['n']} "
+          f"({o['success_rate'] * 100:.0f}%){band}  |  "
+          f"reached: {o.get('n_reached', o['n_success'])}/{o['n']}")
+
+
+if __name__ == '__main__':
+    main()

--- a/gsl_benchmark/oracle_budgets_nav2_reliable.json
+++ b/gsl_benchmark/oracle_budgets_nav2_reliable.json
@@ -1,0 +1,553 @@
+{
+  "10x6_u_left_1_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      1.45,
+      3.0
+    ],
+    "start": [
+      9.0,
+      3.0
+    ],
+    "travel_distance_m": 8.59,
+    "sim_time_s": 38.46,
+    "wall_time_s": 38.5,
+    "final_distance_m": 0.5,
+    "timestamp": "2026-07-18T19:36:41",
+    "scenario": "10x6_u_left_1",
+    "sim": "sim1"
+  },
+  "10x6_u_left_2_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      2.0,
+      5.0
+    ],
+    "start": [
+      9.0,
+      3.0
+    ],
+    "travel_distance_m": 7.497,
+    "sim_time_s": 33.24,
+    "wall_time_s": 33.2,
+    "final_distance_m": 0.492,
+    "timestamp": "2026-07-18T19:37:38",
+    "scenario": "10x6_u_left_2",
+    "sim": "sim1"
+  },
+  "10x6_u_left_3_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      5.5,
+      3.0
+    ],
+    "start": [
+      9.0,
+      3.0
+    ],
+    "travel_distance_m": 7.596,
+    "sim_time_s": 34.16,
+    "wall_time_s": 34.2,
+    "final_distance_m": 0.486,
+    "timestamp": "2026-07-18T19:38:34",
+    "scenario": "10x6_u_left_3",
+    "sim": "sim1"
+  },
+  "10x6_u_left_4_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      9.0,
+      3.0
+    ],
+    "start": [
+      1.45,
+      3.0
+    ],
+    "travel_distance_m": 8.546,
+    "sim_time_s": 35.63,
+    "wall_time_s": 35.6,
+    "final_distance_m": 0.495,
+    "timestamp": "2026-07-18T19:41:40",
+    "scenario": "10x6_u_left_4",
+    "sim": "sim1"
+  },
+  "10x6_u_right_1_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      1.45,
+      3.0
+    ],
+    "start": [
+      9.0,
+      3.0
+    ],
+    "travel_distance_m": 9.039,
+    "sim_time_s": 39.89,
+    "wall_time_s": 39.9,
+    "final_distance_m": 0.498,
+    "timestamp": "2026-07-18T19:42:42",
+    "scenario": "10x6_u_right_1",
+    "sim": "sim1"
+  },
+  "10x6_u_right_2_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      2.0,
+      5.0
+    ],
+    "start": [
+      9.0,
+      3.0
+    ],
+    "travel_distance_m": 7.891,
+    "sim_time_s": 34.18,
+    "wall_time_s": 34.2,
+    "final_distance_m": 0.493,
+    "timestamp": "2026-07-18T19:43:50",
+    "scenario": "10x6_u_right_2",
+    "sim": "sim1"
+  },
+  "10x6_u_right_3_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      5.0,
+      3.0
+    ],
+    "start": [
+      9.0,
+      3.0
+    ],
+    "travel_distance_m": 6.318,
+    "sim_time_s": 28.84,
+    "wall_time_s": 28.8,
+    "final_distance_m": 0.492,
+    "timestamp": "2026-07-18T19:44:38",
+    "scenario": "10x6_u_right_3",
+    "sim": "sim1"
+  },
+  "10x6_u_right_4_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      7.0,
+      3.0
+    ],
+    "start": [
+      1.35,
+      3.0
+    ],
+    "travel_distance_m": 9.374,
+    "sim_time_s": 39.9,
+    "wall_time_s": 39.9,
+    "final_distance_m": 0.486,
+    "timestamp": "2026-07-18T19:45:36",
+    "scenario": "10x6_u_right_4",
+    "sim": "sim1"
+  },
+  "4_rooms_start_a_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      2.5,
+      3.0
+    ],
+    "start": [
+      11.0,
+      2.0
+    ],
+    "travel_distance_m": 8.316,
+    "sim_time_s": 37.3,
+    "wall_time_s": 37.3,
+    "final_distance_m": 0.485,
+    "timestamp": "2026-07-18T19:46:33",
+    "scenario": "4_rooms_start_a",
+    "sim": "sim1"
+  },
+  "4_rooms_start_b_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      1.5,
+      6.5
+    ],
+    "start": [
+      11.0,
+      2.0
+    ],
+    "travel_distance_m": 11.007,
+    "sim_time_s": 48.55,
+    "wall_time_s": 48.6,
+    "final_distance_m": 0.488,
+    "timestamp": "2026-07-18T19:47:40",
+    "scenario": "4_rooms_start_b",
+    "sim": "sim1"
+  },
+  "4_rooms_start_c_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      10.8,
+      10.8
+    ],
+    "start": [
+      11.0,
+      2.0
+    ],
+    "travel_distance_m": 14.659,
+    "sim_time_s": 79.09,
+    "wall_time_s": 79.1,
+    "final_distance_m": 0.494,
+    "timestamp": "2026-07-18T19:49:18",
+    "scenario": "4_rooms_start_c",
+    "sim": "sim1"
+  },
+  "4_rooms_start_d_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      11.5,
+      6.5
+    ],
+    "start": [
+      2.5,
+      3.0
+    ],
+    "travel_distance_m": 10.372,
+    "sim_time_s": 44.05,
+    "wall_time_s": 44.1,
+    "final_distance_m": 0.489,
+    "timestamp": "2026-07-18T19:50:22",
+    "scenario": "4_rooms_start_d",
+    "sim": "sim1"
+  },
+  "4_rooms_start_e_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      10.8,
+      10.8
+    ],
+    "start": [
+      2.5,
+      3.0
+    ],
+    "travel_distance_m": 14.169,
+    "sim_time_s": 60.2,
+    "wall_time_s": 60.2,
+    "final_distance_m": 0.492,
+    "timestamp": "2026-07-18T19:52:56",
+    "scenario": "4_rooms_start_e",
+    "sim": "sim1"
+  },
+  "curved_labrinth_left_1_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      0.5,
+      3.0
+    ],
+    "start": [
+      9.0,
+      1.5
+    ],
+    "travel_distance_m": 15.614,
+    "sim_time_s": 83.67,
+    "wall_time_s": 83.7,
+    "final_distance_m": 0.49,
+    "timestamp": "2026-07-18T19:54:57",
+    "scenario": "curved_labrinth_left_1",
+    "sim": "sim1"
+  },
+  "curved_labrinth_left_2_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      9.0,
+      1.5
+    ],
+    "start": [
+      0.5,
+      3.0
+    ],
+    "travel_distance_m": 15.566,
+    "sim_time_s": 84.14,
+    "wall_time_s": 84.1,
+    "final_distance_m": 0.488,
+    "timestamp": "2026-07-18T19:56:41",
+    "scenario": "curved_labrinth_left_2",
+    "sim": "sim1"
+  },
+  "curved_labrinth_left_3_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      5.0,
+      2.0
+    ],
+    "start": [
+      9.0,
+      1.5
+    ],
+    "travel_distance_m": 13.478,
+    "sim_time_s": 74.33,
+    "wall_time_s": 74.3,
+    "final_distance_m": 0.485,
+    "timestamp": "2026-07-18T19:58:15",
+    "scenario": "curved_labrinth_left_3",
+    "sim": "sim1"
+  },
+  "curved_labrinth_right_1_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      0.5,
+      3.0
+    ],
+    "start": [
+      9.0,
+      1.5
+    ],
+    "travel_distance_m": 15.735,
+    "sim_time_s": 84.38,
+    "wall_time_s": 84.4,
+    "final_distance_m": 0.496,
+    "timestamp": "2026-07-18T19:59:54",
+    "scenario": "curved_labrinth_right_1",
+    "sim": "sim1"
+  },
+  "curved_labrinth_right_2_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      9.0,
+      1.5
+    ],
+    "start": [
+      0.5,
+      3.0
+    ],
+    "travel_distance_m": 15.719,
+    "sim_time_s": 84.24,
+    "wall_time_s": 84.2,
+    "final_distance_m": 0.491,
+    "timestamp": "2026-07-18T20:01:38",
+    "scenario": "curved_labrinth_right_2",
+    "sim": "sim1"
+  },
+  "curved_labrinth_right_3_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      5.0,
+      2.0
+    ],
+    "start": [
+      9.0,
+      1.5
+    ],
+    "travel_distance_m": 10.897,
+    "sim_time_s": 63.83,
+    "wall_time_s": 63.8,
+    "final_distance_m": 0.495,
+    "timestamp": "2026-07-18T20:03:01",
+    "scenario": "curved_labrinth_right_3",
+    "sim": "sim1"
+  },
+  "many_rooms_1_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      2.8,
+      4.2
+    ],
+    "start": [
+      15.0,
+      7.0
+    ],
+    "travel_distance_m": 13.627,
+    "sim_time_s": 59.32,
+    "wall_time_s": 59.3,
+    "final_distance_m": 0.487,
+    "timestamp": "2026-07-18T20:04:20",
+    "scenario": "many_rooms_1",
+    "sim": "sim1"
+  },
+  "many_rooms_2_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      2.0,
+      9.0
+    ],
+    "start": [
+      15.0,
+      7.0
+    ],
+    "travel_distance_m": 13.563,
+    "sim_time_s": 59.21,
+    "wall_time_s": 59.2,
+    "final_distance_m": 0.486,
+    "timestamp": "2026-07-18T20:05:39",
+    "scenario": "many_rooms_2",
+    "sim": "sim1"
+  },
+  "many_rooms_3_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      15.0,
+      6.0
+    ],
+    "start": [
+      2.0,
+      2.0
+    ],
+    "travel_distance_m": 14.784,
+    "sim_time_s": 64.0,
+    "wall_time_s": 64.0,
+    "final_distance_m": 0.495,
+    "timestamp": "2026-07-18T20:07:05",
+    "scenario": "many_rooms_3",
+    "sim": "sim1"
+  },
+  "many_rooms_4_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      15.0,
+      3.0
+    ],
+    "start": [
+      2.0,
+      2.0
+    ],
+    "travel_distance_m": 13.751,
+    "sim_time_s": 58.11,
+    "wall_time_s": 58.1,
+    "final_distance_m": 0.49,
+    "timestamp": "2026-07-18T20:08:25",
+    "scenario": "many_rooms_4",
+    "sim": "sim1"
+  },
+  "ultimate_1_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      1.45,
+      3.0
+    ],
+    "start": [
+      18.0,
+      10.0
+    ],
+    "travel_distance_m": 19.87,
+    "sim_time_s": 88.91,
+    "wall_time_s": 88.9,
+    "final_distance_m": 0.497,
+    "timestamp": "2026-07-18T20:10:11",
+    "scenario": "ultimate_1",
+    "sim": "sim1"
+  },
+  "ultimate_2_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      2.0,
+      11.0
+    ],
+    "start": [
+      18.0,
+      10.0
+    ],
+    "travel_distance_m": 19.556,
+    "sim_time_s": 87.69,
+    "wall_time_s": 87.7,
+    "final_distance_m": 0.492,
+    "timestamp": "2026-07-18T20:11:55",
+    "scenario": "ultimate_2",
+    "sim": "sim1"
+  },
+  "ultimate_3_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      2.0,
+      4.5
+    ],
+    "start": [
+      18.0,
+      10.0
+    ],
+    "travel_distance_m": 18.296,
+    "sim_time_s": 81.38,
+    "wall_time_s": 81.4,
+    "final_distance_m": 0.495,
+    "timestamp": "2026-07-18T20:13:32",
+    "scenario": "ultimate_3",
+    "sim": "sim1"
+  },
+  "ultimate_4_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      18.0,
+      4.5
+    ],
+    "start": [
+      3.0,
+      11.0
+    ],
+    "travel_distance_m": 18.271,
+    "sim_time_s": 78.46,
+    "wall_time_s": 78.5,
+    "final_distance_m": 0.488,
+    "timestamp": "2026-07-18T20:15:06",
+    "scenario": "ultimate_4",
+    "sim": "sim1"
+  },
+  "ultimate_5_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      18.0,
+      2.0
+    ],
+    "start": [
+      3.0,
+      11.0
+    ],
+    "travel_distance_m": 21.407,
+    "sim_time_s": 92.83,
+    "wall_time_s": 92.8,
+    "final_distance_m": 0.5,
+    "timestamp": "2026-07-18T20:16:57",
+    "scenario": "ultimate_5",
+    "sim": "sim1"
+  },
+  "ultimate_6_sim1": {
+    "schema": 1,
+    "status": "success",
+    "source": [
+      18.0,
+      7.0
+    ],
+    "start": [
+      3.0,
+      11.0
+    ],
+    "travel_distance_m": 17.445,
+    "sim_time_s": 74.74,
+    "wall_time_s": 74.7,
+    "final_distance_m": 0.49,
+    "timestamp": "2026-07-18T20:18:31",
+    "scenario": "ultimate_6",
+    "sim": "sim1"
+  }
+}

--- a/gsl_benchmark/run_benchmark.sh
+++ b/gsl_benchmark/run_benchmark.sh
@@ -1,0 +1,58 @@
+#!/usr/bin/env bash
+# gsl_benchmark — one command to run the full 29-scenario GSL benchmark.
+#
+# Everything the benchmark needs lives in this folder:
+#   - oracle_budgets_nav2_reliable.json : the per-scenario oracle distance/time budgets
+#   - this script                       : wires an agent + the benchmark29 suite + the
+#                                         5x/10x/20x envelope into `ros2 run gsl_bench eval`
+#   - aggregate.py                      : re-aggregate any results dir with 95% CIs
+#
+# The actual engine is the gsl_bench package (harness owns sim + Nav2 + metrics).
+# This script just picks the robot (agent), the scenarios, and the repeat count.
+#
+# Usage:
+#   ./run_benchmark.sh <agent> [runs] [extra gsl_bench eval flags...]
+#
+# Examples:
+#   ./run_benchmark.sh gpulaika                 # 29 scenarios x 5 runs, defaults
+#   ./run_benchmark.sh gpulaika 3               # 3 runs each
+#   ./run_benchmark.sh gpulaika 5 --scenario ultimate_1,ultimate_2   # subset
+#   ./run_benchmark.sh adsm 5 --realistic       # ADSM needs realistic perception
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WS="$(cd "$HERE/../.." && pwd)"
+
+AGENT="${1:?usage: run_benchmark.sh <agent> [runs] [extra flags...]}"
+RUNS="${2:-5}"
+shift || true; shift 2>/dev/null || true   # remaining args pass through
+
+# The robot / method under test. "Selecting a robot" == selecting an agent + its
+# config; the checkpoint (if any) is loaded by the agent from its config YAML.
+AGENT_CONFIG="$WS/src/gsl_bench/configs/agents/${AGENT}.yaml"
+CONFIG_FLAG=()
+[[ -f "$AGENT_CONFIG" ]] && CONFIG_FLAG=(--agent-config "$AGENT_CONFIG")
+
+ORACLE="$HERE/oracle_budgets_nav2_reliable.json"
+
+# ROS_DOMAIN_ID keeps this sweep isolated from anything else on the host. Never run
+# two sweeps at once on the same host without distinct ids (see repo memory).
+export ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-42}"
+
+# shellcheck disable=SC1091
+set +u; source "$WS/install/setup.bash"; set -u   # setup.bash uses unbound vars
+
+echo "gsl_benchmark: agent=$AGENT  suite=benchmark29 (29)  runs=$RUNS  domain=$ROS_DOMAIN_ID"
+echo "  success<=5x oracle dist | terminate at 10x dist / 20x time / stuck"
+
+exec ros2 run gsl_bench eval \
+  --agent "$AGENT" \
+  "${CONFIG_FLAG[@]}" \
+  --suite benchmark29 \
+  --runs "$RUNS" \
+  --oracle-budgets "$ORACLE" \
+  --budget-multiplier 10 \
+  --time-budget-multiplier 20 \
+  --success-budget-multiplier 5 \
+  --success-radius 0.5 \
+  "$@"

--- a/gsl_benchmark/watch.sh
+++ b/gsl_benchmark/watch.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+# gsl_benchmark — watch ONE scenario live in RViz (realistic/SLAM mode).
+#
+# Opens an RViz window (over VNC display :99) showing the SLAM map, the gas plume,
+# the robot, and the goal it is driving to, with GADEN's world frame aligned to the
+# SLAM map frame so everything lines up.
+#
+# Usage:
+#   ./watch.sh <scenario> [agent=gpulaika] [extra gsl_bench eval flags...]
+#
+# Examples:
+#   ./watch.sh 4_rooms_start_a
+#   ./watch.sh ultimate_1 gpulaika
+#   ./watch.sh 10x6_u_left_1 surge_cast --max-steps 400
+#
+# View it from your Mac by tunnelling port 5900, then open  vnc://localhost:5900
+# (see REMOTE_VIEWING_README.md). This runs a SINGLE run — for batch stats use
+# run_benchmark.sh (headless).
+set -euo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+WS="$(cd "$HERE/../.." && pwd)"
+
+SCENARIO="${1:?usage: watch.sh <scenario> [agent] [extra flags...]}"
+AGENT="${2:-gpulaika}"
+shift || true; shift 2>/dev/null || true
+
+ORACLE="$HERE/oracle_budgets_nav2_reliable.json"
+export ROS_DOMAIN_ID="${ROS_DOMAIN_ID:-42}"
+export DISPLAY=":99"
+
+# Bring up the virtual display + VNC server if they aren't already running.
+if ! pgrep -f "Xvfb :99" >/dev/null 2>&1; then
+  echo "starting Xvfb :99"
+  Xvfb :99 -screen 0 1600x1000x24 +extension GLX +render >/tmp/gslb_watch_xvfb.log 2>&1 &
+  sleep 2
+fi
+if ! pgrep -f "x11vnc.*:99" >/dev/null 2>&1; then
+  echo "starting x11vnc on :5900"
+  x11vnc -display :99 -rfbport 5900 -forever -shared -nopw -bg >/tmp/gslb_watch_x11vnc.log 2>&1 || true
+  sleep 1
+fi
+export LIBGL_ALWAYS_SOFTWARE=1 GALLIUM_DRIVER=llvmpipe
+
+AGENT_CONFIG="$WS/src/gsl_bench/configs/agents/${AGENT}.yaml"
+CONFIG_FLAG=()
+[[ -f "$AGENT_CONFIG" ]] && CONFIG_FLAG=(--agent-config "$AGENT_CONFIG")
+
+# shellcheck disable=SC1091
+set +u; source "$WS/install/setup.bash"; set -u   # setup.bash uses unbound vars
+
+echo "watch: scenario=$SCENARIO  agent=$AGENT  (realistic/SLAM, 1 run)"
+echo "  view: tunnel 5900 -> open vnc://localhost:5900"
+
+exec ros2 run gsl_bench eval \
+  --agent "$AGENT" \
+  "${CONFIG_FLAG[@]}" \
+  --scenario "$SCENARIO" \
+  --runs 1 \
+  --realistic --visual \
+  --oracle-budgets "$ORACLE" \
+  --budget-multiplier 10 \
+  --time-budget-multiplier 20 \
+  --success-budget-multiplier 5 \
+  --success-radius 0.5 \
+  "$@"

--- a/reinforcement_learning/models/actor_critic.py
+++ b/reinforcement_learning/models/actor_critic.py
@@ -80,7 +80,7 @@ class ActorCritic(nn.Module):
         """
         return self.critic(self.backbone(obs))
 
-    def get_action_and_value(self, obs, action=None):
+    def get_action_and_value(self, obs, action=None, deterministic=False):
         """Sample action and compute log_prob, entropy, V(s).
 
         Parameters
@@ -90,6 +90,9 @@ class ActorCritic(nn.Module):
         action : torch.Tensor, optional
             Shape (batch, 1). If provided, compute log_prob of this action
             instead of sampling a new one.
+        deterministic : bool, optional
+            If True (and action is None), use the distribution mean instead
+            of sampling — used at deployment for reproducible rollouts.
 
         Returns
         -------
@@ -112,7 +115,7 @@ class ActorCritic(nn.Module):
         dist = Beta(alpha, beta)
 
         if action is None:
-            action = dist.rsample()  # (batch, 1)
+            action = dist.mean if deterministic else dist.rsample()  # (batch, 1)
 
         log_prob = dist.log_prob(action).sum(dim=-1)  # (batch,)
         entropy = dist.entropy().sum(dim=-1)           # (batch,)
@@ -224,7 +227,7 @@ class ActorCriticModular(nn.Module):
     def get_value(self, obs):
         return self.critic(self._encode(obs))
 
-    def get_action_and_value(self, obs, action=None):
+    def get_action_and_value(self, obs, action=None, deterministic=False):
         features = self._encode(obs)
 
         ab = self.actor(features)
@@ -233,7 +236,7 @@ class ActorCriticModular(nn.Module):
         dist = Beta(alpha, beta)
 
         if action is None:
-            action = dist.rsample()
+            action = dist.mean if deterministic else dist.rsample()
 
         log_prob = dist.log_prob(action).sum(dim=-1)
         entropy = dist.entropy().sum(dim=-1)
@@ -399,13 +402,13 @@ class ActorCriticDualBackbone(nn.Module):
         feat = self.critic_res(self.critic_proj(encoded))
         return self.critic_head(feat)
 
-    def get_action_and_value(self, obs, action=None):
+    def get_action_and_value(self, obs, action=None, deterministic=False):
         encoded = self._encode_shared(obs)
 
         # Actor
         dist = self._actor_dist(encoded)
         if action is None:
-            action = dist.rsample()  # (B, 2): (cos θ, sin θ)
+            action = dist.mean if deterministic else dist.rsample()  # (B, 2): (cos θ, sin θ)
 
         log_prob = dist.log_prob(action).sum(dim=-1)  # (B,)
         entropy = dist.entropy().sum(dim=-1)           # (B,)


### PR DESCRIPTION
## Summary

This PR adds a reusable gas-source-localization (GSL/OSL) benchmark framework for comparing search agents in both ground-truth and realistic-perception environments.

## What was added

- \`gsl_bench\`: ROS 2 benchmark package with a common agent API, generic runner, observation cache, scenario suites, reporting, metrics, and oracle-derived budgets.
- Built-in agents for random walk, upwind greedy, zigzag, surge-cast, GPULAIKA, and ADSM.
- \`benchmark_env_realistic\`: realistic perception layer using noisy sensing, SLAM/Cartographer, AMCL/Nav2, configurable lidar, visualization profiles, and faithful ADSM navigation settings.
- \`gsl_benchmark\`: sweep scripts, monitoring/aggregation utilities, documentation, and a reliable Nav2 oracle-budget manifest.
- \`directdrive_nav\`: rotate-then-go A* navigation option for BasicSim environments where Nav2 can become stuck.

## Supporting changes

- Extracted the ADSM decision engine into a reusable C++ library with pybind11 bindings and equivalence tests.
- Added ADSM distance budgets, continuous goal updates, faithful Nav2 behavior trees, and configurable random-goal handling.
- Added benchmark termination-budget support to EESA.
- Extended occupancy-grid and navigator helpers used by the generic runner and oracle.
- Added escape-planner and deterministic GPULAIKA inference support.
- Added benchmark-specific Nav2 configurations and behavior trees.

## Benchmark capabilities

- Batch execution with isolated ROS domains and process cleanup.
- Ground-truth and realistic SLAM/TF observation modes.
- Nav2 and direct-drive motion modes.
- Per-scenario oracle time and travel-distance budgets.
- Reproducible agent configuration and fairness metadata.
- JSON results plus CSV/Markdown aggregate reports.
- Offline tests for agents, motion modes, metrics, and reporting.

## Validation

- Python syntax compilation completed successfully for the new benchmark packages and direct-drive utility.
- \`git diff --check\` passed.
- The pytest suite was not run in this shell because pytest is not installed in the active environment.

## Notes

- Generated Python/pytest caches, raw SLAM capture artifacts, compiled test binaries, and local backup files were intentionally excluded.
- GPULAIKA checkpoint YAML files currently reference local checkpoint paths; users should update these for their workspace/checkpoints.
- Some launch/config files retain workspace-specific paths used by the current experimental setup and may need adjustment on another machine.